### PR TITLE
also consider robot search path when looking for specified easyconfigs

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -240,15 +240,14 @@ def alt_easyconfig_paths(tmpdir, tweaked_ecs=False, from_pr=False):
     return tweaked_ecs_path, pr_path
 
 
-def det_easyconfig_paths(orig_paths, from_pr=None, easyconfigs_pkg_paths=None):
+def det_easyconfig_paths(orig_paths):
     """
     Determine paths to easyconfig files.
     @param orig_paths: list of original easyconfig paths
-    @param from_pr: pull request number to fetch easyconfigs from
-    @param easyconfigs_pkg_paths: paths to installed easyconfigs package
+    @return: list of paths to easyconfig files
     """
-    if easyconfigs_pkg_paths is None:
-        easyconfigs_pkg_paths = []
+    from_pr = build_option('from_pr')
+    robot_path = build_option('robot_path')
 
     # list of specified easyconfig files
     ec_files = orig_paths[:]
@@ -266,8 +265,8 @@ def det_easyconfig_paths(orig_paths, from_pr=None, easyconfigs_pkg_paths=None):
             # if no easyconfigs are specified, use all the ones touched in the PR
             ec_files = [path for path in pr_files if path.endswith('.eb')]
 
-    if ec_files and easyconfigs_pkg_paths:
-        # look for easyconfigs with relative paths in easybuild-easyconfigs package,
+    if ec_files and robot_path:
+        # look for easyconfigs with relative paths in robot search path,
         # unless they were found at the given relative paths
 
         # determine which easyconfigs files need to be found, if any
@@ -277,8 +276,8 @@ def det_easyconfig_paths(orig_paths, from_pr=None, easyconfigs_pkg_paths=None):
                 ecs_to_find.append((idx, ec_file))
         _log.debug("List of easyconfig files to find: %s" % ecs_to_find)
 
-        # find missing easyconfigs by walking paths with installed easyconfig files
-        for path in easyconfigs_pkg_paths:
+        # find missing easyconfigs by walking paths in robot search path
+        for path in robot_path:
             _log.debug("Looking for missing easyconfig files (%d left) in %s..." % (len(ecs_to_find), path))
             for (subpath, dirnames, filenames) in os.walk(path, topdown=True):
                 for idx, orig_path in ecs_to_find[:]:
@@ -300,8 +299,7 @@ def det_easyconfig_paths(orig_paths, from_pr=None, easyconfigs_pkg_paths=None):
             if not ecs_to_find:
                 break
 
-    # indicate that specified paths do not contain generated easyconfig files
-    return [(ec_file, False) for ec_file in ec_files]
+    return ec_files
 
 
 def parse_easyconfigs(paths):

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -226,8 +226,11 @@ def main(testing_data=(None, None, None)):
         _log.warning("Failed to determine install path for easybuild-easyconfigs package.")
 
     # determine paths to easyconfigs
-    paths = det_easyconfig_paths(orig_paths, options.from_pr, easyconfigs_pkg_paths)
-    if not paths:
+    paths = det_easyconfig_paths(orig_paths)
+    if paths:
+        # transform paths into tuples, use 'False' to indicate the corresponding easyconfig files were not generated
+        paths = [(p, False) for p in paths]
+    else:
         if 'name' in build_specs:
             # try to obtain or generate an easyconfig file via build specifications if a software name is provided
             paths = find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=testing)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -882,7 +882,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--from-pr=1239',
             '--dry-run',
             # an argument must be specified to --robot, since easybuild-easyconfigs may not be installed
-            '--robot=%s' % os.path.join(os.path.dirname(__file__), 'easyconfigs'),
+            '--robot=%s' % test_ecs_path,
             '--unittest-file=%s' % self.logfile,
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # a GitHub token should be available for this user
             '--tmpdir=%s' % tmpdir,
