### PR TITLE
Skip checksum verification when tweaking software version

### DIFF
--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -42,6 +42,7 @@ from distutils.version import LooseVersion
 from vsc.utils import fancylogger
 from vsc.utils.missing import nub
 
+from easybuild.framework.easyconfig.default import get_easyconfig_parameter_default
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, create_paths, process_easyconfig
 from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
@@ -162,11 +163,16 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
 
     additions = []
 
+    # automagically clear out list of checksums if software version is being tweaked 
+    if 'version' in tweaks and 'checksums' not in tweaks:
+        tweaks['checksums'] = []
+        _log.warning("Tweaking version: checksums cleared, verification disabled.")
+
     # we need to treat list values seperately, i.e. we prepend to the current value (if any)
     for (key, val) in tweaks.items():
 
         if isinstance(val, list):
-            regexp = re.compile(r"^(?P<key>\s*%s)\s*=\s*(?P<val>.*)$" % key, re.M)
+            regexp = re.compile(r"^(?P<key>\s*%s)\s*=\s*(?P<val>\[(.|\n)*\])\s*$" % key, re.M)
             res = regexp.search(ectxt)
             if res:
                 fval = [x for x in val if x != '']  # filter out empty strings
@@ -174,7 +180,10 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
                 # - input ending with comma (empty tail list element) => prepend
                 # - input starting with comma (empty head list element) => append
                 # - no empty head/tail list element => overwrite
-                if val[0] == '':
+                if not val:
+                    newval = '[]'
+                    _log.debug("Clearing %s to empty list (was: %s)" % (key, res.group('val')))
+                elif val[0] == '':
                     newval = "%s + %s" % (res.group('val'), fval)
                     _log.debug("Appending %s to %s" % (fval, key))
                 elif val[-1] == '':
@@ -185,7 +194,7 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
                     _log.debug("Overwriting %s with %s" % (key, fval))
                 ectxt = regexp.sub("%s = %s" % (res.group('key'), newval), ectxt)
                 _log.info("Tweaked %s list to '%s'" % (key, newval))
-            else:
+            elif get_easyconfig_parameter_default(key) != val:
                 additions.append("%s = %s" % (key, val))
 
             tweaks.pop(key)
@@ -211,7 +220,7 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
             if diff:
                 ectxt = regexp.sub("%s = %s" % (res.group('key'), quote_str(val)), ectxt)
                 _log.info("Tweaked '%s' to '%s'" % (key, quote_str(val)))
-        else:
+        elif get_easyconfig_parameter_default(key) != val:
             additions.append("%s = %s" % (key, quote_str(val)))
 
     if additions:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -367,7 +367,6 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain_name': tcname,
             'patches': new_patches[:1],
             'homepage': homepage,
-            'foo': "bar"
         }
 
         tweak_one(self.eb_file, tweaked_fn, tweaks)
@@ -515,7 +514,7 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain_name': tcname,
             'toolchain_version': tcver,
             'version': ver,
-            'foo': 'bar123'
+            'start_dir': 'bar123'
         })
         res = obtain_ec_for(specs, [self.ec_dir], None)
         self.assertEqual(res[1], "%s-%s-%s-%s%s.eb" % (name, ver, tcname, tcver, suff))
@@ -526,10 +525,15 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(ec['version'], specs['version'])
         self.assertEqual(ec['versionsuffix'], specs['versionsuffix'])
         self.assertEqual(ec['toolchain'], {'name': tcname, 'version': tcver})
-        # can't check for key 'foo', because EasyConfig ignores parameter names it doesn't know about
-        txt = read_file(res[1])
-        self.assertTrue(re.search('foo = "%s"' % specs['foo'], txt))
+        self.assertEqual(ec['start_dir'], specs['start_dir'])
         os.remove(res[1])
+
+        specs.update({
+            'foo': 'bar123'
+        })
+        self.assertErrorRegex(EasyBuildError, "Unkown easyconfig parameter: foo",
+                              obtain_ec_for, specs, [self.ec_dir], None)
+        del specs['foo']
 
         # should pick correct version, i.e. not newer than what's specified, if a choice needs to be made
         ver = '3.14'


### PR DESCRIPTION
Using `--try-software-version` on an easyconfig which contains checksums currently fails with a checksum mismatch (different tarball, different checksum). This PR addresses this issue by clearing the checksum list when tweaking the software version.

Note: unit test missing...
