### PR TITLE
fix --try issues

### DIFF
--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -201,12 +201,12 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
             diff = True
             try:
                 _log.debug("eval(%s): %s" % (res.group('val'), eval(res.group('val'))))
-                diff = not eval(res.group('val')) == val
+                diff = eval(res.group('val')) != val
             except (NameError, SyntaxError):
                 # if eval fails, just fall back to string comparison
                 tup = (res.group('val'), val)
                 _log.debug("eval failed for \"%s\", falling back to string comparison against \"%s\"..." % tup)
-                diff = not res.group('val') == val
+                diff = res.group('val') != val
 
             if diff:
                 ectxt = regexp.sub("%s = %s" % (res.group('key'), quote_str(val)), ectxt)
@@ -524,7 +524,7 @@ def select_or_generate_ec(fp, paths, specs):
         for (key, val) in specs.items():
             if key in selected_ec._config:
                 # values must be equal to have a full match
-                if not selected_ec[key] == val:
+                if selected_ec[key] != val:
                     match = False
             else:
                 # if we encounter a key that is not set in the selected easyconfig, we don't have a full match

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -166,7 +166,7 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
     for (key, val) in tweaks.items():
 
         if isinstance(val, list):
-            regexp = re.compile(r"^\s*%s\s*=\s*(.*)$" % key, re.M)
+            regexp = re.compile(r"^(?P<key>\s*%s)\s*=\s*(?P<val>.*)$" % key, re.M)
             res = regexp.search(ectxt)
             if res:
                 fval = [x for x in val if x != '']  # filter out empty strings
@@ -175,48 +175,48 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
                 # - input starting with comma (empty head list element) => append
                 # - no empty head/tail list element => overwrite
                 if val[0] == '':
-                    newval = "%s + %s" % (res.group(1), fval)
+                    newval = "%s + %s" % (res.group('val'), fval)
                     _log.debug("Appending %s to %s" % (fval, key))
                 elif val[-1] == '':
-                    newval = "%s + %s" % (fval, res.group(1))
+                    newval = "%s + %s" % (fval, res.group('val'))
                     _log.debug("Prepending %s to %s" % (fval, key))
                 else:
                     newval = "%s" % fval
                     _log.debug("Overwriting %s with %s" % (key, fval))
-                ectxt = regexp.sub("%s = %s # tweaked by EasyBuild (was: %s)" % (key, newval, res.group(1)), ectxt)
+                ectxt = regexp.sub("%s = %s" % (res.group('key'), newval), ectxt)
                 _log.info("Tweaked %s list to '%s'" % (key, newval))
             else:
-                additions.append("%s = %s # added by EasyBuild" % (key, val))
+                additions.append("%s = %s" % (key, val))
 
             tweaks.pop(key)
 
     # add parameters or replace existing ones
     for (key, val) in tweaks.items():
 
-        regexp = re.compile(r"^\s*%s\s*=\s*(.*)$" % key, re.M)
+        regexp = re.compile(r"^(?P<key>\s*%s)\s*=\s*(?P<val>.*)$" % key, re.M)
         _log.debug("Regexp pattern for replacing '%s': %s" % (key, regexp.pattern))
         res = regexp.search(ectxt)
         if res:
             # only tweak if the value is different
             diff = True
             try:
-                _log.debug("eval(%s): %s" % (res.group(1), eval(res.group(1))))
-                diff = not eval(res.group(1)) == val
+                _log.debug("eval(%s): %s" % (res.group('val'), eval(res.group('val'))))
+                diff = not eval(res.group('val')) == val
             except (NameError, SyntaxError):
                 # if eval fails, just fall back to string comparison
-                _log.debug("eval failed for \"%s\", falling back to string comparison against \"%s\"..." % (res.group(1), val))
-                diff = not res.group(1) == val
+                tup = (res.group('val'), val)
+                _log.debug("eval failed for \"%s\", falling back to string comparison against \"%s\"..." % tup)
+                diff = not res.group('val') == val
 
             if diff:
-                ectxt = regexp.sub("%s = %s # tweaked by EasyBuild (was: %s)" % (key, quote_str(val), res.group(1)), ectxt)
+                ectxt = regexp.sub("%s = %s" % (res.group('key'), quote_str(val)), ectxt)
                 _log.info("Tweaked '%s' to '%s'" % (key, quote_str(val)))
         else:
             additions.append("%s = %s" % (key, quote_str(val)))
 
     if additions:
-        _log.info("Adding additional parameters to tweaked easyconfig file: %s")
-        ectxt += "\n\n# added by EasyBuild as dictated by command line options\n"
-        ectxt += '\n'.join(additions) + '\n'
+        _log.info("Adding additional parameters to tweaked easyconfig file: %s" % additions)
+        ectxt = '\n'.join([ectxt] + additions)
 
     _log.debug("Contents of tweaked easyconfig file:\n%s" % ectxt)
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -585,7 +585,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(res[1])
         self.assertEqual(ec['version'], specs['version'])
         txt = read_file(res[1])
