### PR TITLE
Suppress creation of module symlinks for hierarchical MNS

### DIFF
--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -133,6 +133,13 @@ class HierarchicalMNS(ModuleNamingScheme):
 
         return subdir
 
+    def det_module_symlink_paths(self, ec):
+        """
+        Determine list of paths in which symlinks to module files must be created.
+        """
+        # symlinks are not very useful in the context of a hierarchical MNS
+        return []
+
     def det_modpath_extensions(self, ec):
         """
         Determine module path extensions, if any.


### PR DESCRIPTION
In the context of a hierarchical module naming scheme, the default symlink farm prefixing the module path with the `moduleclass` easyconfig parameter is of very limited use. First, it creates "strange" modulefile layouts such as
```
numlib/
    Compiler/GCC/4.9.2/
        OpenBLAS
    MPI/GCC/4.9.2/OpenMPI/1.8.4/
        FFTW
        ScaLAPACK
```
which are hard to use in a sensible way. And second, the compiler and MPI modules only extend `$MODULEPATH` for the regular hierarchy, resulting in weird effects when loading these modules. Therefore, it's probably best to suppress the generation of these symlinks entirely.