### PR TITLE
make bootstrap script more robust w.r.t. vsc-base component

### DIFF
--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -461,6 +461,9 @@ def main():
         # exclude path if it's potentially an EasyBuild/VSC package, providing the 'easybuild'/'vsc' namespace, resp.
         if any([os.path.exists(os.path.join(path, pkg, '__init__.py')) for pkg in ['easybuild', 'vsc']]):
             include_path = False
+        # exclude any .egg paths
+        if path.endswith('.egg'):
+            include_path = False
         # exclude any path that contains an easy-install.pth file
         if os.path.exists(os.path.join(path, 'easy-install.pth')):
             include_path = False

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -458,12 +458,10 @@ def main():
     sys.path = []
     for path in orig_sys_path:
         include_path = True
-        # exclude path if it's potentially an EasyBuild package
-        if 'easybuild' in path or os.path.exists(os.path.join(path, 'easybuild')):
+        # exclude path if it's potentially an EasyBuild/VSC package, providing the 'easybuild'/'vsc' namespace, resp.
+        if any([os.path.exists(os.path.join(path, pkg, '__init__.py')) for pkg in ['easybuild', 'vsc']]):
             include_path = False
-        if '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
-            include_path = False
-        # exclude path if it contain an easy-install.pth file
+        # exclude any path that contains an easy-install.pth file
         if os.path.exists(os.path.join(path, 'easy-install.pth')):
             include_path = False
 

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -454,13 +454,10 @@ def main():
         # exclude path if it's potentially an EasyBuild package
         if 'easybuild' in path or os.path.exists(os.path.join(path, 'easybuild')):
             include_path = False
-        elif '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
-            include_path = False
-        # exclude path if it provides 'distribute' package
-        elif 'distribute' in path or os.path.exists(os.path.join(path, 'distribute')):
+        if '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
             include_path = False
         # exclude path if it contain an easy-install.pth file
-        elif os.path.exists(os.path.join(path, 'easy-install.pth')):
+        if os.path.exists(os.path.join(path, 'easy-install.pth')):
             include_path = False
 
         if include_path:

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -450,7 +450,7 @@ def main():
         # exclude path if it's potentially an EasyBuild package
         if 'easybuild' in path or os.path.exists(os.path.join(path, 'easybuild')):
             include_path = False
-        if 'vsc_base' in path or os.path.exists(os.path.join(path, 'vsc', 'utils')):
+        if '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
             include_path = False
         # exclude path if it contain an easy-install.pth file
         if os.path.exists(os.path.join(path, 'easy-install.pth')):

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -454,10 +454,13 @@ def main():
         # exclude path if it's potentially an EasyBuild package
         if 'easybuild' in path or os.path.exists(os.path.join(path, 'easybuild')):
             include_path = False
-        if '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
+        elif '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
+            include_path = False
+        # exclude path if it provides 'distribute' package
+        elif 'distribute' in path or os.path.exists(os.path.join(path, 'distribute')):
             include_path = False
         # exclude path if it contain an easy-install.pth file
-        if os.path.exists(os.path.join(path, 'easy-install.pth')):
+        elif os.path.exists(os.path.join(path, 'easy-install.pth')):
             include_path = False
 
         if include_path:

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -448,7 +448,7 @@ def main():
     for path in orig_sys_path:
         include_path = True
         # exclude path if it's potentially an EasyBuild package or vsc-base
