### PR TITLE
remove fetch_parameter_from_easyconfig_file rather than deprecating it

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -692,18 +692,6 @@ def det_installversion(version, toolchain_name, toolchain_version, prefix, suffi
     _log.nosupport('Use det_full_ec_version from easybuild.tools.module_generator instead of %s' % old_fn, '2.0')
 
 
-def fetch_parameter_from_easyconfig_file(path, param):
-    """
-    Fetch parameter specification from given easyconfig file.
-    DEPRECATED: use fetch_parameters_from_easyconfig from easybuild.framework.easyconfigs.parser instead
-    """
-    old = 'fetch_parameter_from_easyconfig_file'
-    new = 'fetch_parameters_from_easyconfig'
-    _log.deprecated("%s is replaced by %s from easybuild.framework.easyconfig.parser" % (old, new), '3.0')
-    ectxt = read_file(path)
-    return fetch_parameters_from_easyconfig(ectxt, [param])[0]
-
-
 def get_easyblock_class(easyblock, name=None, default_fallback=True, error_on_failed_import=True):
     """
     Get class for a particular easyblock (or use default)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -44,7 +44,7 @@ import easybuild.framework.easyconfig as easyconfig
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.framework.easyconfig.easyconfig import create_paths
-from easybuild.framework.easyconfig.easyconfig import fetch_parameter_from_easyconfig_file, get_easyblock_class
+from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak_one
 from easybuild.tools.build_log import EasyBuildError
@@ -873,11 +873,6 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertEqual(easyblock, correct_easyblock)
 
         self.assertEqual(fetch_parameters_from_easyconfig(read_file(toy_ec_file), ['description'])[0], "Toy C program.")
-
-        # also check deprecated function fetch_parameter_from_easyconfig_file
-        os.environ['EASYBUILD_DEPRECATED'] = '2.0'
-        init_config()
-        self.assertEqual(fetch_parameter_from_easyconfig_file(toy_ec_file, 'description'), "Toy C program.")
 
     def test_get_easyblock_class(self):
         """Test get_easyblock_class function."""


### PR DESCRIPTION
no need to deprecate something if it's internal to the framework (i.e., not meant to be used in easyblocks), since that means dragging it along (and documenting it) for quite some time to come...

@wpoely86: please review?