### PR TITLE
Create top-level module paths if they don't exist yet

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -823,6 +823,9 @@ class EasyBlock(object):
         full_mod_subdir = os.path.join(mod_install_path, self.cfg.mod_subdir)
         init_modpaths = mns.det_init_modulepaths(self.cfg)
         top_paths = [mod_install_path] + [os.path.join(mod_install_path, p) for p in init_modpaths]
+        # top-level module paths must exist, otherwise searching for the top path of the module tree fails
+        for path in top_paths:
+            mkdir(path, parents=True)
         excluded_deps = self.modules_tool.path_to_top_of_module_tree(top_paths, self.cfg.short_mod_name,
                                                                      full_mod_subdir, deps)
 


### PR DESCRIPTION
While experimenting with a custom hierarchical module naming scheme including the `moduleclass`, EasyBuild crashed since not all module paths returned by `det_init_modulepaths` existed. With this PR, EasyBuild now creates these directories automatically (as it does for paths returned by `det_modpath_extensions` on higher levels of the hierarchy).

Side note: This feels a bit like fixing symptoms rather than the real cause. Is there a compelling reason why EasyBuild can't gracefully handle (i.e., ignore) nonexistent module paths?
