### PR TITLE
correctly determine variable name for EBEXTLIST

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -881,7 +881,8 @@ class EasyBlock(object):
         # set environment variable that specifies list of extensions
         if self.exts_all:
             exts_list = ','.join(['%s-%s' % (ext['name'], ext.get('version', '')) for ext in self.exts_all])
-            txt += self.module_generator.set_environment('EBEXTSLIST%s' % self.name.upper(), exts_list)
+            env_var_name = convert_name(self.name, upper=True)
+            txt += self.module_generator.set_environment('EBEXTSLIST%s' % env_var_name, exts_list)
 
         return txt
 


### PR DESCRIPTION
This fixes the following issue I ran into while experimenting with a separate bundle of R libraries; the `-` in the name `R-extra` resulted in an invalid variable name in the generated module file:

```
$ module load R-extra/3.1.2-1.0.0-intel-2015a
-bash: EBEXTSLISTR-EXTRA=gmp-0.5-12: command not found
-bash: export: `EBEXTSLISTR-EXTRA': not a valid identifier
```