### PR TITLE
add support for 'eb -a rst', list available easyconfig parameters in RST format

### DIFF
--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -35,8 +35,6 @@ Easyconfig module that contains the default EasyConfig configuration parameters.
 """
 from vsc.utils import fancylogger
 
-from easybuild.tools.deprecated.eb_2_0 import ExtraOptionsDeprecatedReturnValue
-from easybuild.tools.ordereddict import OrderedDict
 
 _log = fancylogger.getLogger('easyconfig.default', fname=False)
 
@@ -185,30 +183,6 @@ def sorted_categories():
     categories = ALL_CATEGORIES.values()
     categories.sort(key=lambda c: c[0])
     return categories
-
-
-def convert_to_help(opts, has_default=False):
-    """
-    Converts the given list to a mapping of category -> [(name, help)] (OrderedDict)
-        @param: has_default, if False, add the DEFAULT_CONFIG list
-    """
-    mapping = OrderedDict()
-    if isinstance(opts, dict):
-        opts = opts.items()
-    elif isinstance(opts, ExtraOptionsDeprecatedReturnValue):
-        opts = list(opts)
-    if not has_default:
-        defs = [(k, [def_val, descr, ALL_CATEGORIES[cat]]) for k, (def_val, descr, cat) in DEFAULT_CONFIG.items()]
-        opts = defs + opts
-
-    # sort opts
-    opts.sort()
-
-    for cat in sorted_categories():
-        mapping[cat[1]] = [(opt[0], "%s (default: %s)" % (opt[1][1], opt[1][0]))
-                           for opt in opts if opt[1][2] == cat]
-
-    return mapping
 
 
 def get_easyconfig_parameter_default(param):

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -40,31 +40,23 @@ _log = fancylogger.getLogger('easyconfig.default', fname=False)
 
 
 # we use a tuple here so we can sort them based on the numbers
-HIDDEN = (-1, 'hidden')
-MANDATORY = (0, 'mandatory')
-CUSTOM = (1, 'easyblock-specific')
-TOOLCHAIN = (2, 'toolchain')
-BUILD = (3, 'build')
-FILEMANAGEMENT = (4, 'file-management')
-DEPENDENCIES = (5, 'dependencies')
-LICENSE = (6, 'license')
-EXTENSIONS = (7, 'extensions')
-MODULES = (8, 'modules')
-OTHER = (9, 'other')
-
 ALL_CATEGORIES = {
-    'HIDDEN': HIDDEN,
-    'MANDATORY': MANDATORY,
-    'CUSTOM': CUSTOM,
-    'TOOLCHAIN': TOOLCHAIN,
-    'BUILD': BUILD,
-    'FILEMANAGEMENT': FILEMANAGEMENT,
-    'DEPENDENCIES': DEPENDENCIES,
-    'LICENSE': LICENSE,
-    'EXTENSIONS': EXTENSIONS,
-    'MODULES': MODULES,
-    'OTHER': OTHER,
+    'HIDDEN': (-1, 'hidden'),
+    'MANDATORY': (0, 'mandatory'),
+    'CUSTOM': (1, 'easyblock-specific'),
+    'TOOLCHAIN': (2, 'toolchain'),
+    'BUILD': (3, 'build'),
+    'FILEMANAGEMENT': (4, 'file-management'),
+    'DEPENDENCIES': (5, 'dependencies'),
+    'LICENSE': (6, 'license'),
+    'EXTENSIONS': (7, 'extensions'),
+    'MODULES': (8, 'modules'),
+    'OTHER': (9, 'other'),
 }
+# define constants so they can be used below
+# avoid that pylint complains about unknown variables in this file
+# pylint: disable=E0602
+globals().update(ALL_CATEGORIES)
 
 # List of tuples. Each tuple has the following format (key, [default, help text, category])
 DEFAULT_CONFIG = {

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -40,30 +40,30 @@ _log = fancylogger.getLogger('easyconfig.default', fname=False)
 
 
 # we use a tuple here so we can sort them based on the numbers
-HIDDEN = "HIDDEN"
-MANDATORY = "MANDATORY"
-CUSTOM = "CUSTOM"
-TOOLCHAIN = "TOOLCHAIN"
-BUILD = "BUILD"
-FILEMANAGEMENT = "FILEMANAGEMENT"
-DEPENDENCIES = "DEPENDENCIES"
-LICENSE = "LICENSE"
-EXTENSIONS = "EXTENSIONS"
-MODULES = "MODULES"
-OTHER = "OTHER"
+HIDDEN = (-1, 'hidden')
+MANDATORY = (0, 'mandatory')
+CUSTOM = (1, 'easyblock-specific')
+TOOLCHAIN = (2, 'toolchain')
+BUILD = (3, 'build')
+FILEMANAGEMENT = (4, 'file-management')
+DEPENDENCIES = (5, 'dependencies')
+LICENSE = (6, 'license')
+EXTENSIONS = (7, 'extensions')
+MODULES = (8, 'modules')
+OTHER = (9, 'other')
 
 ALL_CATEGORIES = {
-    HIDDEN: (-1, 'hidden'),
-    MANDATORY: (0, 'mandatory'),
-    CUSTOM: (1, 'easyblock-specific'),
-    TOOLCHAIN: (2, 'toolchain'),
-    BUILD: (3, 'build'),
-    FILEMANAGEMENT: (4, 'file-management'),
-    DEPENDENCIES: (5, 'dependencies'),
-    LICENSE: (6, 'license'),
-    EXTENSIONS: (7, 'extensions'),
-    MODULES: (8, 'modules'),
-    OTHER: (9, 'other'),
+    'HIDDEN': HIDDEN,
+    'MANDATORY': MANDATORY,
+    'CUSTOM': CUSTOM,
+    'TOOLCHAIN': TOOLCHAIN,
+    'BUILD': BUILD,
+    'FILEMANAGEMENT': FILEMANAGEMENT,
+    'DEPENDENCIES': DEPENDENCIES,
+    'LICENSE': LICENSE,
+    'EXTENSIONS': EXTENSIONS,
+    'MODULES': MODULES,
+    'OTHER': OTHER,
 }
 
 # List of tuples. Each tuple has the following format (key, [default, help text, category])

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -57,7 +57,7 @@ from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME, DUMMY_TOOLCHAIN_VERS
 from easybuild.tools.toolchain.utilities import get_toolchain
 from easybuild.tools.utilities import remove_unwanted_chars
 from easybuild.framework.easyconfig import MANDATORY
-from easybuild.framework.easyconfig.default import DEFAULT_CONFIG, ALL_CATEGORIES, get_easyconfig_parameter_default
+from easybuild.framework.easyconfig.default import DEFAULT_CONFIG, get_easyconfig_parameter_default
 from easybuild.framework.easyconfig.format.convert import Dependency
 from easybuild.framework.easyconfig.format.one import retrieve_blocks_in_spec
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT, License
@@ -150,10 +150,7 @@ class EasyConfig(object):
         if self.valid_module_classes is not None:
             self.log.info("Obtained list of valid module classes: %s" % self.valid_module_classes)
 
-        # replace the category name with the category
-        self._config = {}
-        for k, [def_val, descr, cat] in copy.deepcopy(DEFAULT_CONFIG).items():
-            self._config[k] = [def_val, descr, ALL_CATEGORIES[cat]]
+        self._config = copy.deepcopy(DEFAULT_CONFIG)
 
         if extra_options is None:
             name = fetch_parameter_from_easyconfig_file(path, 'name')

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1,0 +1,168 @@
+# #
+# Copyright 2009-2014 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Documentation-related functionality
+
+@author: Stijn De Weirdt (Ghent University)
+@author: Dries Verdegem (Ghent University)
+@author: Kenneth Hoste (Ghent University)
+@author: Pieter De Baets (Ghent University)
+@author: Jens Timmerman (Ghent University)
+@author: Toon Willems (Ghent University)
+@author: Ward Poelmans (Ghent University)
+"""
+import copy
+
+from easybuild.framework.easyconfig.default import ALL_CATEGORIES, DEFAULT_CONFIG, HIDDEN, sorted_categories
+from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
+from easybuild.tools.deprecated.eb_2_0 import ExtraOptionsDeprecatedReturnValue
+from easybuild.tools.ordereddict import OrderedDict
+from easybuild.tools.utilities import quote_str
+
+
+FORMAT_RST = 'rst'
+FORMAT_TXT = 'txt'
+
+
+def avail_easyconfig_params_rst(title, grouped_params):
+    """
+    Compose overview of available easyconfig parameters, in RST format.
+    """
+    def det_col_width(entries, title):
+        """Determine column width based on column title and list of entries."""
+        return max(map(len, entries + [title]))
+
+    # main title
+    lines = [
+        title,
+        '=' * len(title),
+        '',
+    ]
+
+    for grpname in grouped_params:
+        # group section title
+        lines.append("%s parameters" % grpname)
+        lines.extend(['-' * len(lines[-1]), ''])
+
+        name_title = "**Parameter name**"
+        descr_title = "**Description**"
+        dflt_title = "**Default value**"
+
+        # figure out column widths
+        nw = det_col_width(grouped_params[grpname].keys(), name_title) + 4  # +4 for raw format ("``foo``")
+        dw = det_col_width([x[0] for x in grouped_params[grpname].values()], descr_title)
+        dfw = det_col_width([str(quote_str(x[1])) for x in grouped_params[grpname].values()], dflt_title)
+
+        # 3 columns (name, description, default value), left-aligned, {c} is fill char
+        line_tmpl = "{0:{c}<%s}   {1:{c}<%s}   {2:{c}<%s}" % (nw, dw, dfw)
+        table_line = line_tmpl.format('', '', '', c='=', nw=nw, dw=dw, dfw=dfw)
+
+        # table header
+        lines.append(table_line)
+        lines.append(line_tmpl.format(name_title, descr_title, dflt_title, c=' '))
+        lines.append(line_tmpl.format('', '', '', c='-'))
+
+        # table rows by parameter
+        for name, (descr, dflt) in sorted(grouped_params[grpname].items()):
+            rawname = '``%s``' % name
+            lines.append(line_tmpl.format(rawname, descr, str(quote_str(dflt)), c=' '))
+        lines.append(table_line)
+        lines.append('')
+
+    return '\n'.join(lines)
+
+def avail_easyconfig_params_txt(title, grouped_params):
+    """
+    Compose overview of available easyconfig parameters, in plain text format.
+    """
+    # main title
+    lines = [
+        '%s:' % title,
+        '',
+    ]
+
+    for grpname in grouped_params:
+        # group section title
+        lines.append(grpname.upper())
+        lines.append('-' * len(lines[-1]))
+
+        # determine width of 'name' column, to left-align descriptions
+        nw = max(map(len, grouped_params[grpname].keys()))
+
+        # line by parameter
+        for name, (descr, dflt) in sorted(grouped_params[grpname].items()):
+            lines.append("{0:<{nw}}   {1:} [default: {2:}]".format(name, descr, str(quote_str(dflt)), nw=nw))
+        lines.append('')
+
+    return '\n'.join(lines)
+
+def avail_easyconfig_params(easyblock, output_format):
+    """
+    Compose overview of available easyconfig parameters, in specified format.
+    """
+    params = copy.deepcopy(DEFAULT_CONFIG)
+
+    # include list of extra parameters (if any)
+    extra_params = {}
+    app = get_easyblock_class(easyblock, default_fallback=False)
+    if app is not None:
+        extra_params = app.extra_options()
+    if isinstance(extra_params, ExtraOptionsDeprecatedReturnValue):
+        extra_params = dict(extra_params)
+    params.update(extra_params)
+
+    # compose title
+    title = "Available easyconfig parameters"
+    if extra_params:
+        title += " (* indicates specific to the %s easyblock)" % app.__name__
+
+    # group parameters by category
+    grouped_params = OrderedDict()
+    for category in sorted_categories():
+        # exclude hidden parameters
+        if category[1].upper() in [HIDDEN]:
+            continue
+
+        grpname = category[1]
+        grouped_params[grpname] = {}
+        for name, (dflt, descr, cat) in params.items():
+            # FIXME bug in default.py?
+            if isinstance(cat, basestring):
+                cat = ALL_CATEGORIES[cat]
+            if cat == category:
+                if name in extra_params:
+                    # mark easyblock-specific parameters
+                    name = '%s*' % name
+                grouped_params[grpname].update({name: (descr, dflt)})
+
+        if not grouped_params[grpname]:
+            del grouped_params[grpname]
+
+    # compose output, according to specified format (txt, rst, ...)
+    avail_easyconfig_params_functions = {
+        FORMAT_RST: avail_easyconfig_params_rst,
+        FORMAT_TXT: avail_easyconfig_params_txt,
+    }
+    return avail_easyconfig_params_functions[output_format](title, grouped_params)

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -35,7 +35,7 @@ Documentation-related functionality
 """
 import copy
 
-from easybuild.framework.easyconfig.default import ALL_CATEGORIES, DEFAULT_CONFIG, HIDDEN, sorted_categories
+from easybuild.framework.easyconfig.default import DEFAULT_CONFIG, HIDDEN, sorted_categories
 from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.tools.deprecated.eb_2_0 import ExtraOptionsDeprecatedReturnValue
 from easybuild.tools.ordereddict import OrderedDict
@@ -148,9 +148,6 @@ def avail_easyconfig_params(easyblock, output_format):
         grpname = category[1]
         grouped_params[grpname] = {}
         for name, (dflt, descr, cat) in params.items():
-            # FIXME bug in default.py?
-            if isinstance(cat, basestring):
-                cat = ALL_CATEGORIES[cat]
             if cat == category:
                 if name in extra_params:
                     # mark easyblock-specific parameters

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -33,7 +33,6 @@ Command line options for eb
 @author: Toon Willems (Ghent University)
 @author: Ward Poelmans (Ghent University)
 """
