### PR TITLE
add support for --dump-toolchain-env

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -91,6 +91,7 @@ BUILD_OPTIONS_CMDLINE = {
     False: [
         'allow_modules_tool_mismatch',
         'debug',
+        'dump_toolchain_env',
         'experimental',
         'force',
         'hidden',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -268,6 +268,7 @@ class EasyBuildOptions(GeneralOption):
                                             None, 'store_true', False),
             'dep-graph': ("Create dependency graph",
                           None, "store", None, {'metavar': 'depgraph.<ext>'}),
+            'dump-toolchain-env': ("Dump build environment set up for used toolchain", None, 'store_true', False),
             'list-easyblocks': ("Show list of available easyblocks",
                                 'choice', 'store_or_None', 'simple', ['simple', 'detailed']),
             'list-toolchains': ("Show list of known toolchains",

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -33,6 +33,7 @@ Creating a new toolchain should be as simple as possible.
 
 import os
 import re
+import sys
 from vsc.utils import fancylogger
 from vsc.utils.missing import all, any
 
@@ -381,6 +382,9 @@ class Toolchain(object):
 
         # Generate the variables to be set
         self.set_variables()
+        if build_option('dump_toolchain_env'):
+            print("# Build environment for toolchain %s:\n%s" % (mod_name, self.show_variables()))
+            sys.exit(0)
 
         # set the variables
         # onlymod can be comma-separated string of variables not to be set


### PR DESCRIPTION
This is not complete yet, in particular because:

* it currently requires that the toolchain module is already available, which may not be strictly necessary (not sure yet)
* if the module for the easyconfig file used is already available, this currently requires `--force` to actually get the build env dumped
* may need some code cleanup

cc @ocaisa