### PR TITLE
make sure plain text keyring is used by unit tests

### DIFF
--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -31,12 +31,16 @@ Usage: "python -m test.framework.suite" or "python test/framework/suite.py"
 @author: Kenneth Hoste (Ghent University)
 """
 import glob
+import keyring
 import os
 import shutil
 import sys
 import tempfile
 import unittest
 from vsc.utils import fancylogger
+
+# set plain text key ring to be used, so a GitHub token stored in it can be obtained with having to provide a password
+keyring.set_keyring(keyring.backends.file.PlaintextKeyring())
 
 # disable all logging to significantly speed up tests
 import easybuild.tools.build_log  # initialize EasyBuild logging, so we disable it


### PR DESCRIPTION
if `pycrypto` is available, `keyring` defaults to using an encrypted keyring, which requires a password to unlock it

since the unit tests can't provide a password (over and over again), ensure a plain text keyring is being used via `set_keyring`