### PR TITLE
adding options to be accepted config params

### DIFF
--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -165,6 +165,7 @@ DEFAULT_CONFIG = {
 
     # OTHER easyconfig parameters
     'buildstats': [None, "A list of dicts with build statistics", OTHER],
+    'options' : [{},"A list of extra options for specific blocks", OTHER],
 }
 
 


### PR DESCRIPTION
This is needed, e.g.,  to set the modulename when installing python packages with the easyblock configuremakepythonpackge, cf. easyblock  PR https://github.com/hpcugent/easybuild-easyblocks#540 and easyconfig PR https://github.com/hpcugent/easybuild-easyconfigs#1349.

My first contribution to the framework! 