### PR TITLE
only create the path used in 'module use' if Tcl/C env mods are being used as a modules tool

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -914,7 +914,9 @@ class EasyBlock(object):
             modpath_exts = ActiveMNS().det_modpath_extensions(self.cfg)
             self.log.debug("Including module path extensions returned by module naming scheme: %s" % modpath_exts)
             full_path_modpath_extensions = [os.path.join(top_modpath, mod_path_suffix, ext) for ext in modpath_exts]
-            # module path extensions must exist, otherwise loading this module file will fail
+            # module path extensions must exist since the generated module will run 'module use' on them;
+            # this is only really true for Tcl/C env mods, but we cannot make any assumptions on which modules tool
+            # will be used to consume the generated module (better safe than sorry)
             for modpath_extension in full_path_modpath_extensions:
                 mkdir(modpath_extension, parents=True)
             txt = self.module_generator.use(full_path_modpath_extensions)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -276,8 +276,6 @@ class ModulesTool(object):
 
     def use(self, path):
         """Add module path via 'module use'."""
-        # make sure path exists before we add it
-        mkdir(path, parents=True)
         self.run_module(['use', path])
 
     def unuse(self, path):
@@ -716,6 +714,12 @@ class EnvironmentModulesC(ModulesTool):
     def update(self):
         """Update after new modules were added."""
         pass
+
+    def use(self, path):
+        """Add module path via 'module use'."""
+        # make sure path exists before we add it, since Tcl/C env mods trips over non-existing directories
+        mkdir(path, parents=True)
+        self.run_module(['use', path])
 
 
 class EnvironmentModulesTcl(EnvironmentModulesC):


### PR DESCRIPTION
small optimisation in `tools/modules.py` as result of a discussion with @geimer during the EasyBuild hackathon in Basel (somewhat relates to #1130)