### PR TITLE
sacrifice download progress report in log to restore support for downloading over a proxy (i.e. use urllib2 rather than urllib)

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -80,6 +80,7 @@ def mk_full_default_path(name, prefix=DEFAULT_PREFIX):
 BUILD_OPTIONS_CMDLINE = {
     None: [
         'aggregate_regtest',
+        'download_timeout',
         'dump_test_report',
         'easyblock',
         'filter_deps',

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -289,6 +289,8 @@ def download_file(filename, url, path):
         except IOError as err:
             _log.warning("IOError occurred while trying to download %s to %s: %s" % (url, path, err))
             attempt_cnt += 1
+        except Exception, err:
+            _log.error("Unexpected error occurred when trying to download %s to %s: %s" % (url, path, err))
 
         if not downloaded and attempt_cnt < max_attempts:
             _log.info("Attempt %d of downloading %s to %s failed, trying again..." % (attempt_cnt, url, path))

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -272,12 +272,16 @@ def download_file(filename, url, path):
                 _log.info("Downloaded file %s from url %s to %s", filename, url, path)
                 downloaded = True
                 src_fd.close()
+            except (ValueError, ) as err:
+                attempt_cnt += 1
+                shutil.copy(url, path)
+                downloaded = True
             except (urllib2.HTTPError, ) as err:
-                    if err.code == 404:
-                        attempt_cnt += 1
-                        _log.warning("Downloading failed at attempt %s, retrying...", attempt_cnt)
-                        continue
-                    raise
+                if err.code == 404:
+                    attempt_cnt += 1
+                    _log.warning("Downloading failed at attempt %s, retrying...", attempt_cnt)
+                    continue
+                raise
             except (IOError, ) as err:
                 if attempt_cnt <= 3:
                     _log.warning("Failed to get HTTP response code for %s, retrying: %s", url, err)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -274,7 +274,7 @@ def download_file(filename, url, path):
         try:
             # urllib2 does the right thing for http proxy setups, urllib does not!
             url_fd = urllib2.urlopen(url, timeout=timeout)
-            _log.debug('response code for given url: %s' % url_fd.getcode())
+            _log.debug('response code for given url %s: %s' % (url, url_fd.getcode()))
             write_file(path, url_fd.read())
             _log.info("Downloaded file %s from url %s to %s" % (filename, url, path))
             downloaded = True

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -39,7 +39,7 @@ import re
 import shutil
 import stat
 import time
-import urllib2  # does the right thing for http proxy setups, urllib does not!
+import urllib2
 import zlib
 from vsc.utils import fancylogger
 
@@ -272,6 +272,7 @@ def download_file(filename, url, path):
     attempt_cnt = 0
     while not downloaded and attempt_cnt < max_attempts:
         try:
+            # urllib2 does the right thing for http proxy setups, urllib does not!
             url_fd = urllib2.urlopen(url, timeout=timeout)
             _log.debug('response code for given url: %s' % url_fd.getcode())
             write_file(path, url_fd.read())

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -255,6 +255,13 @@ def download_file(filename, url, path):
 
     _log.debug("Trying to download %s from %s to %s", filename, url, path)
 
+    timeout = build_option('download_timeout')
+    if timeout is None:
+        # default to 10sec timeout if none was specified
+        # default system timeout (used is nothing is specified) may be infinite (?)
+        timeout = 10
+    _log.debug("Using timeout of %s seconds for initiating download" % timeout)
+
     # make sure directory exists
     basedir = os.path.dirname(path)
     mkdir(basedir, parents=True)
@@ -264,7 +271,7 @@ def download_file(filename, url, path):
     attempt_cnt = 0
     while not downloaded and attempt_cnt < 3:
         try:
-            src_fd = urllib2.urlopen(url)
+            src_fd = urllib2.urlopen(url, timeout=timeout)
             _log.debug('HTTP response code for given url: %d', src_fd.getcode())
             write_file(path, src_fd.read())
             _log.info("Downloaded file %s from url %s to %s", filename, url, path)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -179,6 +179,7 @@ class EasyBuildOptions(GeneralOption):
             'cleanup-builddir': ("Cleanup build dir after successful installation.", None, 'store_true', True),
             'deprecated': ("Run pretending to be (future) version, to test removal of deprecated code.",
                            None, 'store', None),
+            'download_timeout': ("Timeout for initiating downloads (in seconds)", None, 'store', None),
             'easyblock': ("easyblock to use for processing the spec file or dumping the options",
                           None, 'store', None, 'e', {'metavar': 'CLASS'}),
             'experimental': ("Allow experimental code (with behaviour that can be changed or removed at any given time).",

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -451,7 +451,7 @@ class EasyBlockTest(EnhancedTestCase):
         # 'downloading' a file to (first) sourcepath works
         init_config(args=["--sourcepath=%s:/no/such/dir:%s" % (tmpdir, testdir)])
         shutil.copy2(toy_tarball_path, tmpdir_subdir)
-        res = eb.obtain_file(toy_tarball, urls=[os.path.join('file://', tmpdir_subdir)])
+        res = eb.obtain_file(toy_tarball, urls=['file://%s' % tmpdir_subdir])
         self.assertEqual(res, os.path.join(tmpdir, 't', 'toy', toy_tarball))
 
         # finding a file in sourcepath works
@@ -460,16 +460,13 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(res, toy_tarball_path)
 
         # sourcepath has preference over downloading
-        res = eb.obtain_file(toy_tarball, urls=[os.path.join('file://', tmpdir_subdir)])
+        res = eb.obtain_file(toy_tarball, urls=['file://%s' % tmpdir_subdir])
         self.assertEqual(res, toy_tarball_path)
 
         # obtain_file yields error for non-existing files
         fn = 'thisisclearlyanonexistingfile'
-        try:
-            eb.obtain_file(fn, urls=[os.path.join('file://', tmpdir_subdir)])
-        except EasyBuildError, err:
-            fail_regex = re.compile("Couldn't find file %s anywhere, and downloading it didn't work either" % fn)
-            self.assertTrue(fail_regex.search(str(err)))
+        error_regex = "Couldn't find file %s anywhere, and downloading it didn't work either" % fn
+        self.assertErrorRegex(EasyBuildError, error_regex, eb.obtain_file, fn, urls=['file://%s' % tmpdir_subdir])
 
         # file specifications via URL also work, are downloaded to (first) sourcepath
         init_config(args=["--sourcepath=%s:/no/such/dir:%s" % (tmpdir, sandbox_sources)])


### PR DESCRIPTION
This is a fork of @serverhorror's PR #1150. I took things over after @serverhorror informed me he wouldn't be able to follow up on this in the coming days/weeks.

On top of PR #1150, this includes a unit test that attempts to verify that `download_file` is taking proxy settings into account, and further cleans up the mess in `download_file` itself. It also adds a dedicated configuration option for specifying the timeout used by `urllib2.urlopen`.

I was informed that downloading over a proxy was supported in an earlier version of EasyBuild, sometime around v1.13, but it was unintentionally broken recently.

Just like PR #1150, this thrashes the download progress report that was added in #1066 by @JensTimmerman, since `urllib2` doesn't provide a report hook.

Although it would be possible to implement a progress report, it's probably not worth the hassle (cfr. http://stackoverflow.com/questions/2028517/python-urllib2-progress-hook/2030027#2030027).
@JensTimmerman already mentioned he was OK with dropping it in #1150.