### PR TITLE
get rid of harmless error in verbose test

### DIFF
--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -534,7 +534,7 @@ class ToyBuildTest(EnhancedTestCase):
             '--module-naming-scheme=HierarchicalMNS',
         ]
 
-        # test module paths/contents with gompi build
+        # test module paths/contents with goolf build
         extra_args = [
             '--try-toolchain=goolf,1.4.10',
         ]
@@ -629,7 +629,7 @@ class ToyBuildTest(EnhancedTestCase):
         os.remove(toy_module_path)
 
         # building a toolchain module should also work
-        args = ['gompi-1.4.10.eb'] + args[1:]
+        args = [os.path.join(os.path.dirname(__file__), 'easyconfigs', 'gompi-1.4.10.eb')] + args[1:]
         modules_tool().purge()
         self.eb_main(args, logfile=self.dummylogfn, do_build=True, verbose=True, raise_error=True)
 


### PR DESCRIPTION
The `toy_build` unit tests are spitting our an error message because a specified easyconfig file is not found in the specified (relative) location.

```bash
$ PYTHONPATH=$PWD python test/framework/toy_build.py
.............== ERROR: Can't find path /Users/kehoste/work/easybuild-framework/gompi-1.4.10.eb

...
----------------------------------------------------------------------
Ran 16 tests in 265.835s

OK
```

The error is harmless since the easyconfig is actually found after all.
This patch fixes the it by specifying the absolute path to easyconfig file to be used.