-import copy
 import os
 import re
 import sys
@@ -43,8 +42,6 @@ from vsc.utils.missing import nub
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig.constants import constant_documentation
-from easybuild.framework.easyconfig.default import ALL_CATEGORIES, DEFAULT_CONFIG, HIDDEN, sorted_categories
-from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_constants_dict
 from easybuild.framework.easyconfig.licenses import license_documentation
 from easybuild.framework.easyconfig.templates import template_documentation
@@ -55,7 +52,7 @@ from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MNS, DEFAULT_
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, DEFAULT_PREFIX, DEFAULT_REPOSITORY, DEFAULT_TMP_LOGDIR
 from easybuild.tools.config import get_default_configfiles, get_pretend_installpath
 from easybuild.tools.config import get_default_oldstyle_configfile, mk_full_default_path
-from easybuild.tools.deprecated.eb_2_0 import ExtraOptionsDeprecatedReturnValue
+from easybuild.tools.docs import FORMAT_RST, FORMAT_TXT, avail_easyconfig_params
 from easybuild.tools.github import HAVE_GITHUB_API, HAVE_KEYRING, fetch_github_token
 from easybuild.tools.modules import avail_modules_tools
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
@@ -63,15 +60,10 @@ from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_s
 from easybuild.tools.ordereddict import OrderedDict
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.repository.repository import avail_repositories
-from easybuild.tools.utilities import quote_str
 from easybuild.tools.version import this_is_easybuild
 from vsc.utils import fancylogger
 from vsc.utils.generaloption import GeneralOption
 from vsc.utils.missing import any
