### PR TITLE
keep $I_MPI_MPD_TMPDIR short to avoid 'socket.error: AF_UNIX path too long

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -446,10 +446,10 @@ def set_tmpdir(tmpdir=None, raise_error=False):
         if tmpdir is not None:
             if not os.path.exists(tmpdir):
                 os.makedirs(tmpdir)
-            current_tmpdir = tempfile.mkdtemp(prefix='easybuild-', dir=tmpdir)
+            current_tmpdir = tempfile.mkdtemp(prefix='eb-', dir=tmpdir)
         else:
             # use tempfile default parent dir
-            current_tmpdir = tempfile.mkdtemp(prefix='easybuild-')
+            current_tmpdir = tempfile.mkdtemp(prefix='eb-')
     except OSError, err:
         _log.error("Failed to create temporary directory (tmpdir: %s): %s" % (tmpdir, err))
 

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -197,7 +197,7 @@ class Mpi(Toolchain):
                 self.log.warning("$I_MPI_MPD_TMPDIR should be (very) short to avoid problems: %s" % mpd_tmpdir)
 
             # temporary location for mpdboot and nodes files
-            tmpdir = tempfile.mkdtemp(prefix='eb-mpi_cmd_for-')
+            tmpdir = tempfile.mkdtemp(prefix='mpi_cmd_for-')
 
             # set PBS_ENVIRONMENT, so that --file option for mpdboot isn't stripped away
             env.setvar('PBS_ENVIRONMENT', "PBS_BATCH_MPI")

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -188,11 +188,16 @@ class Mpi(Toolchain):
         # Intel MPI mpirun needs more work
         if mpi_family == toolchain.INTELMPI:  # @UndefinedVariable
 
-            tmpdir = tempfile.mkdtemp(prefix='eb-mpi_cmd_for-')
-
             # set temporary dir for mdp
             # note: this needs to be kept *short*, to avoid mpirun failing with "socket.error: AF_UNIX path too long"
+            # exact limit is unknown, but ~20 characters seems to be OK
             env.setvar('I_MPI_MPD_TMPDIR', tempfile.gettempdir())
+            mpd_tmpdir = os.environ['I_MPI_MPD_TMPDIR']
+            if len(mpd_tmpdir) > 20:
+                self.log.warning("$I_MPI_MPD_TMPDIR should be (very) short to avoid problems: %s" % mpd_tmpdir)
+
+            # temporary location for mpdboot and nodes files
+            tmpdir = tempfile.mkdtemp(prefix='eb-mpi_cmd_for-')
 
             # set PBS_ENVIRONMENT, so that --file option for mpdboot isn't stripped away
             env.setvar('PBS_ENVIRONMENT', "PBS_BATCH_MPI")

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -191,7 +191,8 @@ class Mpi(Toolchain):
             tmpdir = tempfile.mkdtemp(prefix='eb-mpi_cmd_for-')
 
             # set temporary dir for mdp
-            env.setvar('I_MPI_MPD_TMPDIR', tmpdir)
+            # note: this needs to be kept *short*, to avoid mpirun failing with "socket.error: AF_UNIX path too long"
+            env.setvar('I_MPI_MPD_TMPDIR', tempfile.gettempdir())
 
             # set PBS_ENVIRONMENT, so that --file option for mpdboot isn't stripped away
             env.setvar('PBS_ENVIRONMENT', "PBS_BATCH_MPI")

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -257,13 +257,13 @@ class EasyBuildConfigTest(EnhancedTestCase):
             mytmpdir = set_tmpdir(tmpdir=tmpdir)
 
             for var in ['TMPDIR', 'TEMP', 'TMP']:
-                self.assertTrue(os.environ[var].startswith(os.path.join(parent, 'easybuild-')))
+                self.assertTrue(os.environ[var].startswith(os.path.join(parent, 'eb-')))
                 self.assertEqual(os.environ[var], mytmpdir)
-            self.assertTrue(tempfile.gettempdir().startswith(os.path.join(parent, 'easybuild-')))
+            self.assertTrue(tempfile.gettempdir().startswith(os.path.join(parent, 'eb-')))
             tempfile_tmpdir = tempfile.mkdtemp()
-            self.assertTrue(tempfile_tmpdir.startswith(os.path.join(parent, 'easybuild-')))
+            self.assertTrue(tempfile_tmpdir.startswith(os.path.join(parent, 'eb-')))
             fd, tempfile_tmpfile = tempfile.mkstemp()
-            self.assertTrue(tempfile_tmpfile.startswith(os.path.join(parent, 'easybuild-')))
+            self.assertTrue(tempfile_tmpfile.startswith(os.path.join(parent, 'eb-')))
 
             # tmp_logdir follows tmpdir
             self.assertEqual(get_build_log_path(), mytmpdir)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -848,7 +848,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             regex = re.compile(r"^ \* \[.\] .*/(?P<filepath>.*) \(module: (?P<module>.*)\)$", re.M)
             self.assertTrue(sorted(regex.findall(outtxt)), sorted(modules))
 
