### PR TITLE
Fix "AttributeError: 'bool' object has no attribute 'info'" in calls to ...

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -174,11 +174,11 @@ def get_log(name=None):
     log.nosupport("Use of get_log function", '2.0')
 
 
-def print_msg(msg, log=None, silent=False, prefix=True):
+def print_msg(msg, do_log=False, silent=False, prefix=True):
     """
     Print a message to stdout.
     """
-    if log:
+    if do_log:
         log.info(msg)
     if not silent:
         if prefix:
@@ -187,7 +187,7 @@ def print_msg(msg, log=None, silent=False, prefix=True):
             print msg
 
 
-def print_error(message, log=None, exitCode=1, opt_parser=None, exit_on_error=True, silent=False):
+def print_error(message, do_log=False, exitCode=1, opt_parser=None, exit_on_error=True, silent=False):
     """
     Print error message and exit EasyBuild
     """
@@ -197,7 +197,7 @@ def print_error(message, log=None, exitCode=1, opt_parser=None, exit_on_error=Tr
                 opt_parser.print_shorthelp()
             sys.stderr.write("ERROR: %s\n" % message)
         sys.exit(exitCode)
-    elif log is not None:
+    elif do_log:
         log.error(message)
 
 


### PR DESCRIPTION
...`print_msg()` and `print_error()`

Functions `print_msg` and `print_error` have an argument called `log`, which should apparently cause both functions to echo the message to the EB log file and not just to the screen.  However, the logger object is also called `log` (module-level global), and the local parameter binding shadows the module-level one.

As a result, `print_msg("foo", log=True)` errors out with `AttributeError: 'bool' object has no attribute 'info`.

This commit changes the argument name to `do_log` to avoid the clash altogether.