### PR TITLE
sort all lists obtained via glob.glob, since they are in arbitrary order

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -937,7 +937,7 @@ class EasyBlock(object):
             txt = "\n"
             for key in sorted(requirements):
                 for path in requirements[key]:
-                    paths = glob.glob(path)
+                    paths = sorted(glob.glob(path))
                     if paths:
                         txt += self.module_generator.prepend_paths(key, paths)
             try:

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -302,7 +302,7 @@ def find_matching_easyconfigs(name, installver, paths):
     for path in paths:
         patterns = create_paths(path, name, installver)
         for pattern in patterns:
-            more_ec_files = filter(os.path.isfile, glob.glob(pattern))
+            more_ec_files = filter(os.path.isfile, sorted(glob.glob(pattern)))
             _log.debug("Including files that match glob pattern '%s': %s" % (pattern, more_ec_files))
             ec_files.extend(more_ec_files)
 

--- a/easybuild/tools/jenkins.py
+++ b/easybuild/tools/jenkins.py
@@ -142,7 +142,7 @@ def aggregate_xml_in_dirs(base_dir, output_filename):
     total = 0
 
     for d in dirs:
-        xml_file = glob.glob(os.path.join(d, "*.xml"))
+        xml_file = sorted(glob.glob(os.path.join(d, "*.xml")))
         if xml_file:
             # take the first one (should be only one present)
             xml_file = xml_file[0]

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -68,8 +68,8 @@ from vsc.utils.generaloption import GeneralOption
 
 XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME', os.path.join(os.path.expanduser('~'), ".config"))
 XDG_CONFIG_DIRS = os.environ.get('XDG_CONFIG_DIRS', '/etc').split(os.pathsep)
-DEFAULT_SYSTEM_CONFIGFILES = [f for d in XDG_CONFIG_DIRS for f in glob.glob(os.path.join(d, 'easybuild.d', '*.cfg'))]
-DEFAULT_USER_CONFIGFILE = os.path.join(XDG_CONFIG_HOME, 'easybuild', 'config.cfg')
+DEFAULT_SYS_CFGFILES = [f for d in XDG_CONFIG_DIRS for f in sorted(glob.glob(os.path.join(d, 'easybuild.d', '*.cfg')))]
+DEFAULT_USER_CFGFILE = os.path.join(XDG_CONFIG_HOME, 'easybuild', 'config.cfg')
 
 
 class EasyBuildOptions(GeneralOption):
@@ -77,7 +77,7 @@ class EasyBuildOptions(GeneralOption):
     VERSION = this_is_easybuild()
 
     DEFAULT_LOGLEVEL = 'INFO'
-    DEFAULT_CONFIGFILES = DEFAULT_SYSTEM_CONFIGFILES + [DEFAULT_USER_CONFIGFILE]
+    DEFAULT_CONFIGFILES = DEFAULT_SYS_CFGFILES + [DEFAULT_USER_CFGFILE]
 
     ALLOPTSMANDATORY = False  # allow more than one argument
 

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -94,7 +94,7 @@ def import_available_modules(namespace):
     """
     modules = []
     for path in sys.path:
-        for module in glob.glob(os.path.sep.join([path] + namespace.split('.') + ['*.py'])):
+        for module in sorted(glob.glob(os.path.sep.join([path] + namespace.split('.') + ['*.py']))):
             if not module.endswith('__init__.py'):
                 mod_name = module.split(os.path.sep)[-1].split('.')[0]
                 modpath = '.'.join([namespace, mod_name])


### PR DESCRIPTION
ran into this issue on one particular system:

```
$ python -m test.framework.config
F......
======================================================================
FAIL: test_XDG_CONFIG_env_vars (__main__.EasyBuildConfigTest)
Test effect of XDG_CONFIG* environment variables on default configuration.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/users/k/kehoste/test/easybuild-framework-robust_unit_tests/test/framework/config.py", line 383, in test_XDG_CONFIG_env_vars
    self.assertEqual(eb_go.options.configfiles, cfg_files)
AssertionError: Lists differ: ['/users/k/kehoste/tmpdir/tmpY... != ['/users/k/kehoste/tmpdir/tmpY...

First differing element 0:
/users/k/kehoste/tmpdir/tmpY0uicG/dir1/easybuild.d/foo.cfg
/users/k/kehoste/tmpdir/tmpY0uicG/dir1/easybuild.d/bar.cfg

- ['/users/k/kehoste/tmpdir/tmpY0uicG/dir1/easybuild.d/foo.cfg',
-  '/users/k/kehoste/tmpdir/tmpY0uicG/dir1/easybuild.d/bar.cfg',
? ^

+ ['/users/k/kehoste/tmpdir/tmpY0uicG/dir1/easybuild.d/bar.cfg',
? ^

+  '/users/k/kehoste/tmpdir/tmpY0uicG/dir1/easybuild.d/foo.cfg',
   '/users/k/kehoste/tmpdir/tmpY0uicG/homedir/.config/easybuild/config.cfg']

----------------------------------------------------------------------
Ran 7 tests in 4.412s

FAILED (failures=1)
```

the list of default system config files is obtained via `glob.glob`, which apparently returns a list in arbitrary order (cfr. http://stackoverflow.com/questions/6773584/how-is-pythons-glob-glob-ordered)

hence: sort all lists obtained via `glob.glob` to avoid surprises