@@ -890,13 +890,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
         try:
             outtxt = self.eb_main(args, logfile=dummylogfn, raise_error=True)
             modules = [
-                (ecstmpdir, 'toy/0.0'),
-                ('.*', 'GCC/4.9.2'),  # not included in PR
+                (test_ecs_path, 'toy/0.0'),  # not included in PR
+                (test_ecs_path, 'GCC/4.9.2'),  # not included in PR
                 (tmpdir, 'hwloc/1.10.0-GCC-4.9.2'),
                 (tmpdir, 'numactl/2.0.10-GCC-4.9.2'),
                 (tmpdir, 'OpenMPI/1.8.4-GCC-4.9.2'),
                 (tmpdir, 'gompi/2015a'),
-                ('.*', 'GCC/4.6.3'),
+                (test_ecs_path, 'GCC/4.6.3'),  # not included in PR
             ]
             for path_prefix, module in modules:
                 ec_fn = "%s.eb" % '-'.join(module.split('/'))

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -29,6 +29,9 @@ Unit tests for robot (dependency resolution).
 """
 
 import os
+import re
+import shutil
+import tempfile
 from copy import deepcopy
 from test.framework.utilities import EnhancedTestCase, init_config
 from unittest import TestLoader
@@ -39,8 +42,14 @@ import easybuild.tools.robot as robot
 from easybuild.framework.easyconfig.tools import skip_available
 from easybuild.tools import config, modules
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import read_file, write_file
+from easybuild.tools.github import fetch_github_token
 from easybuild.tools.robot import resolve_dependencies
 from test.framework.utilities import find_full_path
+
+
+# test account, for which a token is available
+GITHUB_TEST_ACCOUNT = 'easybuild_test'
 
 ORIG_MODULES_TOOL = modules.modules_tool
 ORIG_ECTOOLS_MODULES_TOOL = ectools.modules_tool
@@ -79,8 +88,12 @@ class RobotTest(EnhancedTestCase):
     """ Testcase for the robot dependency resolution """
 
     def setUp(self):
-        """Set up everything for a unit test."""
+        """Set up test."""
         super(RobotTest, self).setUp()
+        self.github_token = fetch_github_token(GITHUB_TEST_ACCOUNT)
+
+    def xtest_resolve_dependencies(self):
+        """ Test with some basic testcases (also check if he can find dependencies inside the given directory """
 
         # replace Modules class with something we have control over
         config.modules_tool = mock_module
@@ -88,11 +101,9 @@ class RobotTest(EnhancedTestCase):
         robot.modules_tool = mock_module
         os.environ['module'] = "() {  eval `/bin/echo $*`\n}"
 
-        self.base_easyconfig_dir = find_full_path(os.path.join("test", "framework", "easyconfigs"))
-        self.assertTrue(self.base_easyconfig_dir)
+        base_easyconfig_dir = find_full_path(os.path.join("test", "framework", "easyconfigs"))
+        self.assertTrue(base_easyconfig_dir)
 
-    def test_resolve_dependencies(self):
-        """ Test with some basic testcases (also check if he can find dependencies inside the given directory """
         easyconfig = {
             'spec': '_',
             'full_mod_name': 'name/version',
@@ -128,7 +139,7 @@ class RobotTest(EnhancedTestCase):
             }],
             'parsed': True,
         }
-        build_options.update({'robot': True, 'robot_path': self.base_easyconfig_dir})
+        build_options.update({'robot': True, 'robot_path': base_easyconfig_dir})
         init_config(build_options=build_options)
         res = resolve_dependencies([deepcopy(easyconfig_dep)])
         # dependency should be found, order should be correct
@@ -188,7 +199,7 @@ class RobotTest(EnhancedTestCase):
             'hidden': False,
         }]
         ecs = [deepcopy(easyconfig_dep)]
-        build_options.update({'robot_path': self.base_easyconfig_dir})
+        build_options.update({'robot_path': base_easyconfig_dir})
         init_config(build_options=build_options)
         res = resolve_dependencies([deepcopy(easyconfig_dep)])
 
@@ -288,10 +299,6 @@ class RobotTest(EnhancedTestCase):
         self.assertEqual('goolf/1.4.10', res[2]['full_mod_name'])
         self.assertEqual('foo/1.2.3', res[3]['full_mod_name'])
 
-    def tearDown(self):
-        """ reset the Modules back to its original """
-        super(RobotTest, self).tearDown()
-
         config.modules_tool = ORIG_MODULES_TOOL
         ectools.modules_tool = ORIG_ECTOOLS_MODULES_TOOL
         robot.modules_tool = ORIG_ROBOT_MODULES_TOOL
@@ -300,6 +307,103 @@ class RobotTest(EnhancedTestCase):
         else:
             if 'module' in os.environ:
                 del os.environ['module']
+
+    def test_det_easyconfig_paths(self):
+        """Test det_easyconfig_paths function (without --from-pr)."""
+        fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
+        os.close(fd)
+
+        test_ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs')
+
+        test_ec = 'toy-0.0-deps.eb'
+        shutil.copy2(os.path.join(test_ecs_path, test_ec), self.test_prefix)
+        shutil.copy2(os.path.join(test_ecs_path, 'ictce-4.1.13.eb'), self.test_prefix)
+        self.assertFalse(os.path.exists(test_ec))
+
+        args = [
+            os.path.join(test_ecs_path, 'toy-0.0.eb'),
+            test_ec,  # relative path, should be resolved via robot search path
+            # PR for foss/2015a, see https://github.com/hpcugent/easybuild-easyconfigs/pull/1239/files
+            #'--from-pr=1239',
+            '--dry-run',
+            '--debug',
+            '--robot',
+            '--robot-paths=%s' % self.test_prefix,  # override $EASYBUILD_ROBOT_PATHS
+            '--unittest-file=%s' % self.logfile,
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # a GitHub token should be available for this user
+            '--tmpdir=%s' % self.test_prefix,
+        ]
+        outtxt = self.eb_main(args, logfile=dummylogfn, raise_error=True)
+
+        modules = [
+            (test_ecs_path, 'toy/0.0'),  # specified easyconfigs, available at given location
+            (self.test_prefix, 'ictce/4.1.13'),  # dependency, found in robot search path
+            (self.test_prefix, 'toy/0.0-deps'),  # specified easyconfig, found in robot search path
+        ]
+        for path_prefix, module in modules:
+            ec_fn = "%s.eb" % '-'.join(module.split('/'))
+            regex = re.compile(r"^ \* \[.\] %s.*%s \(module: %s\)$" % (path_prefix, ec_fn, module), re.M)
+            self.assertTrue(regex.search(outtxt), "Found pattern %s in %s" % (regex.pattern, outtxt))
+
+    def test_det_easyconfig_paths_from_pr(self):
+        """Test det_easyconfig_paths function, with --from-pr enabled as well."""
+        if self.github_token is None:
+            print "Skipping test_from_pr, no GitHub token available?"
+            return
+
+        fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
+        os.close(fd)
+
+        test_ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs')
+
+        test_ec = 'toy-0.0-deps.eb'
+        shutil.copy2(os.path.join(test_ecs_path, test_ec), self.test_prefix)
+        shutil.copy2(os.path.join(test_ecs_path, 'ictce-4.1.13.eb'), self.test_prefix)
+        self.assertFalse(os.path.exists(test_ec))
+
+        gompi_2015a_txt = '\n'.join([
+            "easyblock = 'Toolchain'",
+            "name = 'gompi'",
+            "version = '2015a'",
+            "versionsuffix = '-test'",
+            "homepage = 'foo'",
+            "description = 'bar'",
+            "toolchain = {'name': 'dummy', 'version': 'dummy'}",
+        ])
+        write_file(os.path.join(self.test_prefix, 'gompi-2015a-test.eb'), gompi_2015a_txt)
+        # put gompi-2015a.eb easyconfig in place that shouldn't be considered (paths via --from-pr have precedence)
+        write_file(os.path.join(self.test_prefix, 'gompi-2015a.eb'), gompi_2015a_txt)
+
+        args = [
+            os.path.join(test_ecs_path, 'toy-0.0.eb'),
+            test_ec,  # relative path, should be resolved via robot search path
+            # PR for foss/2015a, see https://github.com/hpcugent/easybuild-easyconfigs/pull/1239/files
+            '--from-pr=1239',
+            'FFTW-3.3.4-gompi-2015a.eb',
+            'gompi-2015a-test.eb',  # relative path, available in robot search path
+            '--dry-run',
+            '--robot',
+            '--robot=%s' % self.test_prefix,
+            '--unittest-file=%s' % self.logfile,
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # a GitHub token should be available for this user
+            '--tmpdir=%s' % self.test_prefix,
+        ]
+        outtxt = self.eb_main(args, logfile=dummylogfn, raise_error=True)
+
+        from_pr_prefix = os.path.join(self.test_prefix, '.*', 'files_pr1239')
+        modules = [
+            (test_ecs_path, 'toy/0.0'),  # specified easyconfigs, available at given location
+            (self.test_prefix, 'ictce/4.1.13'),  # dependency, found in robot search path
+            (self.test_prefix, 'toy/0.0-deps'),  # specified easyconfig, found in robot search path
+            (self.test_prefix, 'gompi/2015a-test'),  # specified easyconfig, found in robot search path
+            (from_pr_prefix, 'FFTW/3.3.4-gompi-2015a'),  # part of PR easyconfigs
+            (from_pr_prefix, 'gompi/2015a'),  # part of PR easyconfigs
+            (test_ecs_path, 'GCC/4.9.2'),  # dependency for PR easyconfigs, found in robot search path
+        ]
+        for path_prefix, module in modules:
+            ec_fn = "%s.eb" % '-'.join(module.split('/'))
+            regex = re.compile(r"^ \* \[.\] %s.*%s \(module: %s\)$" % (path_prefix, ec_fn, module), re.M)
+            self.assertTrue(regex.search(outtxt), "Found pattern %s in %s" % (regex.pattern, outtxt))
 
 
 def suite():


### PR DESCRIPTION
behaviour without this patch: only easyconfigs that are part of EasyBuild installation are consider for *specified* easyconfigs, never the ones in robot search path (see `GCC-4.9.2.eb`)

```
$ ls $HOME/myeasyconfigs
GCC-4.9.2.eb

$ eb GCC-4.9.2.eb Autoconf-2.69-GCC-4.9.2.eb --robot=$HOME/myeasyconfigs -D
== temporary log file in case of crash /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-3cBdaG/easybuild-gdCz2w.log
Dry run: printing build status of easyconfigs and dependencies
CFGS=/Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs
 * [ ] $CFGS/g/GCC/GCC-4.9.2.eb (module: GCC/4.9.2)
 * [ ] $CFGS/m/M4/M4-1.4.17-GCC-4.9.2.eb (module: M4/1.4.17-GCC-4.9.2)
 * [ ] $CFGS/a/Autoconf/Autoconf-2.69-GCC-4.9.2.eb (module: Autoconf/2.69-GCC-4.9.2)
== temporary log file /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-3cBdaG/easybuild-gdCz2w.log has been removed.
== temporary directory /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-3cBdaG has been removed.
```

with this patch: all robot search paths are considered for *specified* easyconfigs, in order (see `GCC-4.9.2.eb`):

```
$ ls $HOME/myeasyconfigs
GCC-4.9.2.eb

$ eb GCC-4.9.2.eb Autoconf-2.69-GCC-4.9.2.eb --robot=$HOME/myeasyconfigs -D
== temporary log file in case of crash /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-ExW4E3/easybuild-DAqTuJ.log
Dry run: printing build status of easyconfigs and dependencies
CFGS=/Users/kehoste
 * [ ] $CFGS/myeasyconfigs/GCC-4.9.2.eb (module: GCC/4.9.2)
 * [ ] $CFGS/work/easybuild-easyconfigs/easybuild/easyconfigs/m/M4/M4-1.4.17-GCC-4.9.2.eb (module: M4/1.4.17-GCC-4.9.2)
 * [ ] $CFGS/work/easybuild-easyconfigs/easybuild/easyconfigs/a/Autoconf/Autoconf-2.69-GCC-4.9.2.eb (module: Autoconf/2.69-GCC-4.9.2)
== temporary log file /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-ExW4E3/easybuild-DAqTuJ.log has been removed.
== temporary directory /var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/easybuild-ExW4E3 has been removed.
```