-        self.assertTrue(re.search("version = [\"']%s[\"'] .*was: [\"']3.13[\"']" % ver, txt))
+        self.assertTrue(re.search("^version = [\"']%s[\"']$" % ver, txt, re.M))
         os.remove(res[1])
 
         # should pick correct toolchain version as well, i.e. now newer than what's specified, if a choice needs to be made
@@ -599,8 +599,8 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(ec['version'], specs['version'])
         self.assertEqual(ec['toolchain']['version'], specs['toolchain_version'])
         txt = read_file(res[1])
-        pattern = "toolchain = .*version.*[\"']%s[\"'].*was: .*version.*[\"']%s[\"']" % (specs['toolchain_version'], tcver)
-        self.assertTrue(re.search(pattern, txt))
+        pattern = "^toolchain = .*version.*[\"']%s[\"'].*}$" % specs['toolchain_version']
+        self.assertTrue(re.search(pattern, txt, re.M))
         os.remove(res[1])
 
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1168,6 +1168,14 @@ class CommandLineOptionsTest(EnhancedTestCase):
             (['--try-toolchain-name=gompi', '--try-toolchain-version=1.4.10'], 'toy/0.0-gompi-1.4.10'),
             (['--try-software-version=1.2.3', '--try-toolchain=gompi,1.4.10'], 'toy/1.2.3-gompi-1.4.10'),
             (['--try-amend=versionsuffix=-test'], 'toy/0.0-test'),
+            # tweak existing list-typed value (patches)
+            (['--try-amend=versionsuffix=-test2', '--try-amend=patches=1.patch,2.patch'], 'toy/0.0-test2'),
+            # append to existing list-typed value (patches)
+            (['--try-amend=versionsuffix=-test3', '--try-amend=patches=,extra.patch'], 'toy/0.0-test3'),
+            # prepend to existing list-typed value (patches)
+            (['--try-amend=versionsuffix=-test4', '--try-amend=patches=extra.patch,'], 'toy/0.0-test4'),
+            # define extra list-typed parameter
+            (['--try-amend=versionsuffix=-test5', '--try-amend=exts_list=1,2,3'], 'toy/0.0-test5'),
             # only --try causes other build specs to be included too
             (['--try-software=foo,1.2.3', '--toolchain=gompi,1.4.10'], 'foo/1.2.3-gompi-1.4.10'),
             (['--software=foo,1.2.3', '--try-toolchain=gompi,1.4.10'], 'foo/1.2.3-gompi-1.4.10'),


### PR DESCRIPTION
* stop adding annoying `# tweaked` comments
* fix issue of disappearing newline
* no adding of useless newline at the end

without this patch:

```diff
$ diff -u easybuild/easyconfigs/w/WRF/WRF-3.6.1-intel-2014b-dmpar.eb  /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-s0R3JD/tweaked_easyconfigs/WRF-3.6.1-intel-2015a-dmpar.eb
--- easybuild/easyconfigs/w/WRF/WRF-3.6.1-intel-2014b-dmpar.eb	2015-01-14 12:14:31.000000000 +0100
+++ /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-s0R3JD/tweaked_easyconfigs/WRF-3.6.1-intel-2015a-dmpar.eb	2015-01-23 15:21:00.000000000 +0100
@@ -5,8 +5,7 @@
 description = """The Weather Research and Forecasting (WRF) Model is a next-generation mesoscale
  numerical weather prediction system designed to serve both operational forecasting and atmospheric
  research needs."""
-
-toolchain = {'name': 'intel', 'version': '2014b'}
+toolchain = {'name': 'intel', 'version': '2015a'} # tweaked by EasyBuild (was: {'name': 'intel', 'version': '2014b'})
 toolchainopts = {'opt': False}  # don't use agressive optimization, stick to -O2
 
 sources = ['%(name)sV%(version)s.TAR.gz']
```

with this patch:

```diff
diff -u easybuild/easyconfigs/w/WRF/WRF-3.6.1-intel-2014b-dmpar.eb /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-08vVqj/tweaked_easyconfigs/WRF-3.6.1-intel-2015a-dmpar.eb 
--- easybuild/easyconfigs/w/WRF/WRF-3.6.1-intel-2014b-dmpar.eb	2015-01-14 12:14:31.000000000 +0100
+++ /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-08vVqj/tweaked_easyconfigs/WRF-3.6.1-intel-2015a-dmpar.eb	2015-01-23 16:38:22.000000000 +0100
@@ -6,7 +6,7 @@
  numerical weather prediction system designed to serve both operational forecasting and atmospheric
  research needs."""
 
-toolchain = {'name': 'intel', 'version': '2014b'}
+toolchain = {'name': 'intel', 'version': '2015a'}
 toolchainopts = {'opt': False}  # don't use agressive optimization, stick to -O2
 
 sources = ['%(name)sV%(version)s.TAR.gz']
```