### PR TITLE
Fix path_matches

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -847,12 +847,11 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
 
 def path_matches(path, paths):
     """Check whether given path matches any of the provided paths."""
+    if not os.path.exists(path):
+        return False
     for somepath in paths:
-        try:
-            if os.path.samefile(path, somepath):
-                return True
-        except OSError:
-            pass
+        if os.path.exists(somepath) and os.path.samefile(path, somepath):
+            return True
     return False
 
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -847,7 +847,13 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
 
 def path_matches(path, paths):
     """Check whether given path matches any of the provided paths."""
-    return any([os.path.samefile(path, p) for p in paths])
+    for somepath in paths:
+        try:
+            if os.path.samefile(path, somepath):
+                return True
+        except OSError:
+            pass
+    return False
 
 
 def rmtree2(path, n=3):

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -250,6 +250,26 @@ class FileToolsTest(EnhancedTestCase):
 
         shutil.rmtree(tmpdir)
 
+    def test_path_matches(self):
+        # set up temporary directories
+        tmpdir = tempfile.mkdtemp()
+        path1 = os.path.join(tmpdir, 'path1')
+        ft.mkdir(path1)
+        path2 = os.path.join(tmpdir, 'path2') 
+        ft.mkdir(path1)
+        symlink = os.path.join(tmpdir, 'symlink')
+        os.symlink(path1, symlink)
+        missing = os.path.join(tmpdir, 'missing')
+
+        self.assertFalse(ft.path_matches(missing, [path1, path2]))
+        self.assertFalse(ft.path_matches(path1, [missing]))
+        self.assertFalse(ft.path_matches(path1, [missing, path2]))
+        self.assertFalse(ft.path_matches(path2, [missing, symlink]))
+        self.assertTrue(ft.path_matches(path1, [missing, symlink]))
+
+        # cleanup
+        shutil.rmtree(tmpdir)
+
     def test_read_write_file(self):
         """Test reading/writing files."""
         tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
The `path_matches` routine should ignore non-existing paths rather than fail hard...