### PR TITLE
bump version of vsc-base dep to 2.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,5 +106,5 @@ implement support for installing particular (groups of) software packages.""",
     provides=["eb"] + easybuild_packages,
     test_suite="test.framework.suite",
     zip_safe=False,
-    install_requires=["vsc-base >= 2.0.0"],
+    install_requires=["vsc-base >= 2.0.3"],
 )


### PR DESCRIPTION
bump vsc-base version to 2.0.3, to include:
* fixed typo in debug log message when `--ignoreconfigfiles` is used: https://github.com/hpcugent/vsc-base/pull/158 (required for #1167)
* fix for deprecation warning on use of `message` in exception derived from `BaseException`: https://github.com/hpcugent/vsc-base/pull/155