-
-
-FORMAT_RST = 'rst'
-FORMAT_TXT = 'txt'
 
 
 class EasyBuildOptions(GeneralOption):
@@ -450,7 +442,7 @@ class EasyBuildOptions(GeneralOption):
 
         # dump possible easyconfig params
         if self.options.avail_easyconfig_params:
-            msg += self.avail_easyconfig_params()
+            msg += avail_easyconfig_params(self.options.easyblock, self.options.avail_easyconfig_params)
 
         # dump easyconfig template options
         if self.options.avail_easyconfig_templates:
@@ -510,127 +502,6 @@ class EasyBuildOptions(GeneralOption):
             for cst_name, (cst_value, cst_help) in sorted(self.go_cfg_constants[section].items()):
                 lines.append("* %s: %s [value: %s]" % (cst_name, cst_help, cst_value))
         return '\n'.join(lines)
-
-    def avail_easyconfig_params_txt(self, title, grouped_params):
-        """
-        Compose overview of available easyconfig parameters, in plain text format.
-        """
-        # main title
-        lines = [
-            '%s:' % title,
-            '',
-        ]
-
-        for grpname in grouped_params:
-            # group section title
-            lines.append(grpname.upper())
-            lines.append('-' * len(lines[-1]))
-
-            # determine width of 'name' column, to left-align descriptions
-            nw = max(map(len, grouped_params[grpname].keys()))
-
-            # line by parameter
-            for name, (descr, dflt) in sorted(grouped_params[grpname].items()):
-                lines.append("{0:<{nw}}   {1:} [default: {2:}]".format(name, descr, str(quote_str(dflt)), nw=nw))
-            lines.append('')
-
-        return '\n'.join(lines)
-    
-    def avail_easyconfig_params_rst(self, title, grouped_params):
-        """
-        Compose overview of available easyconfig parameters, in RST format.
-        """
-        def det_col_width(entries, title):
-            """Determine column width based on column title and list of entries."""
-            return max(map(len, entries + [title]))
-
-        # main title
-        lines = [
-            title,
-            '=' * len(title),
-            '',
-        ]
-
-        for grpname in grouped_params:
-            # group section title
-            lines.append("%s parameters" % grpname)
-            lines.extend(['-' * len(lines[-1]), ''])
-
-            name_title = "**Parameter name**"
-            descr_title = "**Description**"
-            dflt_title = "**Default value**"
-
-            # figure out column widths
-            nw = det_col_width(grouped_params[grpname].keys(), name_title) + 4  # +4 for raw format ("``foo``")
-            dw = det_col_width([x[0] for x in grouped_params[grpname].values()], descr_title)
-            dfw = det_col_width([str(quote_str(x[1])) for x in grouped_params[grpname].values()], dflt_title)
-
-            # 3 columns (name, description, default value), left-aligned, {c} is fill char
-            line_tmpl = "{0:{c}<%s}   {1:{c}<%s}   {2:{c}<%s}" % (nw, dw, dfw)
-            table_line = line_tmpl.format('', '', '', c='=', nw=nw, dw=dw, dfw=dfw)
-
-            # table header
-            lines.append(table_line)
-            lines.append(line_tmpl.format(name_title, descr_title, dflt_title, c=' '))
-            lines.append(line_tmpl.format('', '', '', c='-'))
-
-            # table rows by parameter
-            for name, (descr, dflt) in sorted(grouped_params[grpname].items()):
-                rawname = '``%s``' % name
-                lines.append(line_tmpl.format(rawname, descr, str(quote_str(dflt)), c=' '))
-            lines.append(table_line)
-            lines.append('')
-
-        return '\n'.join(lines)
-
-    def avail_easyconfig_params(self):
-        """
-        Compose overview of available easyconfig parameters, in specified format.
-        """
-        params = copy.deepcopy(DEFAULT_CONFIG)
-
-        # include list of extra parameters (if any)
-        extra_params = {}
-        app = get_easyblock_class(self.options.easyblock, default_fallback=False)
-        if app is not None:
-            extra_params = app.extra_options()
-        if isinstance(extra_params, ExtraOptionsDeprecatedReturnValue):
-            extra_params = dict(extra_params)
-        params.update(extra_params)
-
-        # compose title
-        title = "Available easyconfig parameters"
-        if extra_params:
-            title += " (* indicates specific to the %s easyblock)" % app.__name__
-
-        # group parameters by category
-        grouped_params = OrderedDict()
-        for category in sorted_categories():
-            # exclude hidden parameters
-            if category[1].upper() in [HIDDEN]:
-                continue
-
-            grpname = category[1]
-            grouped_params[grpname] = {}
-            for name, (dflt, descr, cat) in params.items():
-                # FIXME bug in default.py?
-                if isinstance(cat, basestring):
-                    cat = ALL_CATEGORIES[cat]
-                if cat == category:
-                    if name in extra_params:
-                        # mark easyblock-specific parameters
-                        name = '%s*' % name
-                    grouped_params[grpname].update({name: (descr, dflt)})
-
-            if not grouped_params[grpname]:
-                del grouped_params[grpname]
-
-        # compose output, according to specified format (txt, rst, ...)
-        avail_easyconfig_params_functions = {
-            FORMAT_RST: self.avail_easyconfig_params_rst,
-            FORMAT_TXT: self.avail_easyconfig_params_txt,
-        }
-        return avail_easyconfig_params_functions[self.options.avail_easyconfig_params](title, grouped_params)
 
     def avail_classes_tree(self, classes, classNames, detailed, depth=0):
         """Print list of classes as a tree."""


### PR DESCRIPTION
This is required to easily update http://easybuild.readthedocs.org/en/latest/eb_a.html#easyconfigs-parameters and use a pretty table format (see for example https://gist.github.com/boegel/490205a6c0607bc7dfc6).

`eb -a` is still supported, and defaults to `eb -a txt`; the output has slightly changed, i.e. the descriptions are now left-aligned per group of parameters, which looks a lot better.

Once this is merged in, I'll look into supporting `rst` for `--list-toolchains`, `--list-easyblocks`, `--help`, too

@wpoely86: please review?