### PR TITLE
Let mpi_family return None if MPI is not supported by a toolchain

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -454,5 +454,7 @@ class Toolchain(object):
         raise NotImplementedError
 
     def mpi_family(self):
-        """ Return type of MPI library used in this toolchain (abstract method)."""
-        raise NotImplementedError
+        """ Return type of MPI library used in this toolchain or 'None' if MPI is not
+            supported.
+        """
+        return None

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -381,6 +381,30 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
         self.assertEqual(tc.comp_family(), "GCC")
 
+    def test_mpi_family(self):
+        """Test determining MPI family."""
+        # check subtoolchain w/o MPI
+        tc = self.get_toolchain("GCC", version="4.7.2")
+        tc.prepare()
+        self.assertEqual(tc.mpi_family(), None)
+        modules.modules_tool().purge()
+
+        # check full toolchain including MPI
+        tc = self.get_toolchain("goalf", version="1.1.0-no-OFED")
+        tc.prepare()
+        self.assertEqual(tc.mpi_family(), "OpenMPI")
+        modules.modules_tool().purge()
+
+        # check another one
+        tmpdir, imkl_module_path, imkl_module_txt = self.setup_sandbox_for_intel_fftw()
+        tc = self.get_toolchain("ictce", version="4.1.13")
+        tc.prepare()
+        self.assertEqual(tc.mpi_family(), "IntelMPI")
+
+        # cleanup
+        shutil.rmtree(tmpdir)
+        open(imkl_module_path, 'w').write(imkl_module_txt)
+
     def test_goolfc(self):
         """Test whether goolfc is handled properly."""
         tc = self.get_toolchain("goolfc", version="1.3.12")

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -403,7 +403,7 @@ class ToolchainTest(EnhancedTestCase):
 
         # cleanup
         shutil.rmtree(tmpdir)
-        open(imkl_module_path, 'w').write(imkl_module_txt)
+        write_file(imkl_module_path, imkl_module_txt)
 
     def test_goolfc(self):
         """Test whether goolfc is handled properly."""
@@ -503,7 +503,7 @@ class ToolchainTest(EnhancedTestCase):
 
         # cleanup
         shutil.rmtree(tmpdir)
-        open(imkl_module_path, 'w').write(imkl_module_txt)
+        write_file(imkl_module_path, imkl_module_txt)
 
     def test_toolchain_verification(self):
         """Test verification of toolchain definition."""
@@ -544,7 +544,7 @@ class ToolchainTest(EnhancedTestCase):
 
         # cleanup
         shutil.rmtree(tmpdir)
-        open(imkl_module_path, 'w').write(imkl_module_txt)
+        write_file(imkl_module_path, imkl_module_txt)
 
     def tearDown(self):
         """Cleanup."""


### PR DESCRIPTION
Some easyblocks (e.g., Score-P) are used by multiple packages, some of which use MPI and others don't. Now, when building a package which doesn't use MPI with a subtoolchain (e.g., plain GCC), the easyblock will currently fail hard with an exception raised by the generic `mpi_family` implementation. This change allows the easyblock to check whether MPI is supported by the toolchain and then "do the right thing" (in case of Score-P, optionally pass the `--with-mpi=` configure option).