### PR TITLE
fix rare case in which used easyconfig and copied easyconfig are the same

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1940,7 +1940,7 @@ def build_and_install_one(module, orig_environ):
                 shutil.copy(spec, newspec)
             _log.debug("Copied easyconfig file %s to %s" % (spec, newspec))
         except (IOError, OSError), err:
-            print_error("Failed to move easyconfig %s to log dir %s: %s" % (spec, new_log_dir, err))
+            print_error("Failed to copy easyconfig %s to %s: %s" % (spec, newspec, err))
 
     # build failed
     else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1936,7 +1936,7 @@ def build_and_install_one(module, orig_environ):
         try:
             newspec = os.path.join(new_log_dir, "%s-%s.eb" % (app.name, det_full_ec_version(app.cfg)))
             # only copy if the files are not the same actual file already
-            if not os.path.samefile(spec, newspec):
+            if not (os.path.exists(newspec) or os.path.samefile(spec, newspec)):
                 shutil.copy(spec, newspec)
             _log.debug("Copied easyconfig file %s to %s" % (spec, newspec))
         except (IOError, OSError), err:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1935,10 +1935,12 @@ def build_and_install_one(module, orig_environ):
 
         try:
             newspec = os.path.join(new_log_dir, "%s-%s.eb" % (app.name, det_full_ec_version(app.cfg)))
-            # only copy if the files are not the same actual file already
-            if not (os.path.exists(newspec) or os.path.samefile(spec, newspec)):
+            # only copy if the files are not the same file already (yes, it happens)
+            if os.path.exists(newspec) and os.path.samefile(spec, newspec):
+                _log.debug("Not copying easyconfig file %s to %s since files are identical" % (spec, newspec))
+            else:
                 shutil.copy(spec, newspec)
-            _log.debug("Copied easyconfig file %s to %s" % (spec, newspec))
+                _log.debug("Copied easyconfig file %s to %s" % (spec, newspec))
         except (IOError, OSError), err:
             print_error("Failed to copy easyconfig %s to %s: %s" % (spec, newspec, err))
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1934,7 +1934,9 @@ def build_and_install_one(module, orig_environ):
 
         try:
             newspec = os.path.join(new_log_dir, "%s-%s.eb" % (app.name, det_full_ec_version(app.cfg)))
-            shutil.copy(spec, newspec)
+            # only copy if the files are not the same actual file already
+            if not os.path.samefile(spec, newspec):
+                shutil.copy(spec, newspec)
             _log.debug("Copied easyconfig file %s to %s" % (spec, newspec))
         except (IOError, OSError), err:
             print_error("Failed to move easyconfig %s to log dir %s: %s" % (spec, new_log_dir, err))


### PR DESCRIPTION
error as shown below occurs when installing additional extensions after editing easyconfig located in install dir; this trivial patch fixes it

```
ERROR: EasyBuild crashed with an error (at easybuild/main.py:135 in build_and_install_software): Traceback (most recent call last):
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_framework-2.0.0dev-py2.6.egg/easybuild/main.py", line 109, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, orig_environ)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_framework-2.0.0dev-py2.6.egg/easybuild/framework/easyblock.py", line 1938, in build_and_install_one
    shutil.copy(spec, newspec)
  File "/usr/lib64/python2.6/shutil.py", line 84, in copy
    copyfile(src, dst)
  File "/usr/lib64/python2.6/shutil.py", line 48, in copyfile
    raise Error("`%s` and `%s` are the same file" % (src, dst))
Error: `/user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/R/3.1.2-intel-2015a/easybuild/R-3.1.2-intel-2015a.eb` and `/user/scratch/gent/vsc400/vsc40023/easybuild_REGTEST/SL6/sandybridge/software/R/3.1.2-intel-2015a/easybuild/R-3.1.2-intel-2015a.eb` are the same file
```