-        if 'easybuild' in path or 'vsc-base' in path:
+        if os.path.exists(os.path.join(path, 'easybuild')) or os.path.exists(os.path.join(path, 'vsc')):
             include_path = False
         # exclude path if it contain an easy-install.pth file
         if os.path.exists(os.path.join(path, 'easy-install.pth')):

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -58,6 +58,9 @@ EASYBUILD_PACKAGES = [VSC_BASE, 'easybuild-framework', 'easybuild-easyblocks', '
 # set print_debug to True for detailed progress info
 print_debug = os.environ.get('EASYBUILD_BOOTSTRAP_DEBUG', False)
 
+# don't add user site directory to sys.path (equivalent to python -s)
+os.environ['PYTHONNOUSERSITE'] = '1'
+
 # clean PYTHONPATH to avoid finding readily installed stuff
 os.environ['PYTHONPATH'] = ''
 

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -46,6 +46,7 @@ import glob
 import os
 import re
 import shutil
+import site
 import sys
 import tempfile
 from distutils.version import LooseVersion
@@ -58,8 +59,9 @@ EASYBUILD_PACKAGES = [VSC_BASE, 'easybuild-framework', 'easybuild-easyblocks', '
 # set print_debug to True for detailed progress info
 print_debug = os.environ.get('EASYBUILD_BOOTSTRAP_DEBUG', False)
 
-# don't add user site directory to sys.path (equivalent to python -s)
+# don't add user site directory to sys.path (equivalent to python -s), see https://www.python.org/dev/peps/pep-0370/
 os.environ['PYTHONNOUSERSITE'] = '1'
+site.ENABLE_USER_SITE = False
 
 # clean PYTHONPATH to avoid finding readily installed stuff
 os.environ['PYTHONPATH'] = ''

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -457,7 +457,7 @@ def main():
         elif '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
             include_path = False
         # exclude path if it provides 'distribute' package
-        elif 'distribute' in path or os.path.exists(os.path.join(path, 'distribute')):
+        elif 'distutils' in path or os.path.exists(os.path.join(path, 'distutils')):
             include_path = False
         # exclude path if it contain an easy-install.pth file
         elif os.path.exists(os.path.join(path, 'easy-install.pth')):

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -447,8 +447,8 @@ def main():
     sys.path = []
     for path in orig_sys_path:
         include_path = True
-        # exclude path if it's potentially an EasyBuild package
-        if 'easybuild' in path:
+        # exclude path if it's potentially an EasyBuild package or vsc-base
+        if 'easybuild' in path or 'vsc-base' in path:
             include_path = False
         # exclude path if it contain an easy-install.pth file
         if os.path.exists(os.path.join(path, 'easy-install.pth')):

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -369,6 +369,7 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
         # make sure we still have distribute in PYTHONPATH, so we have control over which 'setup' is used
         pythonpaths = [x for x in os.environ.get('PYTHONPATH', '').split(os.pathsep) if len(x) > 0]
         os.environ['PYTHONPATH'] = os.pathsep.join([distribute_egg_dir] + pythonpaths)
+        sys.path.insert(0, distribute_egg_dir)
 
     # create easyconfig file
     ebfile = os.path.join(tmpdir, 'EasyBuild-%s.eb' % templates['version'])

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -371,7 +371,7 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
         # make sure we still have distribute in PYTHONPATH, so we have control over which 'setup' is used
         pythonpaths = [x for x in os.environ.get('PYTHONPATH', '').split(os.pathsep) if len(x) > 0]
         os.environ['PYTHONPATH'] = os.pathsep.join([distribute_egg_dir] + pythonpaths)
-        sys.path.insert(0, distribute_egg_dir)
+    debug("stage 2 $PYTHONPATH: %s" % os.environ)
 
     # create easyconfig file
     ebfile = os.path.join(tmpdir, 'EasyBuild-%s.eb' % templates['version'])

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -447,8 +447,10 @@ def main():
     sys.path = []
     for path in orig_sys_path:
         include_path = True
-        # exclude path if it's potentially an EasyBuild package or vsc-base
-        if os.path.exists(os.path.join(path, 'easybuild')) or os.path.exists(os.path.join(path, 'vsc')):
+        # exclude path if it's potentially an EasyBuild package
+        if 'easybuild' in path or os.path.exists(os.path.join(path, 'easybuild')):
+            include_path = False
+        if 'vsc_base' in path or os.path.exists(os.path.join(path, 'vsc', 'utils')):
             include_path = False
         # exclude path if it contain an easy-install.pth file
         if os.path.exists(os.path.join(path, 'easy-install.pth')):

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -457,7 +457,7 @@ def main():
         elif '/vsc_' in path or os.path.exists(os.path.join(path, 'vsc')):
             include_path = False
         # exclude path if it provides 'distribute' package
-        elif 'distutils' in path or os.path.exists(os.path.join(path, 'distutils')):
+        elif 'distribute' in path or os.path.exists(os.path.join(path, 'distribute')):
             include_path = False
         # exclude path if it contain an easy-install.pth file
         elif os.path.exists(os.path.join(path, 'easy-install.pth')):


### PR DESCRIPTION
purposely targeting `master` branch to include #1193

should be fine to include this change in `master` without bumping the version or re-releasing, since the scripts are not part of an actual installation