### PR TITLE
make EasyBuildLog behave according to standard Logger API, except for EasyBuild loggers (WIP)

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -41,15 +41,13 @@ import stat
 import time
 import urllib2
 import zlib
-from vsc.utils import fancylogger
 
-import easybuild.tools.environment as env
-from easybuild.tools.build_log import print_msg  # import build_log must stay, to activate use of EasyBuildLog
+from easybuild.tools.build_log import get_eb_logger, print_msg  # this import must stay, to activate use of EasyBuildLog
 from easybuild.tools.config import build_option
 from easybuild.tools import run
 
 
-_log = fancylogger.getLogger('filetools', fname=False)
+_log = get_eb_logger('filetools', fname=False)
 
 # easyblock class prefix
 EASYBLOCK_CLASS_PREFIX = 'EB_'


### PR DESCRIPTION
replacement for #1171, #1179 by @riccardomurri 

I still need to make all other EasyBuild modules use `get_eb_logger` rather than `fancylogger.getLogger`; I like how this also avoids having to import `fancylogger` everywhere, the modules in the `easybuild` namespace shouldn't care which logger is being used (except for `build_log`)

@stdweird, @riccardomurri: thoughts?
