### PR TITLE
define __contains__ in EasyConfig class

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -241,7 +241,7 @@ class EasyConfig(object):
 
         # provide suggestions for typos
         possible_typos = [(key, difflib.get_close_matches(key.lower(), self._config.keys(), 1, 0.85))
-                          for key in local_vars if key not in self._config]
+                          for key in local_vars if key not in self]
 
         typos = [(key, guesses[0]) for (key, guesses) in possible_typos if len(guesses) == 1]
         if typos:
@@ -656,15 +656,16 @@ class EasyConfig(object):
         if key in self._config:
             self._config[key][0] = value
         else:
-            self.log.error("Use of unknown easyconfig parameter '%s' when setting parameter value" % key)
+            tup = (key, value)
+            self.log.error("Use of unknown easyconfig parameter '%s' when setting parameter value to '%s'" % tup)
 
     @handle_deprecated_or_replaced_easyconfig_parameters
     def get(self, key, default=None):
         """
         Gets the value of a key in the config, with 'default' as fallback.
         """
-        if key in self._config:
-            return self.__getitem__(key)
+        if key in self:
+            return self[key]
         else:
             return default
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -630,10 +630,13 @@ class EasyConfig(object):
                 del self.template_values[k]
 
     @handle_deprecated_or_replaced_easyconfig_parameters
+    def __contains__(self, key):
+        """Check whether easyconfig parameter is defined"""
+        return key in self._config
+
+    @handle_deprecated_or_replaced_easyconfig_parameters
     def __getitem__(self, key):
-        """
-        will return the value without the help text
-        """
+        """Return value of specified easyconfig parameter (without help text, etc.)"""
         value = self._config[key][0]
         if self.enable_templating:
             if self.template_values is None or len(self.template_values) == 0:
@@ -644,10 +647,7 @@ class EasyConfig(object):
 
     @handle_deprecated_or_replaced_easyconfig_parameters
     def __setitem__(self, key, value):
-        """
-        sets the value of key in config.
-        help text is untouched
-        """
+        """Set value of specified easyconfig parameter (help text & co is left untouched)"""
         self._config[key][0] = value
 
     @handle_deprecated_or_replaced_easyconfig_parameters

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -637,18 +637,26 @@ class EasyConfig(object):
     @handle_deprecated_or_replaced_easyconfig_parameters
     def __getitem__(self, key):
         """Return value of specified easyconfig parameter (without help text, etc.)"""
-        value = self._config[key][0]
+        value = None
+        if key in self._config:
+            value = self._config[key][0]
+        else:
+            self.log.error("Use of unknown easyconfig parameter '%s' when getting parameter value" % key)
+
         if self.enable_templating:
             if self.template_values is None or len(self.template_values) == 0:
                 self.generate_template_values()
-            return resolve_template(value, self.template_values)
-        else:
-            return value
+            value = resolve_template(value, self.template_values)
+
+        return value
 
     @handle_deprecated_or_replaced_easyconfig_parameters
     def __setitem__(self, key, value):
         """Set value of specified easyconfig parameter (help text & co is left untouched)"""
-        self._config[key][0] = value
+        if key in self._config:
+            self._config[key][0] = value
+        else:
+            self.log.error("Use of unknown easyconfig parameter '%s' when setting parameter value" % key)
 
     @handle_deprecated_or_replaced_easyconfig_parameters
     def get(self, key, default=None):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -227,7 +227,7 @@ class EasyConfigTest(EnhancedTestCase):
         ])
         self.prep()
         eb = EasyConfig(self.eb_file)
-        self.assertRaises(KeyError, lambda: eb['custom_key'])
+        self.assertErrorRegex(EasyBuildError, "unknown easyconfig parameter", lambda: eb['custom_key'])
 
         extra_vars = {'custom_key': ['default', "This is a default key", easyconfig.CUSTOM]}
 
@@ -1000,6 +1000,27 @@ class EasyConfigTest(EnhancedTestCase):
         reload(easyconfig.easyconfig)
         easyconfig.easyconfig.EasyConfig = orig_EasyConfig
         easyconfig.easyconfig.ActiveMNS = orig_ActiveMNS
+
+    def test_unknown_easyconfig_parameter(self):
+        """Check behaviour when unknown easyconfig parameters are used."""
+        self.contents = '\n'.join([
+            'easyblock = "ConfigureMake"',
+            'name = "pi"',
+            'version = "3.14"',
+            'homepage = "http://example.com"',
+            'description = "test easyconfig"',
+            'toolchain = {"name": "dummy", "version": "dummy"}',
+        ])
+        self.prep()
+        ec = EasyConfig(self.eb_file)
+        self.assertFalse('therenosucheasyconfigparameterlikethis' in ec)
+        error_regex = "unknown easyconfig parameter"
+        self.assertErrorRegex(EasyBuildError, error_regex, lambda k: ec[k], 'therenosucheasyconfigparameterlikethis')
+        def set_ec_key(key):
+            """Dummy function to set easyconfig parameter in 'ec' EasyConfig instance"""
+            ec[key] = 'foobar'
+        self.assertErrorRegex(EasyBuildError, error_regex, set_ec_key, 'therenosucheasyconfigparameterlikethis')
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -259,7 +259,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         init_config(build_options=build_options)
 
         err_pattern = 'nosucheasyconfigparameteravailable'
-        self.assertErrorRegex(KeyError, err_pattern, EasyConfig, os.path.join(ecs_dir, 'gzip-1.5-goolf-1.4.10.eb'))
+        self.assertErrorRegex(EasyBuildError, err_pattern, EasyConfig, os.path.join(ecs_dir, 'gzip-1.5-goolf-1.4.10.eb'))
 
         # test simple custom module naming scheme
         os.environ['EASYBUILD_MODULE_NAMING_SCHEME'] = 'TestModuleNamingScheme'


### PR DESCRIPTION
If no `__contains__` is defined, Python falls back to using `__getitem__` for `key in easyconfig_instance` type of expressions (see https://docs.python.org/2/reference/datamodel.html#object.__contains__)

this patch fixes the issue that this fails hard if such an expression is used with a non-existing key

it also makes sure that a decent error message is shown whenever an undefined easyconfig parameter is used (get or set)