### PR TITLE
drop custom setUp/tearDown in toolchain tests which are hard modifying $MODULEPATH

### DIFF
--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -49,17 +49,6 @@ easybuild.tools.toolchain.compiler.systemtools.get_compiler_family = lambda: st.
 class ToolchainTest(EnhancedTestCase):
     """ Baseclass for toolchain testcases """
 
-    def setUp(self):
-        """Set up everything for a unit test."""
-        super(ToolchainTest, self).setUp()
-
-        # start with a clean slate
-        modules.modules_tool().purge()
-
-        # make sure path with modules for testing is added to MODULEPATH
-        self.orig_modpath = os.environ.get('MODULEPATH', '')
-        os.environ['MODULEPATH'] = find_full_path(os.path.join('test', 'framework', 'modules'))
-
     def get_toolchain(self, name, version=None):
         """Get a toolchain object instance to test with."""
         tc_class, _ = search_toolchain(name)
@@ -553,17 +542,6 @@ class ToolchainTest(EnhancedTestCase):
         # cleanup
         shutil.rmtree(tmpdir)
         write_file(imkl_module_path, imkl_module_txt)
-
-    def tearDown(self):
-        """Cleanup."""
-        # purge any loaded modules before restoring $MODULEPATH
-        modules.modules_tool().purge()
-
-        super(ToolchainTest, self).tearDown()
-
-        os.environ['MODULEPATH'] = self.orig_modpath
-        # reinitialize modules tool after touching $MODULEPATH
-        modules.modules_tool()
 
 def suite():
     """ return all the tests"""


### PR DESCRIPTION
The toolchain unit tests hard modifying `$MODULEPATH` caused some issues with these tests on a system where only `modulecmd.tcl` was available; the tests seemed to get stuck in an infinite loop.

Simply dropping the custom `setUp` and `tearDown` in `test/framework/toolchain.py` fixes the issues, since (re)setting `$MODULEPATH` is already properly done in `test/framework/utilities.py`.

Thanks to @ocaisa to help figure this out.