-            pr_tmpdir = os.path.join(tmpdir, 'easybuild-\S{6}', 'files_pr1239')
+            pr_tmpdir = os.path.join(tmpdir, 'eb-\S{6}', 'files_pr1239')
             regex = re.compile("Prepended list of robot search paths with %s:" % pr_tmpdir, re.M)
             self.assertTrue(regex.search(outtxt), "Found pattern %s in %s" % (regex.pattern, outtxt))
         except URLError, err:
@@ -1009,17 +1009,17 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         outtxt = self.eb_main(args, do_build=True)
 
-        tmpdir_msg = r"Using %s\S+ as temporary directory" % os.path.join(tmpdir, 'easybuild-')
+        tmpdir_msg = r"Using %s\S+ as temporary directory" % os.path.join(tmpdir, 'eb-')
         found = re.search(tmpdir_msg, outtxt, re.M)
         self.assertTrue(found, "Log message for tmpdir found in outtxt: %s" % outtxt)
 
         for var in ['TMPDIR', 'TEMP', 'TMP']:
-            self.assertTrue(os.environ[var].startswith(os.path.join(tmpdir, 'easybuild-')))
-        self.assertTrue(tempfile.gettempdir().startswith(os.path.join(tmpdir, 'easybuild-')))
+            self.assertTrue(os.environ[var].startswith(os.path.join(tmpdir, 'eb-')))
+        self.assertTrue(tempfile.gettempdir().startswith(os.path.join(tmpdir, 'eb-')))
         tempfile_tmpdir = tempfile.mkdtemp()
-        self.assertTrue(tempfile_tmpdir.startswith(os.path.join(tmpdir, 'easybuild-')))
+        self.assertTrue(tempfile_tmpdir.startswith(os.path.join(tmpdir, 'eb-')))
         fd, tempfile_tmpfile = tempfile.mkstemp()
-        self.assertTrue(tempfile_tmpfile.startswith(os.path.join(tmpdir, 'easybuild-')))
+        self.assertTrue(tempfile_tmpfile.startswith(os.path.join(tmpdir, 'eb-')))
 
         # cleanup
         os.close(fd)
@@ -1303,7 +1303,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                     mod = ec_name.replace('-', '/')
                 else:
                     mod = '%s-gompi-1.4.10' % ec_name.replace('-', '/')
-                mod_regex = re.compile("^ \* \[ \] \S+/easybuild-\S+/%s \(module: .*%s\)$" % (ec, mod), re.M)
+                mod_regex = re.compile("^ \* \[ \] \S+/eb-\S+/%s \(module: .*%s\)$" % (ec, mod), re.M)
                 #mod_regex = re.compile("%s \(module: .*%s\)$" % (ec, mod), re.M)
                 self.assertTrue(mod_regex.search(outtxt), "Pattern %s found in %s" % (mod_regex.pattern, outtxt))
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -180,11 +180,11 @@ class ToyBuildTest(EnhancedTestCase):
                               verify=False, fails=True, verbose=False, raise_error=True)
 
         # make sure log file is retained, also for failed build
-        log_path_pattern = os.path.join(tmpdir, 'easybuild-*', 'easybuild-toy-0.0*.log')
+        log_path_pattern = os.path.join(tmpdir, 'eb-*', 'easybuild-toy-0.0*.log')
         self.assertTrue(len(glob.glob(log_path_pattern)) == 1, "Log file found at %s" % log_path_pattern)
 
         # make sure individual test report is retained, also for failed build
-        test_report_fp_pattern = os.path.join(tmpdir, 'easybuild-*', 'easybuild-toy-0.0*test_report.md')
+        test_report_fp_pattern = os.path.join(tmpdir, 'eb-*', 'easybuild-toy-0.0*test_report.md')
         self.assertTrue(len(glob.glob(test_report_fp_pattern)) == 1, "Test report %s found" % test_report_fp_pattern)
 
         # test dumping full test report (doesn't raise an exception)


### PR DESCRIPTION
This fixes problems with the use of `mpi_cmd_for`, that manifest themselves like:

```
mpdboot_node2025.delcatty.os (handle_mpd_output 980): failed to ping mpd on localhost; received output={}
mpdboot_node2025.delcatty.os (handle_mpd_output 982): Please examine the /tmp/mpd2.logfile_vsc40023 log file on each node of the ring
```

Apparently, the value for `I_MPI_MPD_TMPDIR` must be kept *very* short; see also https://software.intel.com/sites/products/documentation/hpc/ics/impi/41/lin/Reference_Manual/index.htm#Environment_Variables_Multipurpose_Daemon_Commands.htm .

@wpoely86: please review