### PR TITLE
derive EasyBuildError from LoggedException, deprecate log.error in favor of raise EasyBuildError

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -423,7 +423,7 @@ class EasyBlock(object):
                             exts_sources.append(ext_src)
 
                         else:
-                            raise EasyBuildError("Source for extension %s not found.")
+                            raise EasyBuildError("Source for extension %s not found.", ext)
 
             elif isinstance(ext, basestring):
                 exts_sources.append({'name': ext})
@@ -655,8 +655,7 @@ class EasyBlock(object):
             # self.builddir should be already set by gen_builddir()
             if not self.builddir:
                 raise EasyBuildError("self.builddir not set, make sure gen_builddir() is called first!")
-            self.log.debug("Creating the build directory %s (cleanup: %s)",
-                           self.builddir, self.cfg['cleanupoldbuild'])
+            self.log.debug("Creating the build directory %s (cleanup: %s)", self.builddir, self.cfg['cleanupoldbuild'])
         else:
             self.log.info("Changing build dir to %s" % self.installdir)
             self.builddir = self.installdir
@@ -1432,9 +1431,8 @@ class EasyBlock(object):
                     self.log.debug("Installing extension %s with default class %s (from %s)",
                                    ext['name'], default_class, default_class_modpath)
                 except (ImportError, NameError), err:
-                    msg = "Also failed to use default class %s from %s for extension %s: %s, giving up" % \
-                        (default_class, default_class_modpath, ext['name'], err)
-                    raise EasyBuildError(msg)
+                    raise EasyBuildError("Also failed to use default class %s from %s for extension %s: %s, giving up",
+                                         default_class, default_class_modpath, ext['name'], err)
             else:
                 self.log.debug("Installing extension %s with class %s (from %s)" % (ext['name'], class_name, mod_path))
 
@@ -1524,8 +1522,8 @@ class EasyBlock(object):
         lenvals = [len(x) for x in paths.values()]
         req_keys = sorted(path_keys_and_check.keys())
         if not ks == req_keys or sum(valnottypes) > 0 or sum(lenvals) == 0:
-            raise EasyBuildError("Incorrect format for sanity_check_paths (should have %s keys, "
-                           "values should be lists (at least one non-empty))." % '/'.join(req_keys))
+            raise EasyBuildError("Incorrect format for sanity_check_paths (should (only) have %s keys, "
+                                 "values should be lists (at least one non-empty)).", ','.join(req_keys))
 
         for key, check_fn in path_keys_and_check.items():
             for xs in paths[key]:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -144,7 +144,7 @@ class EasyBlock(object):
         if isinstance(ec, EasyConfig):
             self.cfg = ec
         else:
-            _log.error("Value of incorrect type passed to EasyBlock constructor: %s ('%s')" % (type(ec), ec))
+            raise EasyBuildError("Value of incorrect type passed to EasyBlock constructor: %s ('%s')", type(ec), ec)
 
         # determine install subdirectory, based on module name
         self.install_subdir = None
@@ -217,8 +217,8 @@ class EasyBlock(object):
         self.log.info(this_is_easybuild())
 
         this_module = inspect.getmodule(self)
-        tup = (self.__class__.__name__, this_module.__name__, this_module.__file__)
-        self.log.info("This is easyblock %s from module %s (%s)" % tup)
+        self.log.info("This is easyblock %s from module %s (%s)",
+                      self.__class__.__name__, this_module.__name__, this_module.__file__)
 
     def close_log(self):
         """
@@ -247,7 +247,7 @@ class EasyBlock(object):
         elif checksums is None:
             return None
         else:
-            self.log.error("Invalid type for checksums (%s), should be list, tuple or None." % type(checksums))
+            raise EasyBuildError("Invalid type for checksums (%s), should be list, tuple or None.", type(checksums))
 
     def fetch_sources(self, list_of_sources, checksums=None):
         """
@@ -276,7 +276,7 @@ class EasyBlock(object):
                     'finalpath': self.builddir,
                 })
             else:
-                self.log.error('No file found for source %s' % source)
+                raise EasyBuildError('No file found for source %s', source)
 
         self.log.info("Added sources: %s" % self.src)
 
@@ -297,8 +297,8 @@ class EasyBlock(object):
             level = None
             if isinstance(patch_spec, (list, tuple)):
                 if not len(patch_spec) == 2:
-                    self.log.error("Unknown patch specification '%s', only two-element lists/tuples are supported!",
-                                   str(patch_spec))
+                    raise EasyBuildError("Unknown patch specification '%s', only 2-element lists/tuples are supported!",
+                                         str(patch_spec))
                 patch_file = patch_spec[0]
 
                 # this *must* be of typ int, nothing else
@@ -311,7 +311,8 @@ class EasyBlock(object):
                         copy_file = True
                     suff = patch_spec[1]
                 else:
-                    self.log.error("Wrong patch spec '%s', only int/string are supported as 2nd element" % str(patch_spec))
+                    raise EasyBuildError("Wrong patch spec '%s', only int/string are supported as 2nd element",
+                                         str(patch_spec))
             else:
                 patch_file = patch_spec
 
@@ -336,7 +337,7 @@ class EasyBlock(object):
                 else:
                     self.patches.append(patchspec)
             else:
-                self.log.error('No file found for patch %s' % patch_spec)
+                raise EasyBuildError('No file found for patch %s', patch_spec)
 
         if extension:
             self.log.info("Fetched extension patches: %s" % patches)
@@ -370,9 +371,9 @@ class EasyBlock(object):
                         ext_options = ext[2]
 
                         if not isinstance(ext_options, dict):
-                            self.log.error("Unexpected type (non-dict) for 3rd element of %s" % ext)
+                            raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
                     elif len(ext) > 3:
-                        self.log.error('Extension specified in unknown format (list/tuple too long)')
+                        raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')
 
                     ext_src = {
                         'name': ext_name,
@@ -401,7 +402,7 @@ class EasyBlock(object):
                                 if verify_checksum(src_fn, fn_checksum):
                                     self.log.info('Checksum for ext source %s verified' % fn)
                                 else:
-                                    self.log.error('Checksum for ext source %s failed' % fn)
+                                    raise EasyBuildError('Checksum for ext source %s failed', fn)
 
                             ext_patches = self.fetch_patches(patch_specs=ext_options.get('patches', []), extension=True)
                             if ext_patches:
@@ -415,20 +416,20 @@ class EasyBlock(object):
                                         if verify_checksum(ext_patch, checksum):
                                             self.log.info('Checksum for extension patch %s verified' % ext_patch)
                                         else:
-                                            self.log.error('Checksum for extension patch %s failed' % ext_patch)
+                                            raise EasyBuildError('Checksum for extension patch %s failed', ext_patch)
                             else:
                                 self.log.debug('No patches found for extension %s.' % ext_name)
 
                             exts_sources.append(ext_src)
 
                         else:
-                            self.log.error("Source for extension %s not found.")
+                            raise EasyBuildError("Source for extension %s not found.")
 
             elif isinstance(ext, basestring):
                 exts_sources.append({'name': ext})
 
             else:
-                self.log.error("Extension specified in unknown format (not a string/list/tuple)")
+                raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
 
         return exts_sources
 
@@ -468,7 +469,7 @@ class EasyBlock(object):
                         return fullpath
 
             except IOError, err:
-                self.log.exception("Downloading file %s from url %s to %s failed: %s" % (filename, url, fullpath, err))
+                raise EasyBuildError("Downloading file %s from url %s to %s failed: %s", filename, url, fullpath, err)
 
         else:
             # try and find file in various locations
@@ -573,7 +574,8 @@ class EasyBlock(object):
                     else:
                         failedpaths.append(fullurl)
 
-                self.log.error("Couldn't find file %s anywhere, and downloading it didn't work either...\nPaths attempted (in order): %s " % (filename, ', '.join(failedpaths)))
+                raise EasyBuildError("Couldn't find file %s anywhere, and downloading it didn't work either... "
+                                     "Paths attempted (in order): %s ", filename, ', '.join(failedpaths))
 
     #
     # GETTER/SETTER UTILITY FUNCTIONS
@@ -652,8 +654,9 @@ class EasyBlock(object):
         if not self.build_in_installdir:
             # self.builddir should be already set by gen_builddir()
             if not self.builddir:
-                self.log.error("self.builddir not set, make sure gen_builddir() is called first!")
-            self.log.debug("Creating the build directory %s (cleanup: %s)" % (self.builddir, self.cfg['cleanupoldbuild']))
+                raise EasyBuildError("self.builddir not set, make sure gen_builddir() is called first!")
+            self.log.debug("Creating the build directory %s (cleanup: %s)",
+                           self.builddir, self.cfg['cleanupoldbuild'])
         else:
             self.log.info("Changing build dir to %s" % self.installdir)
             self.builddir = self.installdir
@@ -680,7 +683,7 @@ class EasyBlock(object):
             self.installdir = os.path.abspath(installdir)
             self.log.info("Install dir set to %s" % self.installdir)
         else:
-            self.log.error("Can't set installation directory")
+            raise EasyBuildError("Can't set installation directory")
 
     def make_installdir(self, dontcreate=None):
         """
@@ -707,7 +710,7 @@ class EasyBlock(object):
                     rmtree2(dir_name)
                     self.log.info("Removed old directory %s" % dir_name)
                 except OSError, err:
-                    self.log.exception("Removal of old directory %s failed: %s" % (dir_name, err))
+                    raise EasyBuildError("Removal of old directory %s failed: %s", dir_name, err)
             else:
                 try:
                     timestamp = time.strftime("%Y%m%d-%H%M%S")
@@ -715,7 +718,7 @@ class EasyBlock(object):
                     shutil.move(dir_name, backupdir)
                     self.log.info("Moved old directory %s to %s" % (dir_name, backupdir))
                 except OSError, err:
-                    self.log.exception("Moving old directory to backup %s %s failed: %s" % (dir_name, backupdir, err))
+                    raise EasyBuildError("Moving old directory to backup %s %s failed: %s", dir_name, backupdir, err)
 
         if dontcreateinstalldir:
             olddir = dir_name
@@ -858,7 +861,8 @@ class EasyBlock(object):
             if isinstance(value, basestring):
                 value = [value]
             elif not isinstance(value, (tuple, list)):
-                self.log.error("modextrapaths dict value %s (type: %s) is not a list or tuple" % (value, type(value)))
+                raise EasyBuildError("modextrapaths dict value %s (type: %s) is not a list or tuple",
+                                     value, type(value))
             txt += self.module_generator.prepend_paths(key, value)
         if self.cfg['modloadmsg']:
             txt += self.module_generator.msg_on_load(self.cfg['modloadmsg'])
@@ -932,7 +936,7 @@ class EasyBlock(object):
             try:
                 os.chdir(self.installdir)
             except OSError, err:
-                self.log.error("Failed to change to %s: %s" % (self.installdir, err))
+                raise EasyBuildError("Failed to change to %s: %s", self.installdir, err)
 
             txt = "\n"
             for key in sorted(requirements):
@@ -943,7 +947,7 @@ class EasyBlock(object):
             try:
                 os.chdir(self.orig_workdir)
             except OSError, err:
-                self.log.error("Failed to change back to %s: %s" % (self.orig_workdir, err))
+                raise EasyBuildError("Failed to change back to %s: %s", self.orig_workdir, err)
         else:
             txt = ""
         return txt
@@ -1009,7 +1013,7 @@ class EasyBlock(object):
                 modtool.remove_module_path(fake_mod_path)
                 rmtree2(os.path.dirname(fake_mod_path))
             except OSError, err:
-                self.log.error("Failed to clean up fake module dir %s: %s" % (fake_mod_path, err))
+                raise EasyBuildError("Failed to clean up fake module dir %s: %s", fake_mod_path, err)
         elif self.full_mod_name is None:
             self.log.warning("Not unloading module, since self.full_mod_name is not set.")
 
@@ -1042,9 +1046,9 @@ class EasyBlock(object):
         self.cfg.enable_templating = True
 
         if not exts_filter or len(exts_filter) == 0:
-            self.log.error("Skipping of extensions, but no exts_filter set in easyconfig")
+            raise EasyBuildError("Skipping of extensions, but no exts_filter set in easyconfig")
         elif isinstance(exts_filter, basestring) or len(exts_filter) != 2:
-            self.log.error('exts_filter should be a list or tuple of ("command","input")')
+            raise EasyBuildError('exts_filter should be a list or tuple of ("command","input")')
         cmdtmpl = exts_filter[0]
         cmdinputtmpl = exts_filter[1]
         if not self.exts:
@@ -1110,7 +1114,7 @@ class EasyBlock(object):
             os.chdir(self.cfg['start_dir'])
             self.log.debug("Changed to real build directory %s" % (self.cfg['start_dir']))
         except OSError, err:
-            self.log.exception("Can't change to real build directory %s: %s" % (self.cfg['start_dir'], err))
+            raise EasyBuildError("Can't change to real build directory %s: %s", self.cfg['start_dir'], err)
 
     def handle_iterate_opts(self):
         """Handle options relevant during iterated part of build/install procedure."""
@@ -1164,12 +1168,12 @@ class EasyBlock(object):
         if not len(self.cfg.dependencies()) == len(self.toolchain.dependencies):
             self.log.debug("dep %s (%s)" % (len(self.cfg.dependencies()), self.cfg.dependencies()))
             self.log.debug("tc.dep %s (%s)" % (len(self.toolchain.dependencies), self.toolchain.dependencies))
-            self.log.error('Not all dependencies have a matching toolchain version')
+            raise EasyBuildError('Not all dependencies have a matching toolchain version')
 
         # check if the application is not loaded at the moment
         (root, env_var) = get_software_root(self.name, with_env_var=True)
         if root:
-            self.log.error("Module is already loaded (%s is set), installation cannot continue." % env_var)
+            raise EasyBuildError("Module is already loaded (%s is set), installation cannot continue.", env_var)
 
         # check if main install needs to be skipped
         # - if a current module can be found, skip is ok
@@ -1189,12 +1193,15 @@ class EasyBlock(object):
         # check EasyBuild version
         easybuild_version = self.cfg['easybuild_version']
         if not easybuild_version:
-            self.log.warn("Easyconfig does not specify an EasyBuild-version (key 'easybuild_version')! Assuming the latest version")
+            self.log.warn("Easyconfig does not specify an EasyBuild-version (key 'easybuild_version')! "
+                          "Assuming the latest version")
         else:
             if LooseVersion(easybuild_version) < VERSION:
-                self.log.warn("EasyBuild-version %s is older than the currently running one. Proceed with caution!" % easybuild_version)
+                self.log.warn("EasyBuild-version %s is older than the currently running one. Proceed with caution!",
+                              easybuild_version)
             elif LooseVersion(easybuild_version) > VERSION:
-                self.log.error("EasyBuild-version %s is newer than the currently running one. Aborting!" % easybuild_version)
+                raise EasyBuildError("EasyBuild-version %s is newer than the currently running one. Aborting!",
+                                     easybuild_version)
 
         # fetch sources
         if self.cfg['sources']:
@@ -1249,7 +1256,7 @@ class EasyBlock(object):
         for fil in self.src + self.patches:
             ok = verify_checksum(fil['path'], fil['checksum'])
             if not ok:
-                self.log.error("Checksum verification for %s using %s failed." % (fil['path'], fil['checksum']))
+                raise EasyBuildError("Checksum verification for %s using %s failed.", fil['path'], fil['checksum'])
             else:
                 self.log.info("Checksum verification for %s using %s passed." % (fil['path'], fil['checksum']))
 
@@ -1263,7 +1270,7 @@ class EasyBlock(object):
             if srcdir:
                 self.src[self.src.index(src)]['finalpath'] = srcdir
             else:
-                self.log.error("Unpacking source %s failed" % src['name'])
+                raise EasyBuildError("Unpacking source %s failed", src['name'])
 
     def patch_step(self, beginpath=None):
         """
@@ -1281,16 +1288,16 @@ class EasyBlock(object):
             # determine whether 'patch' file should be copied rather than applied
             copy_patch = 'copy' in patch and not 'sourcepath' in patch
 
-            tup = (srcind, level, srcpathsuffix, copy)
-            self.log.debug("Source index: %s; patch level: %s; source path suffix: %s; copy patch: %s" % tup)
+            self.log.debug("Source index: %s; patch level: %s; source path suffix: %s; copy patch: %s",
+                           srcind, level, srcpathsuffix, copy)
 
             if beginpath is None:
                 try:
                     beginpath = self.src[srcind]['finalpath']
                     self.log.debug("Determine begin path for patch %s: %s" % (patch['name'], beginpath))
                 except IndexError, err:
-                    tup = (patch['name'], srcind, self.src, err)
-                    self.log.error("Can't apply patch %s to source at index %s of list %s: %s" % tup)
+                    raise EasyBuildError("Can't apply patch %s to source at index %s of list %s: %s",
+                                         patch['name'], srcind, self.src, err)
             else:
                 self.log.debug("Using specified begin path for patch %s: %s" % (patch['name'], beginpath))
 
@@ -1298,7 +1305,7 @@ class EasyBlock(object):
             self.log.debug("Applying patch %s in path %s" % (patch, src))
 
             if not apply_patch(patch['path'], src, copy=copy_patch, level=level):
-                self.log.error("Applying patch %s failed" % patch['name'])
+                raise EasyBuildError("Applying patch %s failed", patch['name'])
 
     def prepare_step(self):
         """
@@ -1368,7 +1375,7 @@ class EasyBlock(object):
         # we really need a default class
         if not exts_defaultclass:
             self.clean_up_fake_module(fake_mod_data)
-            self.log.error("ERROR: No default extension class set for %s" % self.name)
+            raise EasyBuildError("ERROR: No default extension class set for %s", self.name)
 
         # obtain name and module path for default extention class
         if hasattr(exts_defaultclass, '__iter__'):
@@ -1380,7 +1387,7 @@ class EasyBlock(object):
             default_class_modpath = get_module_path(default_class, generic=True)
 
         else:
-            self.log.error("Improper default extension class specification, should be list/tuple or string.")
+            raise EasyBuildError("Improper default extension class specification, should be list/tuple or string.")
 
         # get class instances for all extensions
         for ext in self.exts:
@@ -1413,7 +1420,8 @@ class EasyBlock(object):
                     cls = get_class_for(mod_path, class_name)
                     inst = cls(self, ext)
                 except (ImportError, NameError), err:
-                    self.log.error("Failed to load specified class %s for extension %s: %s" % (class_name, ext['name'], err))
+                    raise EasyBuildError("Failed to load specified class %s for extension %s: %s",
+                                         class_name, ext['name'], err)
 
             # fallback attempt: use default class
             if inst is None:
@@ -1421,12 +1429,12 @@ class EasyBlock(object):
                     cls = get_class_for(default_class_modpath, default_class)
                     self.log.debug("Obtained class %s for installing extension %s" % (cls, ext['name']))
                     inst = cls(self, ext)
-                    tup = (ext['name'], default_class, default_class_modpath)
-                    self.log.debug("Installing extension %s with default class %s (from %s)" % tup)
+                    self.log.debug("Installing extension %s with default class %s (from %s)",
+                                   ext['name'], default_class, default_class_modpath)
                 except (ImportError, NameError), err:
                     msg = "Also failed to use default class %s from %s for extension %s: %s, giving up" % \
                         (default_class, default_class_modpath, ext['name'], err)
-                    self.log.error(msg)
+                    raise EasyBuildError(msg)
             else:
                 self.log.debug("Installing extension %s with class %s (from %s)" % (ext['name'], class_name, mod_path))
 
@@ -1457,10 +1465,10 @@ class EasyBlock(object):
         if self.cfg['postinstallcmds'] is not None:
             # make sure we have a list of commands
             if not isinstance(self.cfg['postinstallcmds'], (list, tuple)):
-                self.log.error("Invalid value for 'postinstallcmds', should be list or tuple of strings.")
+                raise EasyBuildError("Invalid value for 'postinstallcmds', should be list or tuple of strings.")
             for cmd in self.cfg['postinstallcmds']:
                 if not isinstance(cmd, basestring):
-                    self.log.error("Invalid element in 'postinstallcmds', not a string: %s" % cmd)
+                    raise EasyBuildError("Invalid element in 'postinstallcmds', not a string: %s", cmd)
                 run_cmd(cmd, simple=True, log_ok=True, log_all=True)
 
         if self.group is not None:
@@ -1470,7 +1478,7 @@ class EasyBlock(object):
                 adjust_permissions(self.installdir, perms, add=False, recursive=True, group_id=self.group[1],
                                    relative=True, ignore_errors=True)
             except EasyBuildError, err:
-                self.log.error("Unable to change group permissions of file(s): %s" % err)
+                raise EasyBuildError("Unable to change group permissions of file(s): %s", err)
             self.log.info("Successfully made software only available for group %s (gid %s)" % self.group)
 
         if read_only_installdir():
@@ -1516,7 +1524,7 @@ class EasyBlock(object):
         lenvals = [len(x) for x in paths.values()]
         req_keys = sorted(path_keys_and_check.keys())
         if not ks == req_keys or sum(valnottypes) > 0 or sum(lenvals) == 0:
-            self.log.error("Incorrect format for sanity_check_paths (should have %s keys, "
+            raise EasyBuildError("Incorrect format for sanity_check_paths (should have %s keys, "
                            "values should be lists (at least one non-empty))." % '/'.join(req_keys))
 
         for key, check_fn in path_keys_and_check.items():
@@ -1524,7 +1532,8 @@ class EasyBlock(object):
                 if isinstance(xs, basestring):
                     xs = (xs,)
                 elif not isinstance(xs, tuple):
-                    self.log.error("Unsupported type '%s' encountered in %s, not a string or tuple" % (key, type(xs)))
+                    raise EasyBuildError("Unsupported type '%s' encountered in %s, not a string or tuple",
+                                         key, type(xs))
                 found = False
                 for name in xs:
                     path = os.path.join(self.installdir, name)
@@ -1599,7 +1608,7 @@ class EasyBlock(object):
 
         # pass or fail
         if self.sanity_check_fail_msgs:
-            self.log.error("Sanity check failed: %s" % ', '.join(self.sanity_check_fail_msgs))
+            raise EasyBuildError("Sanity check failed: %s", ', '.join(self.sanity_check_fail_msgs))
         else:
             self.log.debug("Sanity check passed!")
 
@@ -1626,7 +1635,7 @@ class EasyBlock(object):
                     base = os.path.dirname(base)
 
             except OSError, err:
-                self.log.exception("Cleaning up builddir %s failed: %s" % (self.builddir, err))
+                raise EasyBuildError("Cleaning up builddir %s failed: %s", self.builddir, err)
 
         if not build_option('cleanup_builddir'):
             self.log.info("Keeping builddir %s" % self.builddir)
@@ -1677,13 +1686,13 @@ class EasyBlock(object):
                     if os.path.exists(path):
                         break
                 if not os.path.exists(path):
-                    self.log.error("Test specifies invalid path: %s" % path)
+                    raise EasyBuildError("Test specifies invalid path: %s", path)
 
             try:
                 self.log.debug("Running test %s" % path)
                 run_cmd(path, log_all=True, simple=True)
             except EasyBuildError, err:
-                self.log.exception("Running test %s failed: %s" % (path, err))
+                raise EasyBuildError("Running test %s failed: %s", path, err)
 
     def update_config_template_run_step(self):
         """Update the the easyconfig template dictionary with easyconfig.TEMPLATE_NAMES_EASYBLOCK_RUN_STEP names"""
@@ -1859,8 +1868,8 @@ def build_and_install_one(ecdict, orig_environ):
         app = app_class(ecdict['ec'])
         _log.info("Obtained application instance of for %s (easyblock: %s)" % (name, easyblock))
     except EasyBuildError, err:
-        tup = (name, easyblock, err.msg)
-        print_error("Failed to get application instance for %s (easyblock: %s): %s" % tup, silent=silent)
+        print_error("Failed to get application instance for %s (easyblock: %s): %s" % (name, easyblock, err.msg),
+                    silent=silent)
 
     # application settings
     stop = build_option('stop')

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -35,6 +35,8 @@ Easyconfig module that contains the default EasyConfig configuration parameters.
 """
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
+
 
 _log = fancylogger.getLogger('easyconfig.default', fname=False)
 
@@ -180,7 +182,7 @@ def sorted_categories():
 def get_easyconfig_parameter_default(param):
     """Get default value for given easyconfig parameter."""
     if param not in DEFAULT_CONFIG:
-        _log.error("Unkown easyconfig parameter: %s (known: %s)" % (param, sorted(DEFAULT_CONFIG.keys())))
+        raise EasyBuildError("Unkown easyconfig parameter: %s (known: %s)", param, sorted(DEFAULT_CONFIG.keys()))
     else:
         _log.debug("Returning default value for easyconfig parameter %s: %s" % (param, DEFAULT_CONFIG[param][0]))
         return DEFAULT_CONFIG[param][0]

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -250,8 +250,8 @@ class EasyConfig(object):
 
         typos = [(key, guesses[0]) for (key, guesses) in possible_typos if len(guesses) == 1]
         if typos:
-            raise EasyBuildError("You may have some typos in your easyconfig file: %s" %
-                            ', '.join(["%s -> %s" % typo for typo in typos]))
+            raise EasyBuildError("You may have some typos in your easyconfig file: %s",
+                                 ', '.join(["%s -> %s" % typo for typo in typos]))
 
         # we need toolchain to be set when we call _parse_dependency
         for key in ['toolchain'] + local_vars.keys():
@@ -304,8 +304,8 @@ class EasyConfig(object):
 
         self.log.info("Checking skipsteps")
         if not isinstance(self._config['skipsteps'][0], (list, tuple,)):
-            raise EasyBuildError('Invalid type for skipsteps. Allowed are list or tuple, got %s (%s)' %
-                           (type(self._config['skipsteps'][0]), self._config['skipsteps'][0]))
+            raise EasyBuildError('Invalid type for skipsteps. Allowed are list or tuple, got %s (%s)',
+                                 type(self._config['skipsteps'][0]), self._config['skipsteps'][0])
 
         self.log.info("Checking build option lists")
         self.validate_iterate_opts_lists()
@@ -321,8 +321,8 @@ class EasyConfig(object):
             if 'software_license' in self.mandatory:
                 raise EasyBuildError("License is mandatory, but 'software_license' is undefined")
         elif not isinstance(lic, License):
-            raise EasyBuildError('License %s has to be a License subclass instance, found classname %s.' %
-                           (lic, lic.__class__.__name__))
+            raise EasyBuildError('License %s has to be a License subclass instance, found classname %s.',
+                                 lic, lic.__class__.__name__)
         elif not lic.name in EASYCONFIG_LICENSES_DICT:
             raise EasyBuildError('Invalid license %s (classname: %s).', lic.name, lic.__class__.__name__)
 
@@ -586,11 +586,9 @@ class EasyConfig(object):
                 if 'name' in tc_spec and 'version' in tc_spec:
                     tc = copy.deepcopy(tc_spec)
                 else:
-                    raise EasyBuildError("Found toolchain spec as dict with required 'name'/'version' keys: %s",
-                                         tc_spec)
+                    raise EasyBuildError("Found toolchain spec as dict with wrong keys (no name/version): %s", tc_spec)
             else:
-                raise EasyBuildError("Unsupported type for toolchain spec encountered: %s => %s",
-                                     tc_spec, type(tc_spec))
+                raise EasyBuildError("Unsupported type for toolchain spec encountered: %s (%s)", tc_spec, type(tc_spec))
 
         dependency['toolchain'] = tc
 
@@ -896,8 +894,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
         try:
             ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
         except EasyBuildError, err:
-            msg = "Failed to process easyconfig %s:\n%s" % (spec, err.msg)
-            raise EasyBuildError(msg)
+            raise EasyBuildError("Failed to process easyconfig %s: %s", spec, err.msg)
 
         name = ec['name']
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -114,7 +114,7 @@ class EasyConfig(object):
         self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
 
         if path is not None and not os.path.isfile(path):
-            self.log.error("EasyConfig __init__ expected a valid path")
+            raise EasyBuildError("EasyConfig __init__ expected a valid path")
 
         # read easyconfig file contents (or use provided rawtxt), so it can be passed down to avoid multiple re-reads
         self.path = None
@@ -215,7 +215,7 @@ class EasyConfig(object):
         elif isinstance(prev_value, list):
             self[key] = prev_value + value
         else:
-            self.log.error("Can't update configuration value for %s, because it's not a string or list." % key)
+            raise EasyBuildError("Can't update configuration value for %s, because it's not a string or list.", key)
 
     def parse(self):
         """
@@ -228,7 +228,8 @@ class EasyConfig(object):
             # build a new dictionary with only the expected keys, to pass as named arguments to get_config_dict()
             arg_specs = self.build_specs
         else:
-            self.log.error("Specifications should be specified using a dictionary, got %s" % type(self.build_specs))
+            raise EasyBuildError("Specifications should be specified using a dictionary, got %s",
+                                 type(self.build_specs))
         self.log.debug("Obtained specs dict %s" % arg_specs)
 
         self.log.info("Parsing easyconfig file %s with rawcontent: %s" % (self.path, self.rawtxt))
@@ -241,7 +242,7 @@ class EasyConfig(object):
         # this includes both generic mandatory parameters and software-specific parameters defined via extra_options
         missing_mandatory_keys = [key for key in self.mandatory if key not in local_vars]
         if missing_mandatory_keys:
-            self.log.error("mandatory parameters not provided in %s: %s" % (self.path, missing_mandatory_keys))
+            raise EasyBuildError("mandatory parameters not provided in %s: %s", self.path, missing_mandatory_keys)
 
         # provide suggestions for typos
         possible_typos = [(key, difflib.get_close_matches(key.lower(), self._config.keys(), 1, 0.85))
@@ -249,7 +250,7 @@ class EasyConfig(object):
 
         typos = [(key, guesses[0]) for (key, guesses) in possible_typos if len(guesses) == 1]
         if typos:
-            self.log.error("You may have some typos in your easyconfig file: %s" %
+            raise EasyBuildError("You may have some typos in your easyconfig file: %s" %
                             ', '.join(["%s -> %s" % typo for typo in typos]))
 
         # we need toolchain to be set when we call _parse_dependency
@@ -263,8 +264,7 @@ class EasyConfig(object):
                     self[key] = [self._parse_dependency(dep, hidden=True) for dep in local_vars[key]]
                 else:
                     self[key] = local_vars[key]
-                tup = (key, self[key], type(self[key]))
-                self.log.info("setting config option %s: value %s (type: %s)" % tup)
+                self.log.info("setting config option %s: value %s (type: %s)", key, self[key], type(self[key]))
             elif key in REPLACED_PARAMETERS:
                 _log.nosupport("Easyconfig parameter '%s' is replaced by '%s'" % (key, REPLACED_PARAMETERS[key]), '2.0')
 
@@ -280,8 +280,10 @@ class EasyConfig(object):
     def handle_allowed_system_deps(self):
         """Handle allowed system dependencies."""
         for (name, version) in self['allow_system_deps']:
-            env.setvar(get_software_root_env_var_name(name), name)  # root is set to name, not an actual path
-            env.setvar(get_software_version_env_var_name(name), version)  # version is expected to be something that makes sense
+            # root is set to name, not an actual path
+            env.setvar(get_software_root_env_var_name(name), name)
+            # version is expected to be something that makes sense
+            env.setvar(get_software_version_env_var_name(name), version)
 
     def validate(self, check_osdeps=True):
         """
@@ -302,7 +304,7 @@ class EasyConfig(object):
 
         self.log.info("Checking skipsteps")
         if not isinstance(self._config['skipsteps'][0], (list, tuple,)):
-            self.log.error('Invalid type for skipsteps. Allowed are list or tuple, got %s (%s)' %
+            raise EasyBuildError('Invalid type for skipsteps. Allowed are list or tuple, got %s (%s)' %
                            (type(self._config['skipsteps'][0]), self._config['skipsteps'][0]))
 
         self.log.info("Checking build option lists")
@@ -317,12 +319,12 @@ class EasyConfig(object):
         if lic is None:
             # when mandatory, remove this possibility
             if 'software_license' in self.mandatory:
-                self.log.error("License is mandatory, but 'software_license' is undefined")
+                raise EasyBuildError("License is mandatory, but 'software_license' is undefined")
         elif not isinstance(lic, License):
-            self.log.error('License %s has to be a License subclass instance, found classname %s.' %
+            raise EasyBuildError('License %s has to be a License subclass instance, found classname %s.' %
                            (lic, lic.__class__.__name__))
         elif not lic.name in EASYCONFIG_LICENSES_DICT:
-            self.log.error('Invalid license %s (classname: %s).' % (lic.name, lic.__class__.__name__))
+            raise EasyBuildError('Invalid license %s (classname: %s).', lic.name, lic.__class__.__name__)
 
         # TODO, when GROUP_SOURCE and/or GROUP_BINARY is True
         #  check the owner of source / binary (must match 'group' parameter from easyconfig)
@@ -340,13 +342,14 @@ class EasyConfig(object):
             if isinstance(dep, basestring):
                 dep = (dep,)
             elif not isinstance(dep, tuple):
-                self.log.error("Non-tuple value type for OS dependency specification: %s (type %s)" % (dep, type(dep)))
+                raise EasyBuildError("Non-tuple value type for OS dependency specification: %s (type %s)",
+                                     dep, type(dep))
 
             if not any([check_os_dependency(cand_dep) for cand_dep in dep]):
                 not_found.append(dep)
 
         if not_found:
-            self.log.error("One or more OS dependencies were not found: %s" % not_found)
+            raise EasyBuildError("One or more OS dependencies were not found: %s", not_found)
         else:
             self.log.info("OS dependencies ok: %s" % self['osdependencies'])
 
@@ -365,7 +368,7 @@ class EasyConfig(object):
 
             # anticipate changes in available easyconfig parameters (e.g. makeopts -> buildopts?)
             if self.get(opt, None) is None:
-                self.log.error("%s not available in self.cfg (anymore)?!" % opt)
+                raise EasyBuildError("%s not available in self.cfg (anymore)?!", opt)
 
             # keep track of list, supply first element as first option to handle
             if isinstance(self[opt], (list, tuple)):
@@ -374,7 +377,7 @@ class EasyConfig(object):
         # make sure that options that specify lists have the same length
         list_opt_lengths = [length for (opt, length) in opt_counts if length > 1]
         if len(nub(list_opt_lengths)) > 1:
-            self.log.error("Build option lists for iterated build should have same length: %s" % opt_counts)
+            raise EasyBuildError("Build option lists for iterated build should have same length: %s", opt_counts)
 
         return True
 
@@ -399,8 +402,8 @@ class EasyConfig(object):
                 faulty_deps.append(visible_mod_name)
 
         if faulty_deps:
-            tup = (faulty_deps, dep_mod_names)
-            self.log.error("Hidden dependencies with visible module names %s not in list of dependencies: %s" % tup)
+            raise EasyBuildError("Hidden dependencies with visible module names %s not in list of dependencies: %s",
+                                 faulty_deps, dep_mod_names)
 
     def dependencies(self):
         """
@@ -515,7 +518,7 @@ class EasyConfig(object):
         if values is None:
             values = []
         if self[attr] and self[attr] not in values:
-            self.log.error("%s provided '%s' is not valid: %s" % (attr, self[attr], values))
+            raise EasyBuildError("%s provided '%s' is not valid: %s", attr, self[attr], values)
 
     # private method
     def _parse_dependency(self, dep, hidden=False):
@@ -564,7 +567,7 @@ class EasyConfig(object):
             dep = list(dep)
             dependency.update(dict(zip(attr, dep)))
         else:
-            self.log.error('Dependency %s of unsupported type: %s.' % (dep, type(dep)))
+            raise EasyBuildError('Dependency %s of unsupported type: %s.', dep, type(dep))
 
         # dependency inherits toolchain, unless it's specified to have a custom toolchain
         tc = copy.deepcopy(self['toolchain'])
@@ -578,14 +581,16 @@ class EasyConfig(object):
                 if len(tc_spec) == 2:
                     tc = {'name': tc_spec[0], 'version': tc_spec[1]}
                 else:
-                    self.log.error("List/tuple value for toolchain should have two elements (%s)" % str(tc_spec))
+                    raise EasyBuildError("List/tuple value for toolchain should have two elements (%s)", str(tc_spec))
             elif isinstance(tc_spec, dict):
                 if 'name' in tc_spec and 'version' in tc_spec:
                     tc = copy.deepcopy(tc_spec)
                 else:
-                    self.log.error("Found toolchain spec as dict with required 'name'/'version' keys: %s" % tc_spec)
+                    raise EasyBuildError("Found toolchain spec as dict with required 'name'/'version' keys: %s",
+                                         tc_spec)
             else:
-                self.log.error("Unsupported type for toolchain spec encountered: %s => %s" % (tc_spec, type(tc_spec)))
+                raise EasyBuildError("Unsupported type for toolchain spec encountered: %s => %s",
+                                     tc_spec, type(tc_spec))
 
         dependency['toolchain'] = tc
 
@@ -594,10 +599,10 @@ class EasyConfig(object):
 
         # validations
         if not dependency['name']:
-            self.log.error("Dependency specified without name: %s" % dependency)
+            raise EasyBuildError("Dependency specified without name: %s", dependency)
 
         if not dependency['version']:
-            self.log.error("Dependency specified without version: %s" % dependency)
+            raise EasyBuildError("Dependency specified without version: %s", dependency)
 
         dependency['short_mod_name'] = ActiveMNS().det_short_module_name(dependency)
         dependency['full_mod_name'] = ActiveMNS().det_full_module_name(dependency)
@@ -643,7 +648,7 @@ class EasyConfig(object):
         if key in self._config:
             value = self._config[key][0]
         else:
-            self.log.error("Use of unknown easyconfig parameter '%s' when getting parameter value" % key)
+            raise EasyBuildError("Use of unknown easyconfig parameter '%s' when getting parameter value", key)
 
         if self.enable_templating:
             if self.template_values is None or len(self.template_values) == 0:
@@ -658,8 +663,8 @@ class EasyConfig(object):
         if key in self._config:
             self._config[key][0] = value
         else:
-            tup = (key, value)
-            self.log.error("Use of unknown easyconfig parameter '%s' when setting parameter value to '%s'" % tup)
+            raise EasyBuildError("Use of unknown easyconfig parameter '%s' when setting parameter value to '%s'",
+                                 key, value)
 
     @handle_deprecated_or_replaced_easyconfig_parameters
     def get(self, key, default=None):
@@ -705,8 +710,8 @@ def get_easyblock_class(easyblock, name=None, default_fallback=True, error_on_fa
             # figure out if full path was specified or not
             if es:
                 modulepath = '.'.join(es)
-                tup = (class_name, modulepath)
-                _log.info("Assuming that full easyblock module path was specified (class: %s, modulepath: %s)" % tup)
+                _log.info("Assuming that full easyblock module path was specified (class: %s, modulepath: %s)",
+                          class_name, modulepath)
                 cls = get_class_for(modulepath, class_name)
             else:
                 # if we only get the class name, most likely we're dealing with a generic easyblock
@@ -763,16 +768,17 @@ def get_easyblock_class(easyblock, name=None, default_fallback=True, error_on_fa
                         _log.nosupport(depr_msg, '2.0')
                 else:
                     if error_on_failed_import:
-                        _log.error("Failed to import easyblock for %s because of module issue: %s" % (class_name, err))
+                        raise EasyBuildError("Failed to import easyblock for %s because of module issue: %s",
+                                             class_name, err)
                     else:
                         _log.debug("Failed to import easyblock for %s, but ignoring it: %s" % (class_name, err))
 
         if cls is not None:
-            tup = (cls.__name__, easyblock, name)
-            _log.info("Successfully obtained class '%s' for easyblock '%s' (software name '%s')" % tup)
+            _log.info("Successfully obtained class '%s' for easyblock '%s' (software name '%s')",
+                      cls.__name__, easyblock, name)
         else:
-            tup = (easyblock, name, default_fallback)
-            _log.debug("No class found for easyblock '%s' (software name '%s', default fallback: %s" % tup)
+            _log.debug("No class found for easyblock '%s' (software name '%s', default fallback: %s",
+                       easyblock, name, default_fallback)
 
         return cls
 
@@ -780,7 +786,7 @@ def get_easyblock_class(easyblock, name=None, default_fallback=True, error_on_fa
         # simply reraise rather than wrapping it into another error
         raise err
     except Exception, err:
-        _log.error("Failed to obtain class for %s easyblock (not available?): %s" % (easyblock, err))
+        raise EasyBuildError("Failed to obtain class for %s easyblock (not available?): %s", easyblock, err)
 
 
 def get_module_path(name, generic=False, decode=True):
@@ -891,7 +897,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
             ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
         except EasyBuildError, err:
             msg = "Failed to process easyconfig %s:\n%s" % (spec, err.msg)
-            _log.exception(msg)
+            raise EasyBuildError(msg)
 
         name = ec['name']
 
@@ -970,7 +976,7 @@ def robot_find_easyconfig(name, version):
         return _easyconfig_files_cache[key]
     paths = build_option('robot_path')
     if not paths:
-        _log.error("No robot path specified, which is required when looking for easyconfigs (use --robot)")
+        raise EasyBuildError("No robot path specified, which is required when looking for easyconfigs (use --robot)")
     if not isinstance(paths, (list, tuple)):
         paths = [paths]
     # candidate easyconfig paths
@@ -1002,7 +1008,8 @@ class ActiveMNS(object):
         if sel_mns in avail_mnss:
             self.mns = avail_mnss[sel_mns]()
         else:
-            self.log.error("Selected module naming scheme %s could not be found in %s" % (sel_mns, avail_mnss.keys()))
+            raise EasyBuildError("Selected module naming scheme %s could not be found in %s",
+                                 sel_mns, avail_mnss.keys())
 
     def requires_full_easyconfig(self, keys):
         """Check whether specified list of easyconfig parameters is sufficient for active module naming scheme."""
@@ -1023,8 +1030,8 @@ class ActiveMNS(object):
                     self.log.debug("Full list of parsed easyconfigs: %s" % parsed_ec)
                 ec = parsed_ec[0]['ec']
             else:
-                tup = (ec['name'], det_full_ec_version(ec), ec)
-                self.log.error("Failed to find easyconfig file '%s-%s.eb' when determining module name for: %s" % tup)
+                raise EasyBuildError("Failed to find easyconfig file '%s-%s.eb' when determining module name for: %s",
+                                     ec['name'], det_full_ec_version(ec), ec)
 
         return ec
 
@@ -1047,7 +1054,7 @@ class ActiveMNS(object):
         mod_name = mns_method(self.check_ec_type(ec))
 
         if not is_valid_module_name(mod_name):
-            self.log.error("%s is not a valid module name" % str(mod_name))
+            raise EasyBuildError("%s is not a valid module name", str(mod_name))
 
         # check whether module name should be hidden or not
         # ec may be either a dict or an EasyConfig instance, 'force_visible' argument overrules
@@ -1076,8 +1083,8 @@ class ActiveMNS(object):
 
         # sanity check: obtained module name should pass the 'is_short_modname_for' check
         if not self.is_short_modname_for(mod_name, ec['name']):
-            tup = (mod_name, ec['name'])
-            self.log.error("is_short_modname_for('%s', '%s') for active module naming scheme returns False" % tup)
+            raise EasyBuildError("is_short_modname_for('%s', '%s') for active module naming scheme returns False",
+                                 mod_name, ec['name'])
 
         return mod_name
 

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -243,14 +243,13 @@ class EBConfigObj(object):
                     new_value = []
                     for dep_name, dep_val in value.items():
                         if isinstance(dep_val, Section):
-                            raise EasyBuildError("Unsupported nested section '%s' found in dependencies section",
-                                                 dep_name)
+                            raise EasyBuildError("Unsupported nested section '%s' in dependencies section", dep_name)
                         else:
                             # FIXME: parse the dependency specification for version, toolchain, suffix, etc.
                             dep = Dependency(dep_val, name=dep_name)
                             if dep.name() is None or dep.version() is None:
-                                tmpl = "Failed to find name/version in parsed dependency: %s (dict: %s)"
-                                raise EasyBuildError(tmpl, dep, dict(dep))
+                                raise EasyBuildError("Failed to find name/version in parsed dependency: %s (dict: %s)",
+                                                     dep, dict(dep))
                             new_value.append(dep)
 
                     tmpl = 'Converted dependency section %s to %s, passed it to parent section (or default)'

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -37,6 +37,7 @@ from vsc.utils.missing import get_subclasses
 from easybuild.framework.easyconfig.format.version import EasyVersion, OrderedVersionOperators
 from easybuild.framework.easyconfig.format.version import ToolchainVersionOperator, VersionOperator
 from easybuild.framework.easyconfig.format.convert import Dependency
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import Section
 
 
@@ -59,7 +60,7 @@ def get_format_version(txt):
             maj_min = res.groupdict()
             format_version = EasyVersion(FORMAT_VERSION_TEMPLATE % maj_min)
         except (KeyError, TypeError), err:
-            _log.error("Failed to get version from match %s: %s" % (res.groups(), err))
+            raise EasyBuildError("Failed to get version from match %s: %s", res.groups(), err)
     return format_version
 
 
@@ -242,13 +243,14 @@ class EBConfigObj(object):
                     new_value = []
                     for dep_name, dep_val in value.items():
                         if isinstance(dep_val, Section):
-                            self.log.error("Unsupported nested section '%s' found in dependencies section" % dep_name)
+                            raise EasyBuildError("Unsupported nested section '%s' found in dependencies section",
+                                                 dep_name)
                         else:
                             # FIXME: parse the dependency specification for version, toolchain, suffix, etc.
                             dep = Dependency(dep_val, name=dep_name)
                             if dep.name() is None or dep.version() is None:
                                 tmpl = "Failed to find name/version in parsed dependency: %s (dict: %s)"
-                                self.log.error(tmpl % (dep, dict(dep)))
+                                raise EasyBuildError(tmpl, dep, dict(dep))
                             new_value.append(dep)
 
                     tmpl = 'Converted dependency section %s to %s, passed it to parent section (or default)'
@@ -268,7 +270,7 @@ class EBConfigObj(object):
                         else:
                             self.log.debug("Not a %s section marker" % marker_type.__name__)
                     if not new_key:
-                        self.log.error("Unsupported section marker '%s'" % key)
+                        raise EasyBuildError("Unsupported section marker '%s'", key)
 
                     # parse value as a section, recursively
                     new_value = self.parse_sections(value, current.get_nested_dict())
@@ -296,10 +298,10 @@ class EBConfigObj(object):
                     # remove possible surrounding whitespace (some people add space after comma)
                     new_value = [value_type(x.strip()) for x in value]
                     if False in [x.is_valid() for x in new_value]:
-                        self.log.error("Failed to parse '%s' as list of %s" % (value, value_type.__name__))
+                        raise EasyBuildError("Failed to parse '%s' as list of %s", value, value_type.__name__)
                 else:
-                    tup = (key, value, type(value))
-                    self.log.error('Bug: supported but unknown key %s with non-string value: %s, type %s' % tup)
+                    raise EasyBuildError('Bug: supported but unknown key %s with non-string value: %s, type %s',
+                                         key, value, type(value))
 
                 self.log.debug("Converted value '%s' for key '%s' into new value '%s'" % (value, key, new_value))
                 current[key] = new_value
@@ -334,7 +336,7 @@ class EBConfigObj(object):
         self.supported = self.sections.pop(self.SECTION_MARKER_SUPPORTED)
         for key, value in self.supported.items():
             if not key in self.VERSION_OPERATOR_VALUE_TYPES:
-                self.log.error('Unsupported key %s in %s section' % (key, self.SECTION_MARKER_SUPPORTED))
+                raise EasyBuildError('Unsupported key %s in %s section', key, self.SECTION_MARKER_SUPPORTED)
             self.sections['%s' % key] = value
 
         for key, supported_key, fn_name in [('version', 'versions', 'get_version_str'),
@@ -344,7 +346,7 @@ class EBConfigObj(object):
                 first = self.supported[supported_key][0]
                 f_val = getattr(first, fn_name)()
                 if f_val is None:
-                    self.log.error("First %s %s can't be used as default (%s returned None)" % (key, first, fn_name))
+                    raise EasyBuildError("First %s %s can't be used as default (%s returned None)", key, first, fn_name)
                 else:
                     self.log.debug('Using first %s (%s) as default %s' % (key, first, f_val))
                     self.default[key] = f_val
@@ -438,8 +440,7 @@ class EBConfigObj(object):
             tc_overops.add(key)
 
             if key.test(tcname, tcversion):
-                tup = (tcname, tcversion, key)
-                self.log.debug("Found matching marker for specified toolchain '%s, %s': %s" % tup)
+                self.log.debug("Found matching marker for specified toolchain '%s, %s': %s", tcname, tcversion, key)
                 # TODO remove when unifying add_toolchina with .add()
                 tmp_squashed = self._squash(vt_tuple, nested_dict, sanity)
                 res_sections.update(tmp_squashed.result)
@@ -456,7 +457,7 @@ class EBConfigObj(object):
             else:
                 self.log.debug('Found non-matching version marker %s. Ignoring this (nested) section.' % key)
         else:
-            self.log.error("Unhandled section marker '%s' (type '%s')" % (key, type(key)))
+            raise EasyBuildError("Unhandled section marker '%s' (type '%s')", key, type(key))
 
         return res_sections
 
@@ -479,8 +480,8 @@ class EBConfigObj(object):
             tmp_tc_oversops = {}  # temporary, only for conflict checking
             for tcversop in value:
                 tc_overops = tmp_tc_oversops.setdefault(tcversop.tc_name, OrderedVersionOperators())
-                tup = (tcversop, tc_overops, tcname, tcversion)
-                self.log.debug('Add tcversop %s to tc_overops %s tcname %s tcversion %s' % tup)
+                self.log.debug("Add tcversop %s to tc_overops %s tcname %s tcversion %s",
+                               tcversop, tc_overops, tcname, tcversion)
                 tc_overops.add(tcversop)  # test non-conflicting list
                 if tcversop.test(tcname, tcversion):
                     matching_toolchains.append(tcversop)
@@ -507,7 +508,7 @@ class EBConfigObj(object):
                 self.log.debug('No matching versions, removing the whole current key %s' % key)
                 return Squashed()
         else:
-            self.log.error('Unexpected VERSION_OPERATOR_VALUE_TYPES key %s value %s' % (key, value))
+            raise EasyBuildError('Unexpected VERSION_OPERATOR_VALUE_TYPES key %s value %s', key, value)
 
         return None
 
@@ -520,11 +521,11 @@ class EBConfigObj(object):
                 version = self.default['version']
                 self.log.debug("No version specified, using default %s" % version)
             else:
-                self.log.error("No version specified, no default found.")
+                raise EasyBuildError("No version specified, no default found.")
         elif version in versions:
             self.log.debug("Version '%s' is supported in easyconfig." % version)
         else:
-            self.log.error("Version '%s' not supported in easyconfig (only %s)" % (version, versions))
+            raise EasyBuildError("Version '%s' not supported in easyconfig (only %s)", version, versions)
 
         tcnames = [tc.tc_name for tc in self.supported['toolchains']]
         if tcname is None:
@@ -532,11 +533,11 @@ class EBConfigObj(object):
                 tcname = self.default['toolchain']['name']
                 self.log.debug("No toolchain name specified, using default %s" % tcname)
             else:
-                self.log.error("No toolchain name specified, no default found.")
+                raise EasyBuildError("No toolchain name specified, no default found.")
         elif tcname in tcnames:
             self.log.debug("Toolchain '%s' is supported in easyconfig." % tcname)
         else:
-            self.log.error("Toolchain '%s' not supported in easyconfig (only %s)" % (tcname, tcnames))
+            raise EasyBuildError("Toolchain '%s' not supported in easyconfig (only %s)", tcname, tcnames)
 
         tcs = [tc for tc in self.supported['toolchains'] if tc.tc_name == tcname]
         if tcversion is None:
@@ -544,17 +545,16 @@ class EBConfigObj(object):
                 tcversion = self.default['toolchain']['version']
                 self.log.debug("No toolchain version specified, using default %s" % tcversion)
             else:
-                self.log.error("No toolchain version specified, no default found.")
+                raise EasyBuildError("No toolchain version specified, no default found.")
         elif any([tc.test(tcname, tcversion) for tc in tcs]):
             self.log.debug("Toolchain '%s' version '%s' is supported in easyconfig" % (tcname, tcversion))
         else:
-            tup = (tcname, tcversion, tcs)
-            self.log.error("Toolchain '%s' version '%s' not supported in easyconfig (only %s)" % tup)
+            raise EasyBuildError("Toolchain '%s' version '%s' not supported in easyconfig (only %s)",
+                                 tcname, tcversion, tcs)
 
-        tup = (version, tcname, tcversion)
-        self.log.debug('version %s, tcversion %s, tcname %s' % tup)
+        self.log.debug('version %s, tcversion %s, tcname %s', version, tcname, tcversion)
 
-        return tup
+        return (version, tcname, tcversion)
 
     def get_specs_for(self, version=None, tcname=None, tcversion=None):
         """
@@ -578,7 +578,7 @@ class EasyConfigFormat(object):
         self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
 
         if not len(self.VERSION) == len(FORMAT_VERSION_TEMPLATE.split('.')):
-            self.log.error('Invalid version number %s (incorrect length)' % self.VERSION)
+            raise EasyBuildError('Invalid version number %s (incorrect length)', self.VERSION)
 
         self.rawtext = None  # text version of the easyconfig
         self.header = None  # easyconfig header (e.g., format version, license, ...)

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -124,8 +124,7 @@ def retrieve_blocks_in_spec(spec, only_blocks, silent=False):
             block_contents = pieces.pop(0)
 
             if block_name in [b['name'] for b in blocks]:
-                msg = "Found block %s twice in %s." % (block_name, spec)
-                raise EasyBuildError(msg)
+                raise EasyBuildError("Found block %s twice in %s.", block_name, spec)
 
             block = {'name': block_name, 'contents': block_contents}
 

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -39,7 +39,7 @@ from vsc.utils import fancylogger
 from easybuild.framework.easyconfig.format.format import FORMAT_DEFAULT_VERSION, get_format_version
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import EasyConfigFormatConfigObj
 from easybuild.framework.easyconfig.format.version import EasyVersion
-from easybuild.tools.build_log import print_msg
+from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.filetools import write_file
 
 
@@ -71,14 +71,14 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         spec_tc_version = spec_tc.get('version', None)
         cfg = self.pyheader_localvars
         if spec_version is not None and not spec_version == cfg['version']:
-            self.log.error('Requested version %s not available, only %s' % (spec_version, cfg['version']))
+            raise EasyBuildError('Requested version %s not available, only %s', spec_version, cfg['version'])
 
         tc_name = cfg['toolchain']['name']
         tc_version = cfg['toolchain']['version']
         if spec_tc_name is not None and not spec_tc_name == tc_name:
-            self.log.error('Requested toolchain name %s not available, only %s' % (spec_tc_name, tc_name))
+            raise EasyBuildError('Requested toolchain name %s not available, only %s', spec_tc_name, tc_name)
         if spec_tc_version is not None and not spec_tc_version == tc_version:
-            self.log.error('Requested toolchain version %s not available, only %s' % (spec_tc_version, tc_version))
+            raise EasyBuildError('Requested toolchain version %s not available, only %s', spec_tc_version, tc_version)
 
         return cfg
 
@@ -102,7 +102,7 @@ def retrieve_blocks_in_spec(spec, only_blocks, silent=False):
     try:
         txt = open(spec).read()
     except IOError, err:
-        _log.error("Failed to read file %s: %s" % (spec, err))
+        raise EasyBuildError("Failed to read file %s: %s", spec, err)
 
     # split into blocks using regex
     pieces = reg_block.split(txt)
@@ -125,7 +125,7 @@ def retrieve_blocks_in_spec(spec, only_blocks, silent=False):
 
             if block_name in [b['name'] for b in blocks]:
                 msg = "Found block %s twice in %s." % (block_name, spec)
-                _log.error(msg)
+                raise EasyBuildError(msg)
 
             block = {'name': block_name, 'contents': block_contents}
 
@@ -157,7 +157,7 @@ def retrieve_blocks_in_spec(spec, only_blocks, silent=False):
             if 'dependencies' in block:
                 for dep in block['dependencies']:
                     if not dep in [b['name'] for b in blocks]:
-                        _log.error("Block %s depends on %s, but block was not found." % (name, dep))
+                        raise EasyBuildError("Block %s depends on %s, but block was not found.", name, dep)
 
                     dep = [b for b in blocks if b['name'] == dep][0]
                     txt += "\n# Dependency block %s" % (dep['name'])

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -36,6 +36,7 @@ from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from easybuild.framework.easyconfig.format.format import get_format_version, EasyConfigFormat
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.systemtools import get_shared_lib_ext
 
@@ -68,7 +69,7 @@ def build_easyconfig_constants_dict():
                 const_dict[cst_key] = cst_val
 
     if len(err) > 0:
-        _log.error("EasyConfig constants sanity check failed: %s" % ("\n".join(err)))
+        raise EasyBuildError("EasyConfig constants sanity check failed: %s", "\n".join(err))
     else:
         return const_dict
 
@@ -128,8 +129,8 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
             last_n = 100
             pre_section_tail = txt[start_section-last_n:start_section]
             sections_head = txt[start_section:start_section+last_n]
-            tup = (start_section, last_n, pre_section_tail, sections_head)
-            self.log.debug('Sections start at index %s, %d-chars context:\n"""%s""""\n<split>\n"""%s..."""' % tup)
+            self.log.debug('Sections start at index %s, %d-chars context:\n"""%s""""\n<split>\n"""%s..."""',
+                           start_section, last_n, pre_section_tail, sections_head)
 
         self.parse_pre_section(txt[:start_section])
         if start_section is not None:
@@ -148,7 +149,7 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
             format_version = get_format_version(line)
             if format_version is not None:
                 if not format_version == self.VERSION:
-                    self.log.error("Invalid format version %s for current format class" % format_version)
+                    raise EasyBuildError("Invalid format version %s for current format class", format_version)
                 else:
                     self.log.info("Valid format version %s found" % format_version)
                 # version is not part of header
@@ -185,7 +186,7 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
         try:
             exec(pyheader, global_vars, local_vars)
         except SyntaxError, err:
-            self.log.error("SyntaxError in easyconfig pyheader %s: %s" % (pyheader, err))
+            raise EasyBuildError("SyntaxError in easyconfig pyheader %s: %s", pyheader, err)
 
         self.log.debug("pyheader final global_vars %s" % global_vars)
         self.log.debug("pyheader final local_vars %s" % local_vars)
@@ -230,14 +231,14 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
         blacklisted parameters are not allowed, mandatory parameters are mandatory unless blacklisted
         """
         if self.pyheader_localvars is None:
-            self.log.error("self.pyheader_localvars must be initialized")
+            raise EasyBuildError("self.pyheader_localvars must be initialized")
         if self.PYHEADER_BLACKLIST is None or self.PYHEADER_MANDATORY is None:
-            self.log.error('Both PYHEADER_BLACKLIST and PYHEADER_MANDATORY must be set')
+            raise EasyBuildError('Both PYHEADER_BLACKLIST and PYHEADER_MANDATORY must be set')
 
         for param in self.PYHEADER_BLACKLIST:
             if param in self.pyheader_localvars:
                 # TODO add to easyconfig unittest (similar to mandatory)
-                self.log.error('blacklisted param %s not allowed in pyheader' % param)
+                raise EasyBuildError('blacklisted param %s not allowed in pyheader', param)
 
         missing = []
         for param in self.PYHEADER_MANDATORY:
@@ -246,13 +247,13 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
             if not param in self.pyheader_localvars:
                 missing.append(param)
         if missing:
-            self.log.error('mandatory parameters not provided in pyheader: %s' % ', '.join(missing))
+            raise EasyBuildError('mandatory parameters not provided in pyheader: %s', ', '.join(missing))
 
     def parse_section_block(self, section):
         """Parse the section block by trying to convert it into a ConfigObj instance"""
         try:
             self.configobj = ConfigObj(section.split('\n'))
         except SyntaxError, err:
-            self.log.error('Failed to convert section text %s: %s' % (section, err))
+            raise EasyBuildError('Failed to convert section text %s: %s', section, err)
 
         self.log.debug("Found ConfigObj instance %s" % self.configobj)

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -69,7 +69,7 @@ def build_easyconfig_constants_dict():
                 const_dict[cst_key] = cst_val
 
     if len(err) > 0:
-        raise EasyBuildError("EasyConfig constants sanity check failed: %s", "\n".join(err))
+        raise EasyBuildError("EasyConfig constants sanity check failed: %s", '\n'.join(err))
     else:
         return const_dict
 

--- a/easybuild/framework/easyconfig/format/two.py
+++ b/easybuild/framework/easyconfig/format/two.py
@@ -37,6 +37,7 @@ import re
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import EasyConfigFormatConfigObj
 from easybuild.framework.easyconfig.format.format import EBConfigObj
 from easybuild.framework.easyconfig.format.version import EasyVersion, ToolchainVersionOperator, VersionOperator
+from easybuild.tools.build_log import EasyBuildError
 
 
 class FormatTwoZero(EasyConfigFormatConfigObj):
@@ -89,10 +90,10 @@ class FormatTwoZero(EasyConfigFormatConfigObj):
             maintainers.append(res['name'])
 
         if self.AUTHOR_REQUIRED and not authors:
-            self.log.error("No author in docstring (regex: '%s')" % self.AUTHOR_DOCSTRING_REGEX.pattern)
+            raise EasyBuildError("No author in docstring (regex: '%s')", self.AUTHOR_DOCSTRING_REGEX.pattern)
 
         if self.MAINTAINER_REQUIRED and not maintainers:
-            self.log.error("No maintainer in docstring (regex: '%s')" % self.MAINTAINER_DOCSTRING_REGEX.pattern)
+            raise EasyBuildError("No maintainer in docstring (regex: '%s')", self.MAINTAINER_DOCSTRING_REGEX.pattern)
 
     def get_config_dict(self):
         """Return the best matching easyconfig dict"""

--- a/easybuild/framework/easyconfig/format/version.py
+++ b/easybuild/framework/easyconfig/format/version.py
@@ -34,6 +34,7 @@ import re
 from distutils.version import LooseVersion
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.utilities import search_toolchain
 
 
@@ -80,7 +81,7 @@ class VersionOperator(object):
         """
         Initialise VersionOperator instance.
         @param versop_str: intialise with version operator string
-        @param error_on_parse_failure: log.error in case of parse error
+        raise EasyBuildError in case of parse error
         """
         self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
 
@@ -100,7 +101,7 @@ class VersionOperator(object):
         """Special function to deal with parse errors"""
         # TODO major issue what to do in case of misparse. error or not?
         if self.error_on_parse_failure:
-            self.log.error(msg)
+            raise EasyBuildError(msg)
         else:
             self.log.debug(msg)
 
@@ -122,7 +123,7 @@ class VersionOperator(object):
         """
         versop_dict = self.parse_versop_str(versop_str)
         if versop_dict is None:
-            self.log.error("Failed to parse '%s' as a version operator string" % versop_str)
+            raise EasyBuildError("Failed to parse '%s' as a version operator string", versop_str)
         else:
             for k, v in versop_dict.items():
                 setattr(self, k, v)
@@ -136,16 +137,16 @@ class VersionOperator(object):
         """
         # checks whether this VersionOperator instance is valid using __bool__ function
         if not self:
-            self.log.error('Not a valid %s. Not initialised yet?' % self.__class__.__name__)
+            raise EasyBuildError('Not a valid %s. Not initialised yet?', self.__class__.__name__)
 
         if isinstance(test_version, basestring):
             test_version = self._convert(test_version)
         elif not isinstance(test_version, EasyVersion):
-            self.log.error("test: argument should be a basestring or EasyVersion (type %s)" % (type(test_version)))
+            raise EasyBuildError("test: argument should be a basestring or EasyVersion (type %s)", type(test_version))
 
         res = self.operator(test_version, self.version)
-        tup = (test_version, self.REVERSE_OPERATOR_MAP[self.operator], self.version, res)
-        self.log.debug("result of testing expression '%s %s %s': %s" % tup)
+        self.log.debug("result of testing expression '%s %s %s': %s",
+                       test_version, self.REVERSE_OPERATOR_MAP[self.operator], self.version, res)
 
         return res
 
@@ -178,7 +179,7 @@ class VersionOperator(object):
         if versop is None:
             return False
         elif not isinstance(versop, self.__class__):
-            self.log.error("Types don't match in comparison: %s, expected %s" % (type(versop), self.__class__))
+            raise EasyBuildError("Types don't match in comparison: %s, expected %s", type(versop), self.__class__)
         return self.version == versop.version and self.operator == versop.operator and self.suffix == versop.suffix
 
     def __ne__(self, versop):
@@ -270,7 +271,7 @@ class VersionOperator(object):
             versop_dict['versop_str'] = versop_str
 
         if not 'versop_str' in versop_dict:
-            self.log.error('Missing versop_str in versop_dict %s' % versop_dict)
+            raise EasyBuildError('Missing versop_str in versop_dict %s', versop_dict)
 
         version = self._convert(versop_dict['version_str'])
         operator = self._convert_operator(versop_dict['operator_str'], version=version)
@@ -311,7 +312,7 @@ class VersionOperator(object):
         versop_msg = "this versop %s and versop_other %s" % (self, versop_other)
 
         if not isinstance(versop_other, self.__class__):
-            self.log.error('overlap/conflict check needs instance of self %s (got type %s)' %
+            raise EasyBuildError('overlap/conflict check needs instance of self %s (got type %s)' %
                            (self.__class__.__name__, type(versop_other)))
 
         if self == versop_other:
@@ -424,12 +425,12 @@ class VersionOperator(object):
             Suffix are not considered.
         """
         if len(self.ORDERED_OPERATORS) != len(self.OPERATOR_MAP):
-            self.log.error('Inconsistency between ORDERED_OPERATORS and OPERATORS (lists are not of same length)')
+            raise EasyBuildError('Inconsistency between ORDERED_OPERATORS and OPERATORS (lists are not of same length)')
 
         # ensure this function is only used for non-conflicting version operators
         _, conflict = self.test_overlap_and_conflict(versop_other)
         if conflict:
-            self.log.error("Conflicting version operator expressions should not be compared with _gt_safe")
+            raise EasyBuildError("Conflicting version operator expressions should not be compared with _gt_safe")
 
         ordered_operators = [self.OPERATOR_MAP[x] for x in self.ORDERED_OPERATORS]
         if self.version == versop_other.version:
@@ -530,7 +531,7 @@ class ToolchainVersionOperator(VersionOperator):
         tcversop_dict = super(ToolchainVersionOperator, self).parse_versop_str(None, versop_dict=tcversop_dict)
 
         if tcversop_dict.get('version_str', None) is not None and tcversop_dict.get('operator_str', None) is None:
-            self.log.error("Toolchain version found, but no operator (use ' == '?).")
+            raise EasyBuildError("Toolchain version found, but no operator (use ' == '?).")
 
         self.log.debug("toolchain versop expression '%s' parsed to '%s'" % (tcversop_str, tcversop_dict))
         return tcversop_dict
@@ -552,15 +553,14 @@ class ToolchainVersionOperator(VersionOperator):
         """
         # checks whether this ToolchainVersionOperator instance is valid using __bool__ function
         if not self:
-            self.log.error('Not a valid %s. Not initialised yet?' % self.__class__.__name__)
+            raise EasyBuildError('Not a valid %s. Not initialised yet?', self.__class__.__name__)
 
         tc_name_res = name == self.tc_name
         if not tc_name_res:
             self.log.debug('Toolchain name %s different from test toolchain name %s' % (self.tc_name, name))
         version_res = super(ToolchainVersionOperator, self).test(version)
         res = tc_name_res and version_res
-        tup = (tc_name_res, version_res, res)
-        self.log.debug("result of testing expression tc_name_res %s version_res %s: %s" % tup)
+        self.log.debug("result of testing expression tc_name_res %s version_res %s: %s", tc_name_res, version_res, res)
 
         return res
 
@@ -622,8 +622,8 @@ class OrderedVersionOperators(object):
         if isinstance(versop_new, basestring):
             versop_new = VersionOperator(versop_new)
         elif not isinstance(versop_new, VersionOperator):
-            tup = (versop_new, type(versop_new))
-            self.log.error(("add: argument must be a VersionOperator instance or basestring: %s; type %s") % tup)
+            raise EasyBuildError("add: argument must be a VersionOperator instance or basestring: %s; type %s",
+                                 versop_new, type(versop_new))
 
         if versop_new in self.versops:
             self.log.debug("Versop %s already added." % versop_new)
@@ -634,7 +634,7 @@ class OrderedVersionOperators(object):
                 # conflict
                 msg = 'add: conflict(s) between versop_new %s and existing versions %s'
                 conflict_versops = [(idx, self.versops[idx]) for idx, gt_val in enumerate(gt_test) if gt_val is None]
-                self.log.error(msg % (versop_new, conflict_versops))
+                raise EasyBuildError(msg, versop_new, conflict_versops)
             else:
                 if True in gt_test:
                     # determine first element for which comparison is True
@@ -655,8 +655,8 @@ class OrderedVersionOperators(object):
         if update and versop_new_str in self.datamap:
             self.log.debug("Keeping track of data for %s UPDATE: %s" % (versop_new_str, data))
             if not hasattr(self.datamap[versop_new_str], 'update'):
-                tup = (versop_new_str, type(self.datamap[versop_new_str]))
-                self.log.error("Can't update on datamap key %s type %s" % tup)
+                raise EasyBuildError("Can't update on datamap key %s type %s",
+                                     versop_new_str, type(self.datamap[versop_new_str]))
             self.datamap[versop_new_str].update(data)
         else:
             self.log.debug("Keeping track of data for %s SET: %s" % (versop_new_str, data))
@@ -665,11 +665,11 @@ class OrderedVersionOperators(object):
     def get_data(self, versop):
         """Return the data for versop from datamap"""
         if not isinstance(versop, VersionOperator):
-            tup = (versop, type(versop))
-            self.log.error(("get_data: argument must be a VersionOperator instance: %s; type %s") % tup)
+            raise EasyBuildError(("get_data: argument must be a VersionOperator instance: %s; type %s"),
+                                  versop, type(versop))
 
         versop_str = str(versop)
         if versop_str in self.datamap:
             return self.datamap[versop_str]
         else:
-            self.log.error('No data in datamap for versop %s' % versop)
+            raise EasyBuildError('No data in datamap for versop %s', versop)

--- a/easybuild/framework/easyconfig/format/version.py
+++ b/easybuild/framework/easyconfig/format/version.py
@@ -81,7 +81,7 @@ class VersionOperator(object):
         """
         Initialise VersionOperator instance.
         @param versop_str: intialise with version operator string
-        raise EasyBuildError in case of parse error
+        @param error_on_parse_failure: raise EasyBuildError in case of parse error
         """
         self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
 
@@ -312,8 +312,8 @@ class VersionOperator(object):
         versop_msg = "this versop %s and versop_other %s" % (self, versop_other)
 
         if not isinstance(versop_other, self.__class__):
-            raise EasyBuildError('overlap/conflict check needs instance of self %s (got type %s)' %
-                           (self.__class__.__name__, type(versop_other)))
+            raise EasyBuildError("overlap/conflict check needs instance of self %s (got type %s)",
+                                 self.__class__.__name__, type(versop_other))
 
         if self == versop_other:
             self.log.debug("%s are equal. Return overlap True, conflict False." % versop_msg)
@@ -425,7 +425,7 @@ class VersionOperator(object):
             Suffix are not considered.
         """
         if len(self.ORDERED_OPERATORS) != len(self.OPERATOR_MAP):
-            raise EasyBuildError('Inconsistency between ORDERED_OPERATORS and OPERATORS (lists are not of same length)')
+            raise EasyBuildError("Inconsistency between ORDERED_OPERATORS and OPERATORS (lists are not of same length)")
 
         # ensure this function is only used for non-conflicting version operators
         _, conflict = self.test_overlap_and_conflict(versop_other)
@@ -632,9 +632,9 @@ class OrderedVersionOperators(object):
             gt_test = [versop_new > versop for versop in self.versops]
             if None in gt_test:
                 # conflict
-                msg = 'add: conflict(s) between versop_new %s and existing versions %s'
                 conflict_versops = [(idx, self.versops[idx]) for idx, gt_val in enumerate(gt_test) if gt_val is None]
-                raise EasyBuildError(msg, versop_new, conflict_versops)
+                raise EasyBuildError("add: conflict(s) between versop_new %s and existing versions %s",
+                                     versop_new, conflict_versops)
             else:
                 if True in gt_test:
                     # determine first element for which comparison is True
@@ -665,11 +665,11 @@ class OrderedVersionOperators(object):
     def get_data(self, versop):
         """Return the data for versop from datamap"""
         if not isinstance(versop, VersionOperator):
-            raise EasyBuildError(("get_data: argument must be a VersionOperator instance: %s; type %s"),
+            raise EasyBuildError("get_data: argument must be a VersionOperator instance: %s; type %s",
                                   versop, type(versop))
 
         versop_str = str(versop)
         if versop_str in self.datamap:
             return self.datamap[versop_str]
         else:
-            raise EasyBuildError('No data in datamap for versop %s', versop)
+            raise EasyBuildError("No data in datamap for versop %s", versop)

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -35,6 +35,7 @@ from vsc.utils import fancylogger
 
 from easybuild.framework.easyconfig.format.format import FORMAT_DEFAULT_VERSION
 from easybuild.framework.easyconfig.format.format import get_format_version, get_format_version_classes
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, write_file
 
 
@@ -96,7 +97,7 @@ class EasyConfigParser(object):
             self._check_filename(filename)
             self.process()
         else:
-            self.log.error("Neither filename nor rawcontent provided to EasyConfigParser")
+            raise EasyBuildError("Neither filename nor rawcontent provided to EasyConfigParser")
 
     def process(self, filename=None):
         """Create an instance"""
@@ -112,9 +113,9 @@ class EasyConfigParser(object):
         self.log.debug("Process filename %s with get function %s, set function %s" % (fn, self.get_fn, self.set_fn))
 
         if self.get_fn is None:
-            self.log.error('Failed to determine get function for filename %s' % fn)
+            raise EasyBuildError('Failed to determine get function for filename %s', fn)
         if self.set_fn is None:
-            self.log.error('Failed to determine set function for filename %s' % fn)
+            raise EasyBuildError('Failed to determine set function for filename %s', fn)
 
     def _read(self, filename=None):
         """Read the easyconfig, dump content in self.rawcontent"""
@@ -124,11 +125,11 @@ class EasyConfigParser(object):
         try:
             self.rawcontent = self.get_fn[0](*self.get_fn[1])
         except IOError, err:
-            self.log.error('Failed to obtain content with %s: %s' % (self.get_fn, err))
+            raise EasyBuildError('Failed to obtain content with %s: %s', self.get_fn, err)
 
         if not isinstance(self.rawcontent, basestring):
             msg = 'rawcontent is not basestring: type %s, content %s' % (type(self.rawcontent), self.rawcontent)
-            self.log.error("Unexpected result for raw content: %s" % msg)
+            raise EasyBuildError("Unexpected result for raw content: %s", msg)
 
     def _det_format_version(self):
         """Extract the format version from the raw content"""
@@ -146,10 +147,10 @@ class EasyConfigParser(object):
         if len(found_classes) == 1:
             return found_classes[0]
         elif not found_classes:
-            self.log.error('No format classes found matching version %s' % self.format_version)
+            raise EasyBuildError('No format classes found matching version %s', self.format_version)
         else:
             msg = 'More than one format class found matching version %s in %s' % (self.format_version, found_classes)
-            self.log.error(msg)
+            raise EasyBuildError(msg)
 
     def _set_formatter(self):
         """Obtain instance of the formatter"""
@@ -171,7 +172,7 @@ class EasyConfigParser(object):
         try:
             self.set_fn[0](*self.set_fn[1])
         except IOError, err:
-            self.log.error('Failed to process content with %s: %s' % (self.set_fn, err))
+            raise EasyBuildError('Failed to process content with %s: %s', self.set_fn, err)
 
     def set_specifications(self, specs):
         """Set specifications."""

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -149,8 +149,8 @@ class EasyConfigParser(object):
         elif not found_classes:
             raise EasyBuildError('No format classes found matching version %s', self.format_version)
         else:
-            msg = 'More than one format class found matching version %s in %s' % (self.format_version, found_classes)
-            raise EasyBuildError(msg)
+            raise EasyBuildError("More than one format class found matching version %s in %s",
+                                 self.format_version, found_classes)
 
     def _set_formatter(self):
         """Obtain instance of the formatter"""
@@ -172,7 +172,7 @@ class EasyConfigParser(object):
         try:
             self.set_fn[0](*self.set_fn[1])
         except IOError, err:
-            raise EasyBuildError('Failed to process content with %s: %s', self.set_fn, err)
+            raise EasyBuildError("Failed to process content with %s: %s", self.set_fn, err)
 
     def set_specifications(self, specs):
         """Set specifications."""

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -34,6 +34,7 @@ be used within an Easyconfig file.
 from vsc.utils import fancylogger
 from distutils.version import LooseVersion
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.systemtools import get_shared_lib_ext
 
 
@@ -175,7 +176,7 @@ def template_constant_dict(config, ignore=None, skip_lower=True):
                 if softname is not None:
                     template_values['nameletter'] = softname[0]
         else:
-            _log.error("Undefined name %s from TEMPLATE_NAMES_EASYCONFIG" % name)
+            raise EasyBuildError("Undefined name %s from TEMPLATE_NAMES_EASYCONFIG", name)
 
     # step 2: add remaining from config
     for name in TEMPLATE_NAMES_CONFIG:

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -314,7 +314,7 @@ def parse_easyconfigs(paths):
         # keep track of whether any files were generated
         generated_ecs |= generated
         if not os.path.exists(path):
-            _log.error("Can't find path %s" % path)
+            _log.error("Can't find path %s", path)
         try:
             ec_files = find_easyconfigs(path, ignore_dirs=build_option('ignore_dirs'))
             for ec_file in ec_files:

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -180,9 +180,8 @@ def dep_graph(*args, **kwargs):
     try:
         _dep_graph(*args, **kwargs)
     except NameError, err:
-        errors = "\n".join(graph_errors)
-        msg = "An optional Python packages required to generate dependency graphs is missing: %s" % errors
-        _log.error("%s\nerr: %s" % (msg, err))
+        raise EasyBuildError("An optional Python packages required to generate dependency graphs is missing: %s, %s",
+                             '\n'.join(graph_errors), err)
 
 
 def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
@@ -314,7 +313,7 @@ def parse_easyconfigs(paths):
         # keep track of whether any files were generated
         generated_ecs |= generated
         if not os.path.exists(path):
-            _log.error("Can't find path %s", path)
+            raise EasyBuildError("Can't find path %s", path)
         try:
             ec_files = find_easyconfigs(path, ignore_dirs=build_option('ignore_dirs'))
             for ec_file in ec_files:
@@ -325,7 +324,7 @@ def parse_easyconfigs(paths):
                 ecs = process_easyconfig(ec_file, **kwargs)
                 easyconfigs.extend(ecs)
         except IOError, err:
-            _log.error("Processing easyconfigs in path %s failed: %s" % (path, err))
+            raise EasyBuildError("Processing easyconfigs in path %s failed: %s", path, err)
 
     return easyconfigs, generated_ecs
 
@@ -335,7 +334,7 @@ def stats_to_str(stats):
     Pretty print build statistics to string.
     """
     if not isinstance(stats, (OrderedDict, dict)):
-        _log.error("Can only pretty print build stats in dictionary form, not of type %s" % type(stats))
+        raise EasyBuildError("Can only pretty print build stats in dictionary form, not of type %s", type(stats))
 
     txt = "{\n"
     pref = "    "

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -43,6 +43,7 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import nub
 
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, create_paths, process_easyconfig
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.robot import resolve_dependencies
@@ -74,7 +75,8 @@ def tweak(easyconfigs, build_specs, targetdir=None):
     # make sure easyconfigs all feature the same toolchain (otherwise we *will* run into trouble)
     toolchains = nub(['%(name)s/%(version)s' % ec['ec']['toolchain'] for ec in easyconfigs])
     if len(toolchains) > 1:
-        _log.error("Multiple toolchains featured in easyconfigs, --try-X not supported in that case: %s" % toolchains)
+        raise EasyBuildError("Multiple toolchains featured in easyconfigs, --try-X not supported in that case: %s",
+                             toolchains)
 
     if 'name' in build_specs or 'version' in build_specs:
         # no recursion if software name/version build specification are included
@@ -143,7 +145,7 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
         tc_regexp = re.compile(r"^\s*toolchain\s*=\s*(.*)$", re.M)
         res = tc_regexp.search(ectxt)
         if not res:
-            _log.error("No toolchain found in easyconfig file %s?" % src_fn)
+            raise EasyBuildError("No toolchain found in easyconfig file %s?", src_fn)
 
         toolchain = eval(res.group(1))
         for key in ['name', 'version']:
@@ -204,8 +206,8 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
                 diff = eval(res.group('val')) != val
             except (NameError, SyntaxError):
                 # if eval fails, just fall back to string comparison
-                tup = (res.group('val'), val)
-                _log.debug("eval failed for \"%s\", falling back to string comparison against \"%s\"..." % tup)
+                _log.debug("eval failed for \"%s\", falling back to string comparison against \"%s\"...",
+                           res.group('val'), val)
                 diff = res.group('val') != val
 
             if diff:
@@ -237,7 +239,7 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
             # get rid of temporary file
             os.remove(tmpfn)
         except OSError, err:
-            _log.error("Failed to determine suiting filename for tweaked easyconfig file: %s" % err)
+            raise EasyBuildError("Failed to determine suiting filename for tweaked easyconfig file: %s", err)
 
         if targetdir is None:
             targetdir = tempfile.gettempdir()
@@ -265,7 +267,7 @@ def pick_version(req_ver, avail_vers):
     """
 
     if not avail_vers:
-        _log.error("Empty list of available versions passed.")
+        raise EasyBuildError("Empty list of available versions passed.")
 
     selected_ver = None
     if req_ver:
@@ -334,7 +336,7 @@ def select_or_generate_ec(fp, paths, specs):
 
     # ensure that at least name is specified
     if not specs.get('name'):
-        _log.error("Supplied 'specs' dictionary doesn't even contain a name of a software package?")
+        raise EasyBuildError("Supplied 'specs' dictionary doesn't even contain a name of a software package?")
     name = specs['name']
     handled_params = ['name']
 
@@ -362,7 +364,8 @@ def select_or_generate_ec(fp, paths, specs):
                 _log.debug("No template found at %s." % templ_file)
 
         if len(ec_files) == 0:
-            _log.error("No easyconfig files found for software %s, and no templates available. I'm all out of ideas." % name)
+            raise EasyBuildError("No easyconfig files found for software %s, and no templates available. "
+                                 "I'm all out of ideas.", name)
 
     ecs_and_files = [(EasyConfig(f, validate=False), f) for f in ec_files]
 
@@ -390,7 +393,7 @@ def select_or_generate_ec(fp, paths, specs):
         if EASYCONFIG_TEMPLATE in tcnames:
             _log.info("No easyconfig file for specified toolchain, but template is available.")
         else:
-            _log.error("No easyconfig file for %s with toolchain %s, " \
+            raise EasyBuildError("No easyconfig file for %s with toolchain %s, " \
                       "and no template available." % (name, specs['toolchain_name']))
 
     tcname = specs.pop('toolchain_name', None)
@@ -414,7 +417,7 @@ def select_or_generate_ec(fp, paths, specs):
             else:
                 # if multiple toolchains are available, and none is specified, we quit
                 # we can't just pick one, how would we prefer one over the other?
-                _log.error("No toolchain name specified, and more than one available: %s." % tcnames)
+                raise EasyBuildError("No toolchain name specified, and more than one available: %s.", tcnames)
 
     _log.debug("Filtering easyconfigs based on toolchain name '%s'..." % selected_tcname)
     ecs_and_files = [x for x in ecs_and_files if x[0]['toolchain']['name'] == selected_tcname]
@@ -497,7 +500,7 @@ def select_or_generate_ec(fp, paths, specs):
             filter_ecs = True
         else:
             # otherwise, we fail, because we don't know how to pick between different fixes
-            _log.error("No %s specified, and can't pick from available %ses %s" % (param,
+            raise EasyBuildError("No %s specified, and can't pick from available %ses %s" % (param,
                                                                                   param,
                                                                                   vals))
 
@@ -515,7 +518,7 @@ def select_or_generate_ec(fp, paths, specs):
     cnt = len(ecs_and_files)
     if not cnt == 1:
         fs = [x[1] for x in ecs_and_files]
-        _log.error("Failed to select a single easyconfig from available ones, %s left: %s" % (cnt, fs))
+        raise EasyBuildError("Failed to select a single easyconfig from available ones, %s left: %s", cnt, fs)
     else:
         (selected_ec, selected_ec_file) = ecs_and_files[0]
 
@@ -570,11 +573,11 @@ def obtain_ec_for(specs, paths, fp=None):
 
     # ensure that at least name is specified
     if not specs.get('name'):
-        _log.error("Supplied 'specs' dictionary doesn't even contain a name of a software package?")
+        raise EasyBuildError("Supplied 'specs' dictionary doesn't even contain a name of a software package?")
 
     # collect paths to search in
     if not paths:
-        _log.error("No paths to look for easyconfig files, specify a path with --robot.")
+        raise EasyBuildError("No paths to look for easyconfig files, specify a path with --robot.")
 
     # select best easyconfig, or try to generate one that fits the requirements
     res = select_or_generate_ec(fp, paths, specs)
@@ -582,4 +585,4 @@ def obtain_ec_for(specs, paths, fp=None):
     if res:
         return res
     else:
-        _log.error("No easyconfig found for requested software, and also failed to generate one.")
+        raise EasyBuildError("No easyconfig found for requested software, and also failed to generate one.")

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -393,8 +393,8 @@ def select_or_generate_ec(fp, paths, specs):
         if EASYCONFIG_TEMPLATE in tcnames:
             _log.info("No easyconfig file for specified toolchain, but template is available.")
         else:
-            raise EasyBuildError("No easyconfig file for %s with toolchain %s, " \
-                      "and no template available." % (name, specs['toolchain_name']))
+            raise EasyBuildError("No easyconfig file for %s with toolchain %s, and no template available.",
+                                 name, specs['toolchain_name'])
 
     tcname = specs.pop('toolchain_name', None)
     handled_params.append('toolchain_name')
@@ -500,9 +500,7 @@ def select_or_generate_ec(fp, paths, specs):
             filter_ecs = True
         else:
             # otherwise, we fail, because we don't know how to pick between different fixes
-            raise EasyBuildError("No %s specified, and can't pick from available %ses %s" % (param,
-                                                                                  param,
-                                                                                  vals))
+            raise EasyBuildError("No %s specified, and can't pick from available ones: %s", param, vals)
 
         if filter_ecs:
             _log.debug("Filtering easyconfigs based on %s '%s'..." % (param, selected_val))

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -36,6 +36,7 @@ The Extension class should serve as a base class for all extensions.
 import copy
 import os
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_path
 from easybuild.tools.run import run_cmd
 
@@ -54,7 +55,7 @@ class Extension(object):
         self.ext = copy.deepcopy(ext)
 
         if not 'name' in self.ext:
-            self.log.error("'name' is missing in supplied class instance 'ext'.")
+            raise EasyBuildError("'name' is missing in supplied class instance 'ext'.")
 
         self.src = self.ext.get('src', None)
         self.patches = self.ext.get('patches', None)
@@ -111,7 +112,7 @@ class Extension(object):
         try:
             os.chdir(build_path())
         except OSError, err:
-            self.log.error("Failed to change directory: %s" % err)
+            raise EasyBuildError("Failed to change directory: %s", err)
 
         # disabling templating is required here to support legacy string templates like name/version
         self.cfg.enable_templating = False

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -31,6 +31,7 @@ from vsc.utils import fancylogger
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extension import Extension
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import apply_patch, extract_file
 from easybuild.tools.utilities import remove_unwanted_chars
 
@@ -97,7 +98,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         if self.patches:
             for patchfile in self.patches:
                 if not apply_patch(patchfile, self.ext_dir):
-                    self.log.error("Applying patch %s failed" % patchfile)
+                    raise EasyBuildError("Applying patch %s failed", patchfile)
 
     def sanity_check_step(self, exts_filter=None, custom_paths=None, custom_commands=None):
         """
@@ -128,7 +129,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             if self.is_extension:
                 self.log.warning(msg)
             else:
-                self.log.error(msg)
+                raise EasyBuildError(msg)
             return False
         else:
             self.log.info("Sanity check for %s successful!" % self.name)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -88,7 +88,7 @@ def find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=
                 _log.warning("Failed to remove generated easyconfig file %s: %s" % (ec_file, err))
 
             # don't use a generated easyconfig unless generation was requested (using a --try-X option)
-            _log.error(("Unable to find an easyconfig for the given specifications: %s; "
+            raise EasyBuildError(("Unable to find an easyconfig for the given specifications: %s; "
                         "to make EasyBuild try to generate a matching easyconfig, "
                         "use the --try-X options ") % build_specs)
 
@@ -132,9 +132,9 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True):
 
         if not ec_res['success'] and exit_on_failure:
             if 'traceback' in ec_res:
-                _log.error(ec_res['traceback'])
+                raise EasyBuildError(ec_res['traceback'])
             else:
-                _log.error(test_msg)
+                raise EasyBuildError(test_msg)
 
         res.append((ec, ec_res))
 
@@ -172,7 +172,8 @@ def main(testing_data=(None, None, None)):
 
     # disallow running EasyBuild as root
     if os.getuid() == 0:
-        _log.error("You seem to be running EasyBuild with root privileges which is not wise, so let's end this here.")
+        raise EasyBuildError("You seem to be running EasyBuild with root privileges which is not wise, "
+                             "so let's end this here.")
 
     # log startup info
     eb_cmd_line = eb_go.generate_cmd_line() + eb_go.args

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -88,9 +88,9 @@ def find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=
                 _log.warning("Failed to remove generated easyconfig file %s: %s" % (ec_file, err))
 
             # don't use a generated easyconfig unless generation was requested (using a --try-X option)
-            raise EasyBuildError(("Unable to find an easyconfig for the given specifications: %s; "
-                        "to make EasyBuild try to generate a matching easyconfig, "
-                        "use the --try-X options ") % build_specs)
+            raise EasyBuildError("Unable to find an easyconfig for the given specifications: %s; "
+                                 "to make EasyBuild try to generate a matching easyconfig, "
+                                 "use the --try-X options ", build_specs)
 
     return [(ec_file, generated)]
 

--- a/easybuild/scripts/clean_gists.py
+++ b/easybuild/scripts/clean_gists.py
@@ -77,7 +77,7 @@ def main():
 
     if status != HTTP_STATUS_OK:
         raise EasyBuildError("Failed to get a lists of gists for user %s: error code %s, message = %s",
-                  username, status, gists)
+                             username, status, gists)
     else:
         log.info("Found %s gists", len(gists))
 
@@ -104,7 +104,7 @@ def main():
                     status, pr = gh.repos[GITHUB_EB_MAIN][GITHUB_EASYCONFIGS_REPO].pulls[pr_num].get()
                     if status != HTTP_STATUS_OK:
                         raise EasyBuildError("Failed to get pull-request #%s: error code %s, message = %s",
-                                  pr_num, status, pr)
+                                             pr_num, status, pr)
                     pr_cache[pr_num] = pr["state"]
 
                 if pr_cache[pr_num] == "closed":
@@ -120,7 +120,7 @@ def main():
 
             if status != HTTP_DELETE_OK:
                 raise EasyBuildError("Unable to remove gist (id=%s): error code %s, message = %s",
-                          gist["id"], status, del_gist)
+                                     gist["id"], status, del_gist)
             else:
                 log.info("Delete gist with id=%s", gist["id"])
                 num_deleted += 1

--- a/easybuild/scripts/clean_gists.py
+++ b/easybuild/scripts/clean_gists.py
@@ -31,6 +31,7 @@ import re
 from vsc.utils import fancylogger
 from vsc.utils.generaloption import simple_option
 from vsc.utils.rest import RestClient
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.github import GITHUB_API_URL, HTTP_STATUS_OK, GITHUB_EASYCONFIGS_REPO
 from easybuild.tools.github import GITHUB_EB_MAIN, fetch_github_token
 from easybuild.tools.options import EasyBuildOptions
@@ -54,7 +55,7 @@ def main():
     log = go.log
 
     if not (go.options.all or go.options.closed_pr or go.options.orphans):
-        log.error("Please tell me what to do?")
+        raise EasyBuildError("Please tell me what to do?")
 
     if go.options.github_user is None:
         eb_go = EasyBuildOptions(envvar_prefix='EASYBUILD', go_args=[])
@@ -64,7 +65,7 @@ def main():
         username = go.options.github_user
 
     if username is None:
-        log.error("Could not find a github username")
+        raise EasyBuildError("Could not find a github username")
     else:
         log.info("Using username = %s", username)
 
@@ -75,7 +76,7 @@ def main():
     status, gists = gh.gists.get(per_page=100)
 
     if status != HTTP_STATUS_OK:
-        log.error("Failed to get a lists of gists for user %s: error code %s, message = %s",
+        raise EasyBuildError("Failed to get a lists of gists for user %s: error code %s, message = %s",
                   username, status, gists)
     else:
         log.info("Found %s gists", len(gists))
@@ -102,7 +103,7 @@ def main():
                 if pr_num not in pr_cache:
                     status, pr = gh.repos[GITHUB_EB_MAIN][GITHUB_EASYCONFIGS_REPO].pulls[pr_num].get()
                     if status != HTTP_STATUS_OK:
-                        log.error("Failed to get pull-request #%s: error code %s, message = %s",
+                        raise EasyBuildError("Failed to get pull-request #%s: error code %s, message = %s",
                                   pr_num, status, pr)
                     pr_cache[pr_num] = pr["state"]
 
@@ -118,7 +119,7 @@ def main():
             status, del_gist = gh.gists[gist["id"]].delete()
 
             if status != HTTP_DELETE_OK:
-                log.error("Unable to remove gist (id=%s): error code %s, message = %s",
+                raise EasyBuildError("Unable to remove gist (id=%s): error code %s, message = %s",
                           gist["id"], status, del_gist)
             else:
                 log.info("Delete gist with id=%s", gist["id"])

--- a/easybuild/scripts/fix_broken_easyconfigs.py
+++ b/easybuild/scripts/fix_broken_easyconfigs.py
@@ -98,7 +98,7 @@ def process_easyconfig_file(ec_file):
                 os.rename(ec_file, backup_ec_file)
                 log.info("Backed up %s to %s" % (ec_file, backup_ec_file))
             except OSError, err:
-                log.error("Failed to backup %s before rewriting it: %s" % (ec_file, err))
+                raise EasyBuildError("Failed to backup %s before rewriting it: %s", ec_file, err)
 
         write_file(ec_file, fixed_ectxt)
         log.debug("Contents of fixed easyconfig file: %s" % fixed_ectxt)
@@ -124,15 +124,15 @@ try:
     try:
         import easybuild.easyblocks.generic.configuremake
     except ImportError, err:
-        log.error("easyblocks are not available in Python search path: %s" % err)
+        raise EasyBuildError("easyblocks are not available in Python search path: %s", err)
 
     for path in go.args:
         if not os.path.exists(path):
-            log.error("Non-existing path %s specified" % path)
+            raise EasyBuildError("Non-existing path %s specified", path)
 
     ec_files = [ec for p in go.args for ec in find_easyconfigs(p)]
     if not ec_files:
-        log.error("No easyconfig files specified")
+        raise EasyBuildError("No easyconfig files specified")
 
     log.info("Processing %d easyconfigs" % len(ec_files))
     for ec_file in ec_files:

--- a/easybuild/scripts/generate_software_list.py
+++ b/easybuild/scripts/generate_software_list.py
@@ -33,10 +33,10 @@ correctly by easybuild.
 from datetime import date
 from optparse import OptionParser
 
-import easybuild.tools.build_log  # ensure use of EasyBuildLog
 import easybuild.tools.config as config
 import easybuild.tools.options as eboptions
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, get_easyblock_class
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.github import Githubfs
 from vsc.utils import fancylogger
 
@@ -136,7 +136,7 @@ for root, subfolders, files in walk(options.path):
                 configs.append(ec)
                 names.append(ec.name)
         except Exception, err:
-            log.error("faulty easyconfig %s: %s" % (ec_file, err))
+            raise EasyBuildError("faulty easyconfig %s: %s", ec_file, err)
 
 log.info("Found easyconfigs: %s" % [x.name for x in configs])
 # sort by name

--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -32,6 +32,7 @@ Support for Clang as toolchain compiler.
 """
 
 import easybuild.tools.systemtools as systemtools
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.compiler import Compiler
 
 
@@ -98,6 +99,5 @@ class Clang(Compiler):
         super(Clang, self)._set_compiler_vars()
 
         if self.options.get('32bit', None):
-            self.log.raiseException("_set_compiler_vars: 32bit set, but no support yet for " \
-                                    "32bit Clang in EasyBuild")
+            raise EasyBuildError("_set_compiler_vars: 32bit set, but no support yet for 32bit Clang in EasyBuild")
 

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -30,6 +30,7 @@ Support for GCC (GNU Compiler Collection) as toolchain compiler.
 """
 
 import easybuild.tools.systemtools as systemtools
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.compiler import Compiler
 
 
@@ -83,8 +84,7 @@ class Gcc(Compiler):
         super(Gcc, self)._set_compiler_vars()
 
         if self.options.get('32bit', None):
-            self.log.raiseException("_set_compiler_vars: 32bit set, but no support yet for " \
-                                    "32bit GCC in EasyBuild")
+            raise EasyBuildError("_set_compiler_vars: 32bit set, but no support yet for 32bit GCC in EasyBuild")
 
         # to get rid of lots of problems with libgfortranbegin
         # or remove the system gcc-gfortran

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -32,6 +32,7 @@ Support for Intel compilers (icc, ifort) as toolchain compilers.
 from distutils.version import LooseVersion
 
 import easybuild.tools.systemtools as systemtools
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.compiler import Compiler
 
 
@@ -93,14 +94,15 @@ class IntelIccIfort(Compiler):
         super(IntelIccIfort, self)._set_compiler_vars()
 
         if not ('icc' in self.COMPILER_MODULE_NAME and 'ifort' in self.COMPILER_MODULE_NAME):
-            self.log.raiseException("_set_compiler_vars: missing icc and/or ifort from COMPILER_MODULE_NAME %s" % self.COMPILER_MODULE_NAME)
+            raise EasyBuildError("_set_compiler_vars: missing icc and/or ifort from COMPILER_MODULE_NAME %s",
+                                 self.COMPILER_MODULE_NAME)
 
         icc_root, _ = self.get_software_root(self.COMPILER_MODULE_NAME)
         icc_version, ifort_version = self.get_software_version(self.COMPILER_MODULE_NAME)
 
         if not ifort_version == icc_version:
-            msg = "_set_compiler_vars: mismatch between icc version %s and ifort version %s"
-            self.log.raiseException(msg % (icc_version, ifort_version))
+            raise EasyBuildError("_set_compiler_vars: mismatch between icc version %s and ifort version %s",
+                                 icc_version, ifort_version)
 
         if LooseVersion(icc_version) < LooseVersion('2011'):
             self.LIB_MULTITHREAD.insert(1, "guide")

--- a/easybuild/toolchains/fft/fftw.py
+++ b/easybuild/toolchains/fft/fftw.py
@@ -31,6 +31,7 @@ Support for FFTW (Fastest Fourier Transform in the West) as toolchain FFT librar
 
 from distutils.version import LooseVersion
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.fft import Fft
 
 
@@ -44,7 +45,7 @@ class Fftw(Fft):
         suffix = ''
         version = self.get_software_version(self.FFT_MODULE_NAME)[0]
         if LooseVersion(version) < LooseVersion('2') or LooseVersion(version) >= LooseVersion('4'):
-            self.log.raiseException("_set_fft_variables: FFTW unsupported version %s (major should be 2 or 3)" % version)
+            raise EasyBuildError("_set_fft_variables: FFTW unsupported version %s (major should be 2 or 3)", version)
         elif LooseVersion(version) > LooseVersion('2'):
             suffix = '3'
 

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -31,6 +31,7 @@ Support for Intel FFTW as toolchain FFT library.
 import os
 from distutils.version import LooseVersion
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.tools.modules import get_software_root, get_software_version
 
@@ -45,7 +46,7 @@ class IntelFFTW(Fftw):
 
     def _set_fftw_variables(self):
         if not hasattr(self, 'BLAS_LIB_DIR'):
-            self.log.raiseException("_set_fftw_variables: IntelFFT based on IntelMKL (no BLAS_LIB_DIR found)")
+            raise EasyBuildError("_set_fftw_variables: IntelFFT based on IntelMKL (no BLAS_LIB_DIR found)")
 
         imklver = get_software_version(self.FFT_MODULE_NAME[0])
 
@@ -60,7 +61,7 @@ class IntelFFTW(Fftw):
             if get_software_root('GCC'):
                 compsuff = '_gnu'
             else:
-                self.log.error("Not using Intel compilers or GCC, don't know compiler suffix for FFTW libraries.")
+                raise EasyBuildError("Not using Intel compilers or GCC, don't know compiler suffix for FFTW libraries.")
 
         fftw_libs = ["fftw3xc%s%s" % (compsuff, picsuff)]
         if self.options['usempi']:
@@ -89,6 +90,5 @@ class IntelFFTW(Fftw):
         if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
             self.FFT_LIB = fftw_libs
         else:
-            tup = (check_fftw_libs, fft_lib_dirs)
-            msg = "Not all FFTW interface libraries %s are found in %s, can't set FFT_LIB." % tup
-            self.log.error(msg)
+            raise EasyBuildError("Not all FFTW interface libraries %s are found in %s, can't set FFT_LIB.",
+                                 check_fftw_libs, fft_lib_dirs)

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -34,6 +34,7 @@ from distutils.version import LooseVersion
 
 from easybuild.toolchains.compiler.inteliccifort import TC_CONSTANT_INTELCOMP
 from easybuild.toolchains.compiler.gcc import TC_CONSTANT_GCC
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
@@ -60,7 +61,7 @@ class Acml(LinAlg):
     def _set_blas_variables(self):
         """Fix the map a bit"""
         if self.options.get('32bit', None):
-            self.log.raiseException("_set_blas_variables: 32bit ACML not (yet) supported")
+            raise EasyBuildError("_set_blas_variables: 32bit ACML not (yet) supported")
         try:
             for root in self.get_software_root(self.BLAS_MODULE_NAME):
                 subdirs = self.ACML_SUBDIRS_MAP[self.COMPILER_FAMILY]
@@ -69,8 +70,8 @@ class Acml(LinAlg):
                 incdirs = [os.path.join(x, 'include') for x in subdirs]
                 self.variables.append_exists('CPPFLAGS', root, incdirs, append_all=True)
         except:
-            self.log.raiseException(("_set_blas_variables: ACML set LDFLAGS/CPPFLAGS unknown entry in ACML_SUBDIRS_MAP"
-                                     " with compiler family %s") % self.COMPILER_FAMILY)
+            raise EasyBuildError("_set_blas_variables: ACML set LDFLAGS/CPPFLAGS unknown entry in ACML_SUBDIRS_MAP "
+                                 " with compiler family %s", self.COMPILER_FAMILY)
 
         # version before 5.x still featured the acml_mv library
         ver = self.get_software_version(self.BLAS_MODULE_NAME)[0]

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -71,7 +71,7 @@ class Acml(LinAlg):
                 self.variables.append_exists('CPPFLAGS', root, incdirs, append_all=True)
         except:
             raise EasyBuildError("_set_blas_variables: ACML set LDFLAGS/CPPFLAGS unknown entry in ACML_SUBDIRS_MAP "
-                                 " with compiler family %s", self.COMPILER_FAMILY)
+                                 "with compiler family %s", self.COMPILER_FAMILY)
 
         # version before 5.x still featured the acml_mv library
         ver = self.get_software_version(self.BLAS_MODULE_NAME)[0]

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -38,6 +38,7 @@ from easybuild.toolchains.mpi.mpich import TC_CONSTANT_MPICH
 from easybuild.toolchains.mpi.mpich2 import TC_CONSTANT_MPICH2
 from easybuild.toolchains.mpi.mvapich2 import TC_CONSTANT_MVAPICH2
 from easybuild.toolchains.mpi.openmpi import TC_CONSTANT_OPENMPI
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
@@ -84,8 +85,8 @@ class IntelMKL(LinAlg):
                 "interface": interfacemap[self.COMPILER_FAMILY],
             })
         except:
-            self.log.raiseException(("_set_blas_variables: interface unsupported combination"
-                                     " with MPI family %s") % self.COMPILER_FAMILY)
+            raise EasyBuildError("_set_blas_variables: interface unsupported combination with MPI family %s",
+                                 self.COMPILER_FAMILY)
 
         interfacemap_mt = {
             TC_CONSTANT_INTELCOMP: 'intel',
@@ -94,8 +95,8 @@ class IntelMKL(LinAlg):
         try:
             self.BLAS_LIB_MAP.update({"interface_mt":interfacemap_mt[self.COMPILER_FAMILY]})
         except:
-            self.log.raiseException(("_set_blas_variables: interface_mt unsupported combination "
-                                     "with compiler family %s") % self.COMPILER_FAMILY)
+            raise EasyBuildError("_set_blas_variables: interface_mt unsupported combination with compiler family %s",
+                                 self.COMPILER_FAMILY)
 
 
         if self.options.get('32bit', None):
@@ -117,8 +118,8 @@ class IntelMKL(LinAlg):
             self.BLAS_INCLUDE_DIR = ['include']
         else:
             if self.options.get('32bit', None):
-                self.log.raiseException(("_set_blas_variables: 32-bit libraries not supported yet "
-                                        "for IMKL v%s (> v10.3)") % found_version)
+                raise EasyBuildError("_set_blas_variables: 32-bit libraries not supported yet for IMKL v%s (> v10.3)",
+                                     found_version)
             else:
                 self.BLAS_LIB_DIR = ['mkl/lib/intel64', 'compiler/lib/intel64' ]
 
@@ -140,8 +141,8 @@ class IntelMKL(LinAlg):
         try:
             self.BLACS_LIB_MAP.update({'mpi': mpimap[self.MPI_FAMILY]})
         except:
-            self.log.raiseException(("_set_blacs_variables: mpi unsupported combination with"
-                                     " MPI family %s") % self.MPI_FAMILY)
+            raise EasyBuildError("_set_blacs_variables: mpi unsupported combination with MPI family %s",
+                                 self.MPI_FAMILY)
 
         self.BLACS_LIB_DIR = self.BLAS_LIB_DIR
         self.BLACS_INCLUDE_DIR = self.BLAS_INCLUDE_DIR
@@ -166,4 +167,3 @@ class IntelMKL(LinAlg):
         self.SCALAPACK_INCLUDE_DIR = self.BLAS_INCLUDE_DIR
 
         super(IntelMKL, self)._set_scalapack_variables()
-

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -126,7 +126,6 @@ class EasyBuildLog(fancylogger.FancyLogger):
             self.deprecated("Use 'raise EasyBuildError' rather than error() logging method that raises", '3.0')
             raise EasyBuildError(ebmsg, *args)
 
-    # note: self is deliberatly ignored
     def _error_no_raise(self, msg):
         """Utility function to log an error with raising an exception."""
         # make sure raising of error is disabled

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -125,13 +125,14 @@ class EasyBuildLog(fancylogger.FancyLogger):
             self.deprecated("Use 'raise EasyBuildError' rather than error() logging method that raises", '3.0')
             raise EasyBuildError(ebmsg, *args)
 
+    # FIXME: remove this when error() no longer raises EasyBuildError
     def _error_no_raise(self, msg):
         """Utility function to log an error with raising an exception."""
+
         # make sure raising of error is disabled
         orig_raise_error = self.raiseError
         self.raiseError = False
 
-        self.deprecated("Use of dedicated _error_no_raise log method", '3.0')
         self.error(msg)
 
         # reinstate previous raiseError setting

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -69,7 +69,6 @@ class EasyBuildError(LoggedException):
 
     def __str__(self):
         """Return string representation of this EasyBuildError instance."""
-        print '__str__'
         return repr(self.msg)
 
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -43,8 +43,8 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import nub, FrozenDictKnownKeys
 from vsc.utils.patterns import Singleton
 
-import easybuild.tools.build_log  # this import is required to obtain a correct (EasyBuild) logger!
 import easybuild.tools.environment as env
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import read_environment as _read_environment
 from easybuild.tools.run import run_cmd
 
@@ -201,8 +201,7 @@ class ConfigurationVariables(FrozenDictKnownKeys):
         """
         missing = [x for x in self.KNOWN_KEYS if not x in self]
         if len(missing) > 0:
-            msg = 'Cannot determine value for configuration variables %s. Please specify it.' % missing
-            self.log.error(msg)
+            raise EasyBuildError("Cannot determine value for configuration variables %s. Please specify it.", missing)
 
         return self.items()
 
@@ -234,7 +233,7 @@ def init(options, config_options_dict):
         tmpdict['sourcepath'] = sourcepath.split(':')
         _log.debug("Converted source path ('%s') to a list of paths: %s" % (sourcepath, tmpdict['sourcepath']))
     elif not isinstance(sourcepath, (tuple, list)):
-        _log.error("Value for sourcepath has invalid type (%s): %s" % (type(sourcepath), sourcepath))
+        raise EasyBuildError("Value for sourcepath has invalid type (%s): %s", type(sourcepath), sourcepath)
 
     # initialize configuration variables (any future calls to ConfigurationVariables() will yield the same instance
     variables = ConfigurationVariables(tmpdict, ignore_unknown_keys=True)
@@ -451,7 +450,7 @@ def set_tmpdir(tmpdir=None, raise_error=False):
             # use tempfile default parent dir
             current_tmpdir = tempfile.mkdtemp(prefix='eb-')
     except OSError, err:
-        _log.error("Failed to create temporary directory (tmpdir: %s): %s" % (tmpdir, err))
+        raise EasyBuildError("Failed to create temporary directory (tmpdir: %s): %s", tmpdir, err)
 
     _log.info("Temporary directory used in this EasyBuild run: %s" % current_tmpdir)
 
@@ -470,7 +469,7 @@ def set_tmpdir(tmpdir=None, raise_error=False):
             msg = "The temporary directory (%s) does not allow to execute files. " % tempfile.gettempdir()
             msg += "This can cause problems in the build process, consider using --tmpdir."
             if raise_error:
-                _log.error(msg)
+                raise EasyBuildError(msg)
             else:
                 _log.warning(msg)
         else:
@@ -478,6 +477,6 @@ def set_tmpdir(tmpdir=None, raise_error=False):
         os.remove(tmptest_file)
 
     except OSError, err:
-        _log.error("Failed to test whether temporary directory allows to execute files: %s" % err)
+        raise EasyBuildError("Failed to test whether temporary directory allows to execute files: %s", err)
 
     return current_tmpdir

--- a/easybuild/tools/convert.py
+++ b/easybuild/tools/convert.py
@@ -34,6 +34,9 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import get_subclasses, nub
 from vsc.utils.wrapper import Wrapper
 
+from easybuild.tools.build_log import EasyBuildError
+
+
 _log = fancylogger.getLogger('tools.convert', fname=False)
 
 
@@ -56,7 +59,7 @@ class Convert(Wrapper):
         if isinstance(obj, basestring):
             self.data = self._from_string(obj)
         else:
-            self.log.error('unsupported type %s for %s: %s' % (type(obj), self.__class__.__name__, obj))
+            raise EasyBuildError('unsupported type %s for %s: %s', type(obj), self.__class__.__name__, obj)
         super(Convert, self).__init__(self.data)
 
     def _split_string(self, txt, sep=None, max=0):
@@ -66,7 +69,7 @@ class Convert(Wrapper):
         """
         if sep is None:
             if self.SEPARATOR is None:
-                self.log.error('No SEPARATOR set, also no separator passed')
+                raise EasyBuildError('No SEPARATOR set, also no separator passed')
             else:
                 sep = self.SEPARATOR
         return [x.strip() for x in re.split(r'' + sep, txt, maxsplit=max)]
@@ -221,4 +224,4 @@ def get_convert_class(class_name):
     if len(res) == 1:
         return res[0]
     else:
-        _log.error('More then one Convert subclass found for name %s: %s' % (class_name, res))
+        raise EasyBuildError('More then one Convert subclass found for name %s: %s', class_name, res)

--- a/easybuild/tools/convert.py
+++ b/easybuild/tools/convert.py
@@ -59,7 +59,7 @@ class Convert(Wrapper):
         if isinstance(obj, basestring):
             self.data = self._from_string(obj)
         else:
-            raise EasyBuildError('unsupported type %s for %s: %s', type(obj), self.__class__.__name__, obj)
+            raise EasyBuildError("unsupported type %s for %s: %s", type(obj), self.__class__.__name__, obj)
         super(Convert, self).__init__(self.data)
 
     def _split_string(self, txt, sep=None, max=0):
@@ -69,7 +69,7 @@ class Convert(Wrapper):
         """
         if sep is None:
             if self.SEPARATOR is None:
-                raise EasyBuildError('No SEPARATOR set, also no separator passed')
+                raise EasyBuildError("No SEPARATOR set, also no separator passed")
             else:
                 sep = self.SEPARATOR
         return [x.strip() for x in re.split(r'' + sep, txt, maxsplit=max)]
@@ -224,4 +224,4 @@ def get_convert_class(class_name):
     if len(res) == 1:
         return res[0]
     else:
-        raise EasyBuildError('More then one Convert subclass found for name %s: %s', class_name, res)
+        raise EasyBuildError("More than one Convert subclass found for name %s: %s", class_name, res)

--- a/easybuild/tools/environment.py
+++ b/easybuild/tools/environment.py
@@ -32,6 +32,8 @@ import os
 from vsc.utils import fancylogger
 from vsc.utils.missing import shell_quote
 
+from easybuild.tools.build_log import EasyBuildError
+
 
 _log = fancylogger.getLogger('environment', fname=False)
 
@@ -53,7 +55,7 @@ def write_changes(filename):
     except IOError, err:
         if script is not None:
             script.close()
-        _log.error("Failed to write to %s: %s" % (filename, err))
+        raise EasyBuildError("Failed to write to %s: %s", filename, err)
     reset_changes()
 
 
@@ -120,7 +122,7 @@ def read_environment(env_vars, strict=False):
         missing = ','.join(["%s / %s" % (k, v) for k, v in env_vars.items() if not k in result])
         msg = 'Following name/variable not found in environment: %s' % missing
         if strict:
-            _log.error(msg)
+            raise EasyBuildError(msg)
         else:
             _log.debug(msg)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -905,7 +905,8 @@ def move_logs(src_logfile, target_logfile):
             _log.info("Moved log file %s to %s" % (src_logfile, new_log_path))
 
     except (IOError, OSError), err:
-        _log.error("Failed to move log file(s) %s* to new log file %s*: %s" % (src_logfile, target_logfile, err))
+        raise EasyBuildError("Failed to move log file(s) %s* to new log file %s*: %s" ,
+                             src_logfile, target_logfile, err)
 
 
 def cleanup(logfile, tempdir, testing):
@@ -915,14 +916,14 @@ def cleanup(logfile, tempdir, testing):
             for log in glob.glob('%s*' % logfile):
                 os.remove(log)
         except OSError, err:
-            _log.error("Failed to remove log file(s) %s*: %s" % (logfile, err))
+            raise EasyBuildError("Failed to remove log file(s) %s*: %s", logfile, err)
         print_msg('temporary log file(s) %s* have been removed.' % (logfile), log=None, silent=testing)
 
     if not testing and tempdir is not None:
         try:
             shutil.rmtree(tempdir, ignore_errors=True)
         except OSError, err:
-            _log.error("Failed to remove temporary directory %s: %s" % (tempdir, err))
+            raise EasyBuildError("Failed to remove temporary directory %s: %s", tempdir, err)
         print_msg('temporary directory %s has been removed.' % (tempdir), log=None, silent=testing)
 
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -44,7 +44,7 @@ import zlib
 from vsc.utils import fancylogger
 
 import easybuild.tools.environment as env
-from easybuild.tools.build_log import EasyBuildError, print_msg  # import build_log must stay, to activate use of EasyBuildLog
+from easybuild.tools.build_log import EasyBuildError, print_msg  # import build_log must stay, to use of EasyBuildLog
 from easybuild.tools.config import build_option
 from easybuild.tools import run
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -44,7 +44,7 @@ import zlib
 from vsc.utils import fancylogger
 
 import easybuild.tools.environment as env
-from easybuild.tools.build_log import print_msg  # import build_log must stay, to activate use of EasyBuildLog
+from easybuild.tools.build_log import EasyBuildError, print_msg  # import build_log must stay, to activate use of EasyBuildLog
 from easybuild.tools.config import build_option
 from easybuild.tools import run
 
@@ -147,7 +147,7 @@ def read_file(path, log_error=True):
         if f is not None:
             f.close()
         if log_error:
-            _log.error("Failed to read %s: %s" % (path, err))
+            raise EasyBuildError("Failed to read %s: %s", path, err)
         else:
             return None
 
@@ -168,7 +168,7 @@ def write_file(path, txt, append=False):
         # make sure file handle is always closed
         if f is not None:
             f.close()
-        _log.error("Failed to write to %s: %s" % (path, err))
+        raise EasyBuildError("Failed to write to %s: %s", path, err)
 
 
 def remove_file(path):
@@ -177,7 +177,7 @@ def remove_file(path):
         if os.path.exists(path):
             os.remove(path)
     except OSError, err:
-          _log.error("Failed to remove %s: %s", path, err)
+          raise EasyBuildError("Failed to remove %s: %s", path, err)
 
 
 def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
@@ -186,7 +186,7 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
     - returns the directory name in case of success
     """
     if not os.path.isfile(fn):
-        _log.error("Can't extract file %s: no such file" % fn)
+        raise EasyBuildError("Can't extract file %s: no such file", fn)
 
     mkdir(dest, parents=True)
 
@@ -198,7 +198,7 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
         _log.debug("Unpacking %s in directory %s." % (fn, absDest))
         os.chdir(absDest)
     except OSError, err:
-        _log.error("Can't change to directory %s: %s" % (absDest, err))
+        raise EasyBuildError("Can't change to directory %s: %s", absDest, err)
 
     if not cmd:
         cmd = extract_cmd(fn, overwrite=overwrite)
@@ -206,7 +206,7 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
         # complete command template with filename
         cmd = cmd % fn
     if not cmd:
-        _log.error("Can't extract file %s with unknown filetype" % fn)
+        raise EasyBuildError("Can't extract file %s with unknown filetype", fn)
 
     if extra_options:
         cmd = "%s %s" % (cmd, extra_options)
@@ -232,7 +232,7 @@ def which(cmd):
 def det_common_path_prefix(paths):
     """Determine common path prefix for a given list of paths."""
     if not isinstance(paths, list):
-        _log.error("det_common_path_prefix: argument must be of type list (got %s: %s)" % (type(paths), paths))
+        raise EasyBuildError("det_common_path_prefix: argument must be of type list (got %s: %s)", type(paths), paths)
     elif not paths:
         return None
 
@@ -290,7 +290,7 @@ def download_file(filename, url, path):
             _log.warning("IOError occurred while trying to download %s to %s: %s" % (url, path, err))
             attempt_cnt += 1
         except Exception, err:
-            _log.error("Unexpected error occurred when trying to download %s to %s: %s" % (url, path, err))
+            raise EasyBuildError("Unexpected error occurred when trying to download %s to %s: %s", url, path, err)
 
         if not downloaded and attempt_cnt < max_attempts:
             _log.info("Attempt %d of downloading %s to %s failed, trying again..." % (attempt_cnt, url, path))
@@ -338,7 +338,8 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False):
     if ignore_dirs is None:
         ignore_dirs = ['.git', '.svn']
     if not isinstance(ignore_dirs, list):
-        _log.error("search_file: ignore_dirs (%s) should be of type list, not %s" % (ignore_dirs, type(ignore_dirs)))
+        raise EasyBuildError("search_file: ignore_dirs (%s) should be of type list, not %s",
+                             ignore_dirs, type(ignore_dirs))
 
     var_lines = []
     hit_lines = []
@@ -386,12 +387,13 @@ def compute_checksum(path, checksum_type=DEFAULT_CHECKSUM):
     @param checksum_type: Type of checksum ('adler32', 'crc32', 'md5' (default), 'sha1', 'size')
     """
     if not checksum_type in CHECKSUM_FUNCTIONS:
-        _log.error("Unknown checksum type (%s), supported types are: %s" % (checksum_type, CHECKSUM_FUNCTIONS.keys()))
+        raise EasyBuildError("Unknown checksum type (%s), supported types are: %s",
+                             checksum_type, CHECKSUM_FUNCTIONS.keys())
 
     try:
         checksum = CHECKSUM_FUNCTIONS[checksum_type](path)
     except IOError, err:
-        _log.error("Failed to read %s: %s" % (path, err))
+        raise EasyBuildError("Failed to read %s: %s", path, err)
     except MemoryError, err:
         _log.warning("A memory error occured when computing the checksum for %s: %s" % (path, err))
         checksum = 'dummy_checksum_due_to_memory_error'
@@ -416,7 +418,7 @@ def calc_block_checksum(path, algorithm):
             algorithm.update(block)
         f.close()
     except IOError, err:
-        _log.error("Failed to read %s: %s" % (path, err))
+        raise EasyBuildError("Failed to read %s: %s", path, err)
 
     return algorithm.hexdigest()
 
@@ -443,7 +445,8 @@ def verify_checksum(path, checksums):
         elif isinstance(checksum, tuple) and len(checksum) == 2:
             typ, checksum = checksum
         else:
-            _log.error("Invalid checksum spec '%s', should be a string (MD5) or 2-tuple (type, value)." % checksum)
+            raise EasyBuildError("Invalid checksum spec '%s', should be a string (MD5) or 2-tuple (type, value).",
+                                 checksum)
 
         actual_checksum = compute_checksum(path, typ)
         _log.debug("Computed %s checksum for %s: %s (correct checksum: %s)" % (typ, path, actual_checksum, checksum))
@@ -482,7 +485,7 @@ def find_base_dir():
         try:
             os.chdir(new_dir)
         except OSError, err:
-            _log.exception("Changing to dir %s from current dir %s failed: %s" % (new_dir, os.getcwd(), err))
+            raise EasyBuildError("Changing to dir %s from current dir %s failed: %s", new_dir, os.getcwd(), err)
         lst = get_local_dirs_purged()
 
     # make sure it's a directory, and not a (single) file that was in a tarball for example
@@ -548,7 +551,7 @@ def extract_cmd(filepath, overwrite=False):
             cmd_tmpl = "unzip -qq %(filepath)s"
 
     if cmd_tmpl is None:
-        _log.error('Unknown file type for file %s (%s)' % (filepath, exts))
+        raise EasyBuildError('Unknown file type for file %s (%s)', filepath, exts)
 
     return cmd_tmpl % {'filepath': filepath, 'target': target}
 
@@ -564,9 +567,9 @@ def det_patched_files(path=None, txt=None, omit_ab_prefix=False):
             txt = f.read()
             f.close()
         except IOError, err:
-            _log.error("Failed to read patch %s: %s" % (path, err))
+            raise EasyBuildError("Failed to read patch %s: %s", path, err)
     elif txt is None:
-        _log.error("Either a file path or a string representing a patch should be supplied to det_patched_files")
+        raise EasyBuildError("Either a file path or a string representing a patch should be supplied")
 
     patched_files = []
     for match in patched_regex.finditer(txt):
@@ -611,15 +614,15 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None):
     """
 
     if not os.path.isfile(patch_file):
-        _log.error("Can't find patch %s: no such file" % patch_file)
+        raise EasyBuildError("Can't find patch %s: no such file", patch_file)
         return
 
     if fn and not os.path.isfile(fn):
-        _log.error("Can't patch file %s: no such file" % fn)
+        raise EasyBuildError("Can't patch file %s: no such file", fn)
         return
 
     if not os.path.isdir(dest):
-        _log.error("Can't patch directory %s: no such directory" % dest)
+        raise EasyBuildError("Can't patch directory %s: no such directory", dest)
         return
 
     # copy missing files
@@ -629,7 +632,7 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None):
             _log.debug("Copied patch %s to dir %s" % (patch_file, dest))
             return 'ok'
         except IOError, err:
-            _log.error("Failed to copy %s to dir %s: %s" % (patch_file, dest, err))
+            raise EasyBuildError("Failed to copy %s to dir %s: %s", patch_file, dest, err)
             return
 
     # use absolute paths
@@ -644,14 +647,14 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None):
         patched_files = det_patched_files(path=apatch)
 
         if not patched_files:
-            _log.error("Can't guess patchlevel from patch %s: no testfile line found in patch" % apatch)
+            raise EasyBuildError("Can't guess patchlevel from patch %s: no testfile line found in patch", apatch)
             return
 
         patch_level = guess_patch_level(patched_files, adest)
 
         if patch_level is None:  # patch_level can also be 0 (zero), so don't use "not patch_level"
             # no match
-            _log.error("Can't determine patch level for patch %s from directory %s" % (patch_file, adest))
+            raise EasyBuildError("Can't determine patch level for patch %s from directory %s", patch_file, adest)
         else:
             _log.debug("Guessed patch level %d for patch %s" % (patch_level, patch_file))
 
@@ -663,13 +666,13 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None):
         os.chdir(adest)
         _log.debug("Changing to directory %s" % adest)
     except OSError, err:
-        _log.error("Can't change to directory %s: %s" % (adest, err))
+        raise EasyBuildError("Can't change to directory %s: %s", adest, err)
         return
 
     patch_cmd = "patch -b -p%d -i %s" % (patch_level, apatch)
     result = run.run_cmd(patch_cmd, simple=True)
     if not result:
-        _log.error("Patching with patch %s failed" % patch_file)
+        raise EasyBuildError("Patching with patch %s failed", patch_file)
         return
 
     return result
@@ -761,14 +764,14 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
                 failed_paths.append(path)
 
     if failed_paths:
-        _log.error("Failed to chmod/chown several paths: %s (last error: %s)" % (failed_paths, err))
+        raise EasyBuildError("Failed to chmod/chown several paths: %s (last error: %s)", failed_paths, err)
 
     # we ignore some errors, but if there are to many, something is definitely wrong
     fail_ratio = fail_cnt / float(len(allpaths))
     max_fail_ratio = 0.5
     if fail_ratio > max_fail_ratio:
-        _log.error("%.2f%% of permissions/owner operations failed (more than %.2f%%), something must be wrong..." %
-                  (100 * fail_ratio, 100 * max_fail_ratio))
+        raise EasyBuildError("%.2f%% of permissions/owner operations failed (more than %.2f%%), "
+                             "something must be wrong...", 100 * fail_ratio, 100 * max_fail_ratio)
     elif fail_cnt > 0:
         _log.debug("%.2f%% of permissions/owner operations failed, ignoring that..." % (100 * fail_ratio))
 
@@ -813,8 +816,7 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
 
     # exit early if path already exists
     if not os.path.exists(path):
-        tup = (path, parents, set_gid, sticky)
-        _log.info("Creating directory %s (parents: %s, set_gid: %s, sticky: %s)" % tup)
+        _log.info("Creating directory %s (parents: %s, set_gid: %s, sticky: %s)", path, parents, set_gid, sticky)
         # set_gid and sticky bits are only set on new directories, so we need to determine the existing parent path
         existing_parent_path = os.path.dirname(path)
         try:
@@ -826,7 +828,7 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
             else:
                 os.mkdir(path)
         except OSError, err:
-            _log.error("Failed to create directory %s: %s" % (path, err))
+            raise EasyBuildError("Failed to create directory %s: %s", path, err)
 
         # set group ID and sticky bits, if desired
         bits = 0
@@ -840,7 +842,7 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
                 new_path = os.path.join(existing_parent_path, new_subdir.split(os.path.sep)[0])
                 adjust_permissions(new_path, bits, add=True, relative=True, recursive=True, onlydirs=True)
             except OSError, err:
-                _log.error("Failed to set groud ID/sticky bit: %s" % err)
+                raise EasyBuildError("Failed to set groud ID/sticky bit: %s", err)
     else:
         _log.debug("Not creating existing path %s" % path)
 
@@ -868,7 +870,7 @@ def rmtree2(path, n=3):
             _log.debug("Failed to remove path %s with shutil.rmtree at attempt %d: %s" % (path, n, err))
             time.sleep(2)
     if not ok:
-        _log.error("Failed to remove path %s with shutil.rmtree, even after %d attempts." % (path, n))
+        raise EasyBuildError("Failed to remove path %s with shutil.rmtree, even after %d attempts.", path, n)
     else:
         _log.info("Path %s successfully removed." % path)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -191,14 +191,14 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
     mkdir(dest, parents=True)
 
     # use absolute pathnames from now on
-    absDest = os.path.abspath(dest)
+    abs_dest = os.path.abspath(dest)
 
     # change working directory
     try:
-        _log.debug("Unpacking %s in directory %s." % (fn, absDest))
-        os.chdir(absDest)
+        _log.debug("Unpacking %s in directory %s.", fn, abs_dest)
+        os.chdir(abs_dest)
     except OSError, err:
-        raise EasyBuildError("Can't change to directory %s: %s", absDest, err)
+        raise EasyBuildError("Can't change to directory %s: %s", abs_dest, err)
 
     if not cmd:
         cmd = extract_cmd(fn, overwrite=overwrite)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -37,6 +37,8 @@ import urllib2
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
 
+from easybuild.tools.build_log import EasyBuildError
+
 
 _log = fancylogger.getLogger('github', fname=False)
 
@@ -140,7 +142,7 @@ class Githubfs(object):
             return listing[1]
         else:
             self.log.warning("error: %s" % str(listing))
-            self.log.exception("Invalid response from github (I/O error)")
+            raise EasyBuildError("Invalid response from github (I/O error)")
 
     def walk(self, top=None, topdown=True):
         """
@@ -205,15 +207,15 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
                 _, httpmsg = urllib.urlretrieve(url, path)
                 _log.debug("Downloaded %s to %s" % (url, path))
             except IOError, err:
-                _log.error("Failed to download %s to %s: %s" % (url, path, err))
+                raise EasyBuildError("Failed to download %s to %s: %s", url, path, err)
 
             if not httpmsg.type == 'text/plain':
-                _log.error("Unexpected file type for %s: %s" % (path, httpmsg.type))
+                raise EasyBuildError("Unexpected file type for %s: %s", path, httpmsg.type)
         else:
             try:
                 return urllib2.urlopen(url).read()
             except urllib2.URLError, err:
-                _log.error("Failed to open %s for reading: %s" % (url, err))
+                raise EasyBuildError("Failed to open %s for reading: %s", url, err)
 
     # a GitHub token is optional here, but can be used if available in order to be less susceptible to rate limiting
     github_token = fetch_github_token(github_user)
@@ -235,14 +237,14 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
         status, pr_data = 0, None
     _log.debug("status: %d, data: %s" % (status, pr_data))
     if not status == HTTP_STATUS_OK:
-        tup = (pr, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, status, pr_data)
-        _log.error("Failed to get data for PR #%d from %s/%s (status: %d %s)" % tup)
+        raise EasyBuildError("Failed to get data for PR #%d from %s/%s (status: %d %s)",
+                             pr, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, status, pr_data)
 
     # 'clean' on successful (or missing) test, 'unstable' on failed tests
     stable = pr_data['mergeable_state'] == GITHUB_MERGEABLE_STATE_CLEAN
     if not stable:
-        tup = (pr, GITHUB_MERGEABLE_STATE_CLEAN, pr_data['mergeable_state'])
-        _log.warning("Mergeable state for PR #%d is not '%s': %s." % tup)
+        _log.warning("Mergeable state for PR #%d is not '%s': %s.",
+                     pr, GITHUB_MERGEABLE_STATE_CLEAN, pr_data['mergeable_state'])
 
     for key, val in sorted(pr_data.items()):
         _log.debug("\n%s:\n\n%s\n" % (key, val))
@@ -256,7 +258,7 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     # obtain last commit
     # get all commits, increase to (max of) 100 per page
     if pr_data['commits'] > GITHUB_MAX_PER_PAGE:
-        _log.error("PR #%s contains more than %s commits, can't obtain last commit" % (pr, GITHUB_MAX_PER_PAGE))
+        raise EasyBuildError("PR #%s contains more than %s commits, can't obtain last commit", pr, GITHUB_MAX_PER_PAGE)
     status, commits_data = pr_url.commits.get(per_page=GITHUB_MAX_PER_PAGE)
     last_commit = commits_data[-1]
     _log.debug("Commits: %s, last commit: %s" % (commits_data, last_commit['sha']))
@@ -272,7 +274,7 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     all_files = [os.path.basename(x) for x in patched_files]
     tmp_files = os.listdir(path)
     if not sorted(tmp_files) == sorted(all_files):
-        _log.error("Not all patched files were downloaded to %s: %s vs %s" % (path, tmp_files, all_files))
+        raise EasyBuildError("Not all patched files were downloaded to %s: %s vs %s", path, tmp_files, all_files)
 
     ec_files = [os.path.join(path, fn) for fn in tmp_files]
 
@@ -298,7 +300,7 @@ def create_gist(txt, fn, descr=None, github_user=None):
     status, data = g.gists.post(body=body)
 
     if not status == HTTP_STATUS_CREATED:
-        _log.error("Failed to create gist; status %s, data: %s" % (status, data))
+        raise EasyBuildError("Failed to create gist; status %s, data: %s", status, data)
 
     return data['html_url']
 
@@ -309,7 +311,7 @@ def post_comment_in_issue(issue, txt, repo=GITHUB_EASYCONFIGS_REPO, github_user=
         try:
             issue = int(issue)
         except ValueError, err:
-            _log.error("Failed to parse specified pull request number '%s' as an int: %s; " % (issue, err))
+            raise EasyBuildError("Failed to parse specified pull request number '%s' as an int: %s; ", issue, err)
     github_token = fetch_github_token(github_user)
 
     g = RestClient(GITHUB_API_URL, username=github_user, token=github_token)
@@ -317,7 +319,7 @@ def post_comment_in_issue(issue, txt, repo=GITHUB_EASYCONFIGS_REPO, github_user=
 
     status, data = pr_url.comments.post(body={'body': txt})
     if not status == HTTP_STATUS_CREATED:
-        _log.error("Failed to create comment in PR %s#%d; status %s, data: %s" % (repo, issue, status, data))
+        raise EasyBuildError("Failed to create comment in PR %s#%d; status %s, data: %s", repo, issue, status, data)
 
 
 class GithubToken(object):

--- a/easybuild/tools/jenkins.py
+++ b/easybuild/tools/jenkins.py
@@ -34,6 +34,7 @@ import xml.dom.minidom as xml
 from datetime import datetime
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.version import FRAMEWORK_VERSION, EASYBLOCKS_VERSION
 
 
@@ -108,7 +109,7 @@ def write_to_xml(succes, failed, filename):
         root.writexml(output_file)
         output_file.close()
     except IOError, err:
-        _log.error("Failed to write out XML file %s: %s" % (filename, err))
+        raise EasyBuildError("Failed to write out XML file %s: %s", filename, err)
 
 
 def aggregate_xml_in_dirs(base_dir, output_filename):
@@ -149,7 +150,7 @@ def aggregate_xml_in_dirs(base_dir, output_filename):
             try:
                 dom = xml.parse(xml_file)
             except IOError, err:
-                _log.error("Failed to read/parse XML file %s: %s" % (xml_file, err))
+                raise EasyBuildError("Failed to read/parse XML file %s: %s", xml_file, err)
             # only one should be present, we are just discarding the rest
             testcase = dom.getElementsByTagName("testcase")[0]
             root.firstChild.appendChild(testcase)
@@ -165,6 +166,6 @@ def aggregate_xml_in_dirs(base_dir, output_filename):
         root.writexml(output_file, addindent="\t", newl="\n")
         output_file.close()
     except IOError, err:
-        _log.error("Failed to write out XML file %s: %s" % (output_filename, err))
+        raise EasyBuildError("Failed to write out XML file %s: %s", output_filename, err)
 
     print "Aggregate regtest results written to %s" % output_filename

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -39,6 +39,7 @@ from vsc.utils import fancylogger
 
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS
 from easybuild.tools import config
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.module_naming_scheme.utilities import det_hidden_modname
@@ -95,7 +96,8 @@ class ModuleGenerator(object):
                     os.remove(class_mod_file)
                 os.symlink(self.filename, class_mod_file)
         except OSError, err:
-            _log.error("Failed to create symlinks from %s to %s: %s" % (self.class_mod_files, self.filename, err))
+            raise EasyBuildError("Failed to create symlinks from %s to %s: %s",
+                                 self.class_mod_files, self.filename, err)
 
     def get_description(self, conflict=True):
         """
@@ -186,7 +188,8 @@ class ModuleGenerator(object):
         # make sure only relative paths are passed
         for i in xrange(len(paths)):
             if os.path.isabs(paths[i]) and not allow_abs:
-                _log.error("Absolute path %s passed to prepend_paths which only expects relative paths." % paths[i])
+                raise EasyBuildError("Absolute path %s passed to prepend_paths which only expects relative paths.",
+                                     paths[i])
             elif not os.path.isabs(paths[i]):
                 # prepend $root (= installdir) for relative paths
                 paths[i] = "$root/%s" % paths[i]

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -33,6 +33,7 @@ import os
 import re
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.module_naming_scheme import ModuleNamingScheme
 from easybuild.tools.module_naming_scheme.toolchain import det_toolchain_compilers, det_toolchain_mpi
 
@@ -102,9 +103,10 @@ class HierarchicalMNS(ModuleNamingScheme):
                 tc_comp_ver = tc_comp_ver_tmpl % comp_versions
                 # make sure that icc/ifort versions match
                 if tc_comp_name == 'intel' and comp_versions['icc'] != comp_versions['ifort']:
-                    self.log.error("Bumped into different versions for Intel compilers: %s" % comp_versions)
+                    raise EasyBuildError("Bumped into different versions for Intel compilers: %s", comp_versions)
             else:
-                self.log.error("Unknown set of toolchain compilers, module naming scheme needs work: %s" % comp_names)
+                raise EasyBuildError("Unknown set of toolchain compilers, module naming scheme needs work: %s",
+                                     comp_names)
             res = (tc_comp_name, tc_comp_ver)
         return res
 
@@ -180,10 +182,9 @@ class HierarchicalMNS(ModuleNamingScheme):
 
         elif modclass == MODULECLASS_MPI:
             if tc_comp_info is None:
-                tup = (ec['toolchain'], ec['name'], ec['version'])
-                error_msg = ("No compiler available in toolchain %s used to install MPI library %s v%s, "
-                             "which is required by the active module naming scheme.") % tup
-                self.log.error(error_msg)
+                raise EasyBuildError("No compiler available in toolchain %s used to install MPI library %s v%s, "
+                                     "which is required by the active module naming scheme.",
+                                     ec['toolchain'], ec['name'], ec['version'])
             else:
                 tc_comp_name, tc_comp_ver = tc_comp_info
                 fullver = self.det_full_version(ec)

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -32,6 +32,8 @@ import re
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
 
+from easybuild.tools.build_log import EasyBuildError
+
 
 class ModuleNamingScheme(object):
     """Abstract class for a module naming scheme implementation."""
@@ -50,7 +52,8 @@ class ModuleNamingScheme(object):
         if self.REQUIRED_KEYS is not None:
             return set(keys).issuperset(set(self.REQUIRED_KEYS))
         else:
-            self.log.error("Constant REQUIRED_KEYS is not defined, should specify required easyconfig parameters.")
+            raise EasyBuildError("Constant REQUIRED_KEYS is not defined, "
+                                 "should specify required easyconfig parameters.")
 
     def requires_toolchain_details(self):
         """
@@ -134,7 +137,7 @@ class ModuleNamingScheme(object):
         modname_regex = re.compile('^%s/\S+$' % re.escape(name))
         res = bool(modname_regex.match(short_modname))
 
-        tup = (short_modname, name, modname_regex.pattern, res)
-        self.log.debug("Checking whether '%s' is a module name for software with name '%s' via regex %s: %s" % tup)
+        self.log.debug("Checking whether '%s' is a module name for software with name '%s' via regex %s: %s",
+                       short_modname, name, modname_regex.pattern, res)
 
         return res

--- a/easybuild/tools/module_naming_scheme/toolchain.py
+++ b/easybuild/tools/module_naming_scheme/toolchain.py
@@ -30,6 +30,7 @@ Toolchain querying support for module naming schemes.
 from vsc.utils import fancylogger
 
 from easybuild.framework.easyconfig.easyconfig import process_easyconfig, robot_find_easyconfig
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 
@@ -77,7 +78,7 @@ def det_toolchain_element_details(tc, elem):
         if tc_ec['name'] == elem:
             tc_elem_details = tc_ec
         else:
-            _log.error("No toolchain element '%s' found for toolchain %s: %s" % (elem, tc.as_dict(), tc_ec))
+            raise EasyBuildError("No toolchain element '%s' found for toolchain %s: %s", elem, tc.as_dict(), tc_ec)
     _toolchain_details_cache[key] = tc_elem_details
     _log.debug("Obtained details for '%s' in toolchain '%s', added to cache" % (elem, tc_dict))
     return _toolchain_details_cache[key]
@@ -95,14 +96,15 @@ def det_toolchain_compilers(ec):
         tc_comps = None
     elif not TOOLCHAIN_COMPILER in tc_elems:
         # every toolchain should have at least a compiler
-        _log.error("No compiler found in toolchain %s: %s" % (ec.toolchain.as_dict(), tc_elems))
+        raise EasyBuildError("No compiler found in toolchain %s: %s", ec.toolchain.as_dict(), tc_elems)
     elif tc_elems[TOOLCHAIN_COMPILER]:
         tc_comps = []
         for comp_elem in tc_elems[TOOLCHAIN_COMPILER]:
             tc_comps.append(det_toolchain_element_details(ec.toolchain, comp_elem))
     else:
-        _log.error("Empty list of compilers for %s toolchain definition: %s" % (ec.toolchain.as_dict(), tc_elems))
-    _log.debug("Found compilers %s for toolchain %s (%s)" % (tc_comps, ec.toolchain.name, ec.toolchain.as_dict()))
+        raise EasyBuildError("Empty list of compilers for %s toolchain definition: %s",
+                             ec.toolchain.as_dict(), tc_elems)
+    _log.debug("Found compilers %s for toolchain %s (%s)", tc_comps, ec.toolchain.name, ec.toolchain.as_dict())
 
     return tc_comps
 
@@ -116,7 +118,8 @@ def det_toolchain_mpi(ec):
     tc_elems = ec.toolchain.definition()
     if TOOLCHAIN_MPI in tc_elems:
         if not tc_elems[TOOLCHAIN_MPI]:
-            _log.error("Empty list of MPI libs for %s toolchain definition: %s" % (ec.toolchain.as_dict(), tc_elems))
+            raise EasyBuildError("Empty list of MPI libs for %s toolchain definition: %s",
+                                 ec.toolchain.as_dict(), tc_elems)
         # assumption: only one MPI toolchain element
         tc_mpi = det_toolchain_element_details(ec.toolchain, tc_elems[TOOLCHAIN_MPI][0])
     else:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -491,8 +491,8 @@ class ModulesTool(object):
         cmdlist = [self.cmd, 'python']
         if self.COMMAND_SHELL is not None:
             if not isinstance(self.COMMAND_SHELL, (list, tuple)):
-                msg = 'COMMAND_SHELL needs to be list or tuple, now %s (value %s)'
-                raise EasyBuildError(msg, type(self.COMMAND_SHELL), self.COMMAND_SHELL)
+                raise EasyBuildError("COMMAND_SHELL needs to be list or tuple, now %s (value %s)",
+                                     type(self.COMMAND_SHELL), self.COMMAND_SHELL)
             cmdlist = self.COMMAND_SHELL + cmdlist
 
         full_cmd = ' '.join(cmdlist + args)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -163,7 +163,7 @@ class ModulesTool(object):
             self.cmd = os.environ[self.COMMAND_ENVIRONMENT]
 
         if self.cmd is None:
-            self.log.error('No command set.')
+            raise EasyBuildError("No command set.")
         else:
             self.log.debug('Using command %s' % self.cmd)
 
@@ -188,7 +188,7 @@ class ModulesTool(object):
     def set_and_check_version(self):
         """Get the module version, and check any requirements"""
         if self.VERSION_REGEXP is None:
-            self.log.error('No VERSION_REGEXP defined')
+            raise EasyBuildError("No VERSION_REGEXP defined")
 
         try:
             txt = self.run_module(self.VERSION_OPTION, return_output=True)
@@ -207,16 +207,17 @@ class ModulesTool(object):
 
                 self.log.info("Converted actual version to '%s'" % self.version)
             else:
-                self.log.error("Failed to determine version from option '%s' output: %s" % (self.VERSION_OPTION, txt))
+                raise EasyBuildError("Failed to determine version from option '%s' output: %s",
+                                     self.VERSION_OPTION, txt)
         except (OSError), err:
-            self.log.error("Failed to check version: %s" % err)
+            raise EasyBuildError("Failed to check version: %s", err)
 
         if self.REQ_VERSION is None:
-            self.log.debug('No version requirement defined.')
+            self.log.debug("No version requirement defined.")
         else:
             if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
-                msg = "EasyBuild requires v%s >= v%s (no rc), found v%s"
-                self.log.error(msg % (self.__class__.__name__, self.REQ_VERSION, self.version))
+                raise EasyBuildError("EasyBuild requires v%s >= v%s (no rc), found v%s",
+                                     self.__class__.__name__, self.REQ_VERSION, self.version)
             else:
                 self.log.debug('Version %s matches requirement %s' % (self.version, self.REQ_VERSION))
 
@@ -228,7 +229,7 @@ class ModulesTool(object):
             self.log.info("Full path for module command is %s, so using it" % self.cmd)
         else:
             mod_tool = self.__class__.__name__
-            self.log.error("%s modules tool can not be used, '%s' command is not available." % (mod_tool, self.cmd))
+            raise EasyBuildError("%s modules tool can not be used, '%s' command is not available.", mod_tool, self.cmd)
 
     def check_module_function(self, allow_mismatch=False, regex=None):
         """Check whether selected module tool matches 'module' function definition."""
@@ -259,7 +260,7 @@ class ModulesTool(object):
                 else:
                     msg += "Or alternatively, use --allow-modules-tool-mismatch to stop treating this as an error. "
                     msg += "Obtained definition of 'module' function: %s" % out
-                    self.log.error(msg)
+                    raise EasyBuildError(msg)
         else:
             # module function may not be defined (weird, but fine)
             self.log.warning("No 'module' function defined, can't check if it matches %s." % mod_details)
@@ -440,9 +441,10 @@ class ModulesTool(object):
             if res:
                 return res.group(1)
             else:
-                self.log.error("Failed to determine value from 'show' (pattern: '%s') in %s" % (regex.pattern, modinfo))
+                raise EasyBuildError("Failed to determine value from 'show' (pattern: '%s') in %s",
+                                     regex.pattern, modinfo)
         else:
-            raise EasyBuildError("Can't get value from a non-existing module %s" % mod_name)
+            raise EasyBuildError("Can't get value from a non-existing module %s", mod_name)
 
     def modulefile_path(self, mod_name):
         """Get the path of the module file for the specified module."""
@@ -490,7 +492,7 @@ class ModulesTool(object):
         if self.COMMAND_SHELL is not None:
             if not isinstance(self.COMMAND_SHELL, (list, tuple)):
                 msg = 'COMMAND_SHELL needs to be list or tuple, now %s (value %s)'
-                self.log.error(msg % (type(self.COMMAND_SHELL), self.COMMAND_SHELL))
+                raise EasyBuildError(msg, type(self.COMMAND_SHELL), self.COMMAND_SHELL)
             cmdlist = self.COMMAND_SHELL + cmdlist
 
         full_cmd = ' '.join(cmdlist + args)
@@ -518,7 +520,7 @@ class ModulesTool(object):
                 exec stdout
             except Exception, err:
                 out = "stdout: %s, stderr: %s" % (stdout, stderr)
-                raise EasyBuildError("Changing environment as dictated by module failed: %s (%s)" % (err, out))
+                raise EasyBuildError("Changing environment as dictated by module failed: %s (%s)", err, out)
 
             # correct LD_LIBRARY_PATH as yielded by the adjustments made
             # make sure we get the order right (reverse lists with [::-1])
@@ -537,7 +539,6 @@ class ModulesTool(object):
 
                 error = output_matchers['error'].search(line)
                 if error:
-                    self.log.error(line)
                     raise EasyBuildError(line)
 
                 modules = output_matchers['available'].finditer(line)
@@ -678,8 +679,8 @@ class ModulesTool(object):
                 full_mod_subdirs.append(dep_full_mod_subdir)
 
                 mods_to_top.append(dep)
-                tup = (dep, dep_full_mod_subdir, full_modpath_exts)
-                self.log.debug("Found module to top of module tree: %s (subdir: %s, modpath extensions %s)" % tup)
+                self.log.debug("Found module to top of module tree: %s (subdir: %s, modpath extensions %s)",
+                               dep, dep_full_mod_subdir, full_modpath_exts)
 
             if full_modpath_exts:
                 # load module for this dependency, since it may extend $MODULEPATH to make dependencies available
@@ -845,7 +846,7 @@ class Lmod(ModulesTool):
             (stdout, stderr) = proc.communicate()
 
             if stderr:
-                self.log.error("An error occured when running '%s': %s" % (' '.join(cmd), stderr))
+                raise EasyBuildError("An error occured when running '%s': %s", ' '.join(cmd), stderr)
 
             if self.testing:
                 # don't actually update local cache when testing, just return the cache contents
@@ -861,7 +862,7 @@ class Lmod(ModulesTool):
                     cache_file.write(stdout)
                     cache_file.close()
                 except (IOError, OSError), err:
-                    self.log.error("Failed to update Lmod spider cache %s: %s" % (cache_fp, err))
+                    raise EasyBuildError("Failed to update Lmod spider cache %s: %s", cache_fp, err)
 
     def prepend_module_path(self, path):
         # Lmod pushes a path to the front on 'module use'
@@ -923,7 +924,8 @@ def get_software_libdir(name, only_one=True, fs=None):
             if len(res) == 1:
                 res = res[0]
             else:
-                _log.error("Multiple library subdirectories found for %s in %s: %s" % (name, root, ', '.join(res)))
+                raise EasyBuildError("Multiple library subdirectories found for %s in %s: %s",
+                                     name, root, ', '.join(res))
         return res
     else:
         # return None if software package root could not be determined

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -49,6 +49,7 @@ from easybuild.framework.easyconfig.templates import template_documentation
 from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.extension import Extension
 from easybuild.tools import build_log, config, run  # @UnusedImport make sure config is always initialized!
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MNS, DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, DEFAULT_PREFIX, DEFAULT_REPOSITORY
 from easybuild.tools.config import get_pretend_installpath
@@ -371,7 +372,8 @@ class EasyBuildOptions(GeneralOption):
                 error_cnt += 1
 
         if error_cnt > 0:
-            self.log.error("Found %s problems validating the options, treating warnings above as fatal." % error_cnt)
+            raise EasyBuildError("Found %s problems validating the options, treating warnings above as fatal.",
+                                 error_cnt)
 
     def postprocess(self):
         """Do some postprocessing, in particular print stuff"""
@@ -403,17 +405,17 @@ class EasyBuildOptions(GeneralOption):
         # fail early if required dependencies for functionality requiring using GitHub API are not available:
         if self.options.from_pr or self.options.upload_test_report:
             if not HAVE_GITHUB_API:
-                self.log.error("Required support for using GitHub API is not available (see warnings).")
+                raise EasyBuildError("Required support for using GitHub API is not available (see warnings).")
 
         # make sure a GitHub token is available when it's required
         if self.options.upload_test_report:
             if not HAVE_KEYRING:
-                self.log.error("Python 'keyring' module required for obtaining GitHub token is not available.")
+                raise EasyBuildError("Python 'keyring' module required for obtaining GitHub token is not available.")
             if self.options.github_user is None:
-                self.log.error("No GitHub user name provided, required for fetching GitHub token.")
+                raise EasyBuildError("No GitHub user name provided, required for fetching GitHub token.")
             token = fetch_github_token(self.options.github_user)
             if token is None:
-                self.log.error("Failed to obtain required GitHub token for user '%s'" % self.options.github_user)
+                raise EasyBuildError("Failed to obtain required GitHub token for user '%s'", self.options.github_user)
 
         self._postprocess_config()
 

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -68,7 +68,7 @@ def build_easyconfigs_in_parallel(build_command, easyconfigs, output_dir=None, p
     # create a single connection, and reuse it
     conn = connect_to_server()
     if conn is None:
-        _log.error("connect_to_server returned %s, can't submit jobs." % (conn))
+        raise EasyBuildError("connect_to_server returned %s, can't submit jobs.", conn)
 
     # determine ppn once, and pass is to each job being created
     # this avoids having to figure out ppn over and over again, every time creating a temp connection to the server
@@ -214,4 +214,4 @@ def prepare_easyconfig(ec):
         easyblock_instance.close_log()
         os.remove(easyblock_instance.logfile)
     except (OSError, EasyBuildError), err:
-        _log.error("An error occured while preparing %s: %s" % (ec, err))
+        raise EasyBuildError("An error occured while preparing %s: %s", ec, err)

--- a/easybuild/tools/pbs_job.py
+++ b/easybuild/tools/pbs_job.py
@@ -35,6 +35,8 @@ import tempfile
 import time
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
+
 
 _log = fancylogger.getLogger('pbs_job', fname=False)
 
@@ -52,15 +54,13 @@ try:
     KNOWN_HOLD_TYPES = [pbs.USER_HOLD, pbs.OTHER_HOLD, pbs.SYSTEM_HOLD]
 except ImportError:
     _log.debug("Failed to import pbs from pbs_python. Silently ignoring, is only a real issue with --job")
-    pbs_import_failed = ("PBSQuery or pbs modules not available. "
-                         "Please make sure pbs_python is installed and usable.")
+    pbs_import_failed = "PBSQuery or pbs modules not available. Please make sure pbs_python is installed and usable."
 
 
 def connect_to_server(pbs_server=None):
     """Connect to PBS server and return connection."""
     if pbs_import_failed:
-        _log.error(pbs_import_failed)
-        return None
+        raise EasyBuildError(pbs_import_failed)
 
     if not pbs_server:
         pbs_server = pbs.pbs_default()
@@ -70,8 +70,7 @@ def connect_to_server(pbs_server=None):
 def disconnect_from_server(conn):
     """Disconnect a given connection."""
     if pbs_import_failed:
-        _log.error(pbs_import_failed)
-        return None
+        raise EasyBuildError(pbs_import_failed)
 
     pbs.pbs_disconnect(conn)
 
@@ -116,7 +115,7 @@ class PbsJob(object):
         self.name = name
 
         if pbs_import_failed:
-            self.log.error(pbs_import_failed)
+            raise EasyBuildError(pbs_import_failed)
 
         try:
             self.pbs_server = pbs.pbs_default()
@@ -126,7 +125,7 @@ class PbsJob(object):
             else:
                 self.pbsconn = pbs.pbs_connect(self.pbs_server)
         except Exception, err:
-            self.log.error("Failed to connect to the default pbs server: %s" % err)
+            raise EasyBuildError("Failed to connect to the default pbs server: %s", err)
 
         # setup the resources requested
 
@@ -242,7 +241,7 @@ class PbsJob(object):
         jobid = pbs.pbs_submit(self.pbsconn, pbs_attributes, scriptfn, self.queue, NULL)
         is_error, errormsg = pbs.error()
         if is_error or jobid is None:
-            self.log.error("Failed to submit job script %s (job id: %s, error %s)" % (scriptfn, jobid, errormsg))
+            raise EasyBuildError("Failed to submit job script %s (job id: %s, error %s)", scriptfn, jobid, errormsg)
         else:
             self.log.debug("Succesful job submission returned jobid %s" % jobid)
             self.jobid = jobid
@@ -257,13 +256,13 @@ class PbsJob(object):
         # only set hold if it wasn't set before
         if hold_type not in self.holds:
             if hold_type not in KNOWN_HOLD_TYPES:
-                self.log.error("set_hold: unknown hold type: %s (supported: %s)" % (hold_type, KNOWN_HOLD_TYPES))
+                raise EasyBuildError("set_hold: unknown hold type: %s (supported: %s)", hold_type, KNOWN_HOLD_TYPES)
             # set hold, check for errors, and keep track of this hold
             ec = pbs.pbs_holdjob(self.pbsconn, self.jobid, hold_type, NULL)
             is_error, errormsg = pbs.error()
             if is_error or ec:
-                tup = (hold_type, self.jobid, is_error, ec, errormsg)
-                self.log.error("Failed to set hold of type %s on job %s (is_error: %s, exit code: %s, msg: %s)" % tup)
+                raise EasyBuildError("Failed to set hold of type %s on job %s (is_error: %s, exit code: %s, msg: %s)",
+                                     hold_type, self.jobid, is_error, ec, errormsg)
             else:
                 self.holds.append(hold_type)
         else:
@@ -278,14 +277,14 @@ class PbsJob(object):
         # only release hold if it was set
         if hold_type in self.holds:
             if hold_type not in KNOWN_HOLD_TYPES:
-                self.log.error("release_hold: unknown hold type: %s (supported: %s)" % (hold_type, KNOWN_HOLD_TYPES))
+                raise EasyBuildError("release_hold: unknown hold type: %s (supported: %s)", hold_type, KNOWN_HOLD_TYPES)
             # release hold, check for errors, remove from list of holds
             ec = pbs.pbs_rlsjob(self.pbsconn, self.jobid, hold_type, NULL)
             self.log.debug("Released hold of type %s for job %s" % (hold_type, self.jobid))
             is_error, errormsg = pbs.error()
             if is_error or ec:
-                tup = (hold_type, self.jobid, is_error, ec, errormsg)
-                self.log.error("Failed to release hold type %s on job %s (is_error: %s, exit code: %s, msg: %s)" % tup)
+                raise EasyBuildError("Failed to release hold type %s on job %s (is_error: %s, exit code: %s, msg: %s)",
+                                     hold_type, self.jobid, is_error, ec, errormsg)
             else:
                 self.holds.remove(hold_type)
         else:
@@ -371,7 +370,7 @@ class PbsJob(object):
         elif len(jobs) == 1:
             self.log.debug("Request for jobid %s returned one result %s" % (self.jobid, jobs))
         else:
-            self.log.error("Request for jobid %s returned more then one result %s" % (self.jobid, jobs))
+            raise EasyBuildError("Request for jobid %s returned more then one result %s", self.jobid, jobs)
 
         # only expect to have a list with one element
         j = jobs[0]
@@ -386,7 +385,7 @@ class PbsJob(object):
         """Remove the job with id jobid"""
         result = pbs.pbs_deljob(self.pbsconn, self.jobid, '')  # use empty string, not NULL
         if result:
-            self.log.error("Failed to delete job %s: error %s" % (self.jobid, result))
+            raise EasyBuildError("Failed to delete job %s: error %s", self.jobid, result)
         else:
             self.log.debug("Succesfully deleted job %s" % self.jobid)
 

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -43,6 +43,7 @@ import tempfile
 import time
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.repository.filerepo import FileRepository
 
@@ -87,7 +88,7 @@ class GitRepository(FileRepository):
         try:
             git.GitCommandError
         except NameError, err:
-            self.log.exception("It seems like GitPython is not available: %s" % err)
+            raise EasyBuildError("It seems like GitPython is not available: %s", err)
 
         self.wc = tempfile.mkdtemp(prefix='git-wc-')
 
@@ -105,7 +106,7 @@ class GitRepository(FileRepository):
             self.log.debug("rep name is %s" % reponame)
         except git.GitCommandError, err:
             # it might already have existed
-            self.log.warning("Git local repo initialization failed, it might already exist: %s" % err)
+            self.log.warning("Git local repo initialization failed, it might already exist: %s", err)
 
         # local repo should now exist, let's connect to it again
         try:
@@ -113,14 +114,14 @@ class GitRepository(FileRepository):
             self.log.debug("connectiong to git repo in %s" % self.wc)
             self.client = git.Git(self.wc)
         except (git.GitCommandError, OSError), err:
-            self.log.error("Could not create a local git repo in wc %s: %s" % (self.wc, err))
+            raise EasyBuildError("Could not create a local git repo in wc %s: %s", self.wc, err)
 
         # try to get the remote data in the local repo
         try:
             res = self.client.pull()
             self.log.debug("pulled succesfully to %s in %s" % (res, self.wc))
         except (git.GitCommandError, OSError), err:
-            self.log.exception("pull in working copy %s went wrong: %s" % (self.wc, err))
+            raise EasyBuildError("pull in working copy %s went wrong: %s", self.wc, err)
 
     def add_easyconfig(self, cfg, name, version, stats, append):
         """
@@ -166,4 +167,4 @@ class GitRepository(FileRepository):
             self.wc = os.path.dirname(self.wc)
             rmtree2(self.wc)
         except IOError, err:
-            self.log.exception("Can't remove working copy %s: %s" % (self.wc, err))
+            raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)

--- a/easybuild/tools/repository/repository.py
+++ b/easybuild/tools/repository/repository.py
@@ -37,6 +37,7 @@ Generic support for dealing with repositories
 from vsc.utils import fancylogger
 from vsc.utils.missing import get_subclasses
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.utilities import import_available_modules
 
 _log = fancylogger.getLogger('repository', fname=False)
@@ -126,7 +127,7 @@ def avail_repositories(check_useable=True):
     class_dict = dict([(x.__name__, x) for x in get_subclasses(Repository) if x.USABLE or not check_useable])
 
     if not 'FileRepository' in class_dict:
-        _log.error('avail_repositories: FileRepository missing from list of repositories')
+        raise EasyBuildError("avail_repositories: FileRepository missing from list of repositories")
 
     return class_dict
 
@@ -144,13 +145,13 @@ def init_repository(repository, repository_path):
             elif isinstance(repository_path, (tuple, list)) and len(repository_path) <= 2:
                 inited_repo = repo(*repository_path)
             else:
-                _log.error('repository_path should be a string or list/tuple of maximum 2 elements (current: %s, type %s)' %
-                           (repository_path, type(repository_path)))
+                raise EasyBuildError("repository_path should be a string or list/tuple of maximum 2 elements "
+                                     "(current: %s, type %s)", repository_path, type(repository_path))
         except Exception, err:
-            _log.error('Failed to create a repository instance for %s (class %s) with args %s (msg: %s)' %
-                       (repository, repo.__name__, repository_path, err))
+            raise EasyBuildError("Failed to create a repository instance for %s (class %s) with args %s (msg: %s)",
+                                 repository, repo.__name__, repository_path, err)
     else:
-        _log.error('Unknown typo of repository spec: %s (type %s)' % (repo, type(repo)))
+        raise EasyBuildError("Unknown typo of repository spec: %s (type %s)", repo, type(repo))
 
     inited_repo.init()
     return inited_repo

--- a/easybuild/tools/repository/svnrepo.py
+++ b/easybuild/tools/repository/svnrepo.py
@@ -43,6 +43,7 @@ import tempfile
 import time
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.repository.filerepo import FileRepository
 
@@ -88,8 +89,8 @@ class SvnRepository(FileRepository):
         try:
             pysvn.ClientError  # IGNORE:E0611 pysvn fails to recognize ClientError is available
         except NameError, err:
-            self.log.exception("pysvn not available (%s). Make sure it is installed " % err +
-                               "properly. Run 'python -c \"import pysvn\"' to test.")
+            raise EasyBuildError("pysvn not available (%s). Make sure it is installed properly. "
+                                 "Run 'python -c \"import pysvn\"' to test.", err)
 
         # try to connect to the repository
         self.log.debug("Try to connect to repository %s" % self.repo)
@@ -97,13 +98,13 @@ class SvnRepository(FileRepository):
             self.client = pysvn.Client()
             self.client.exception_style = 0
         except ClientError:
-            self.log.exception("Svn Client initialization failed.")
+            raise EasyBuildError("Svn Client initialization failed.")
 
         try:
             if not self.client.is_url(self.repo):
-                self.log.error("Provided repository %s is not a valid svn url" % self.repo)
+                raise EasyBuildError("Provided repository %s is not a valid svn url", self.repo)
         except ClientError:
-            self.log.exception("Can't connect to svn repository %s" % self.repo)
+            raise EasyBuildError("Can't connect to svn repository %s", self.repo)
 
     def create_working_copy(self):
         """
@@ -116,16 +117,16 @@ class SvnRepository(FileRepository):
         try:
             self.client.info2(self.repo, recurse=False)
         except ClientError:
-            self.log.exception("Getting info from %s failed." % self.wc)
+            raise EasyBuildError("Getting info from %s failed.", self.wc)
 
         try:
             res = self.client.update(self.wc)
             self.log.debug("Updated to revision %s in %s" % (res, self.wc))
         except ClientError:
-            self.log.exception("Update in wc %s went wrong" % self.wc)
+            raise EasyBuildError("Update in wc %s went wrong", self.wc)
 
         if len(res) == 0:
-            self.log.error("Update returned empy list (working copy: %s)" % (self.wc))
+            raise EasyBuildError("Update returned empy list (working copy: %s)", self.wc)
 
         if res[0].number == -1:
             # revision number of update is -1
@@ -134,7 +135,7 @@ class SvnRepository(FileRepository):
                 res = self.client.checkout(self.repo, self.wc)
                 self.log.debug("Checked out revision %s in %s" % (res.number, self.wc))
             except ClientError, err:
-                self.log.exception("Checkout of path / in working copy %s went wrong: %s" % (self.wc, err))
+                raise EasyBuildError("Checkout of path / in working copy %s went wrong: %s", self.wc, err)
 
     def add_easyconfig(self, cfg, name, version, stats, append):
         """
@@ -160,7 +161,7 @@ class SvnRepository(FileRepository):
         try:
             self.client.checkin(self.wc, completemsg, recurse=True)
         except ClientError, err:
-            self.log.exception("Commit from working copy %s (msg: %s) failed: %s" % (self.wc, msg, err))
+            raise EasyBuildError("Commit from working copy %s (msg: %s) failed: %s", self.wc, msg, err)
 
     def cleanup(self):
         """
@@ -169,4 +170,4 @@ class SvnRepository(FileRepository):
         try:
             rmtree2(self.wc)
         except OSError, err:
-            self.log.exception("Can't remove working copy %s: %s" % (self.wc, err))
+            raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -153,8 +153,8 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
         # make sure this stops, we really don't want to get stuck in an infinite loop
         loopcnt += 1
         if loopcnt > maxloopcnt:
-            msg = "Maximum loop cnt %s reached, so quitting (unprocessed: %s, irresolvable: %s)"
-            raise EasyBuildError(msg, maxloopcnt, unprocessed, irresolvable)
+            raise EasyBuildError("Maximum loop cnt %s reached, so quitting (unprocessed: %s, irresolvable: %s)",
+                                 maxloopcnt, unprocessed, irresolvable)
 
         # first try resolving dependencies without using external dependencies
         last_processed_count = -1
@@ -205,8 +205,8 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
                         mods = [spec['ec'].full_mod_name for spec in processed_ecs]
                         dep_mod_name = ActiveMNS().det_full_module_name(cand_dep)
                         if not dep_mod_name in mods:
-                            msg = "easyconfig file %s does not contain module %s (mods: %s)"
-                            raise EasyBuildError(msg, path, dep_mod_name, mods)
+                            raise EasyBuildError("easyconfig file %s does not contain module %s (mods: %s)",
+                                                 path, dep_mod_name, mods)
 
                         for ec in processed_ecs:
                             if not ec in unprocessed + additional:
@@ -229,9 +229,9 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
         irresolvable_mods_eb = [EasyBuildMNS().det_full_module_name(dep) for dep in irresolvable]
         _log.warning("Irresolvable dependencies (EasyBuild module names): %s" % ', '.join(irresolvable_mods_eb))
         irresolvable_mods = [ActiveMNS().det_full_module_name(dep) for dep in irresolvable]
-        raise EasyBuildError('Irresolvable dependencies encountered: %s', ', '.join(irresolvable_mods))
+        raise EasyBuildError("Irresolvable dependencies encountered: %s", ', '.join(irresolvable_mods))
 
-    _log.info("Dependency resolution complete, building as follows:\n%s" % ordered_ecs)
+    _log.info("Dependency resolution complete, building as follows: %s" % ordered_ecs)
     return ordered_ecs
 
 

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -38,6 +38,7 @@ from vsc.utils import fancylogger
 
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS, process_easyconfig, robot_find_easyconfig
 from easybuild.framework.easyconfig.tools import find_resolved_modules, skip_available
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import det_common_path_prefix, search_file
 from easybuild.tools.module_naming_scheme.easybuild_mns import EasyBuildMNS
@@ -154,7 +155,7 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
         if loopcnt > maxloopcnt:
             tup = (maxloopcnt, unprocessed, irresolvable)
             msg = "Maximum loop cnt %s reached, so quitting (unprocessed: %s, irresolvable: %s)" % tup
-            _log.error(msg)
+            raise EasyBuildError(msg)
 
         # first try resolving dependencies without using external dependencies
         last_processed_count = -1
@@ -206,7 +207,7 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
                         dep_mod_name = ActiveMNS().det_full_module_name(cand_dep)
                         if not dep_mod_name in mods:
                             tup = (path, dep_mod_name, mods)
-                            _log.error("easyconfig file %s does not contain module %s (mods: %s)" % tup)
+                            raise EasyBuildError("easyconfig file %s does not contain module %s (mods: %s)" % tup)
 
                         for ec in processed_ecs:
                             if not ec in unprocessed + additional:
@@ -229,7 +230,7 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
         irresolvable_mods_eb = [EasyBuildMNS().det_full_module_name(dep) for dep in irresolvable]
         _log.warning("Irresolvable dependencies (EasyBuild module names): %s" % ', '.join(irresolvable_mods_eb))
         irresolvable_mods = [ActiveMNS().det_full_module_name(dep) for dep in irresolvable]
-        _log.error('Irresolvable dependencies encountered: %s' % ', '.join(irresolvable_mods))
+        raise EasyBuildError('Irresolvable dependencies encountered: %s' % ', '.join(irresolvable_mods))
 
     _log.info("Dependency resolution complete, building as follows:\n%s" % ordered_ecs)
     return ordered_ecs

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -153,9 +153,8 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
         # make sure this stops, we really don't want to get stuck in an infinite loop
         loopcnt += 1
         if loopcnt > maxloopcnt:
-            tup = (maxloopcnt, unprocessed, irresolvable)
-            msg = "Maximum loop cnt %s reached, so quitting (unprocessed: %s, irresolvable: %s)" % tup
-            raise EasyBuildError(msg)
+            msg = "Maximum loop cnt %s reached, so quitting (unprocessed: %s, irresolvable: %s)"
+            raise EasyBuildError(msg, maxloopcnt, unprocessed, irresolvable)
 
         # first try resolving dependencies without using external dependencies
         last_processed_count = -1
@@ -206,8 +205,8 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
                         mods = [spec['ec'].full_mod_name for spec in processed_ecs]
                         dep_mod_name = ActiveMNS().det_full_module_name(cand_dep)
                         if not dep_mod_name in mods:
-                            tup = (path, dep_mod_name, mods)
-                            raise EasyBuildError("easyconfig file %s does not contain module %s (mods: %s)" % tup)
+                            msg = "easyconfig file %s does not contain module %s (mods: %s)"
+                            raise EasyBuildError(msg, path, dep_mod_name, mods)
 
                         for ec in processed_ecs:
                             if not ec in unprocessed + additional:
@@ -230,7 +229,7 @@ def resolve_dependencies(unprocessed, build_specs=None, retain_all_deps=False):
         irresolvable_mods_eb = [EasyBuildMNS().det_full_module_name(dep) for dep in irresolvable]
         _log.warning("Irresolvable dependencies (EasyBuild module names): %s" % ', '.join(irresolvable_mods_eb))
         irresolvable_mods = [ActiveMNS().det_full_module_name(dep) for dep in irresolvable]
-        raise EasyBuildError('Irresolvable dependencies encountered: %s' % ', '.join(irresolvable_mods))
+        raise EasyBuildError('Irresolvable dependencies encountered: %s', ', '.join(irresolvable_mods))
 
     _log.info("Dependency resolution complete, building as follows:\n%s" % ordered_ecs)
     return ordered_ecs

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -38,6 +38,7 @@ from socket import gethostname
 from vsc.utils import fancylogger
 from vsc.utils.affinity import sched_getaffinity
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, which
 from easybuild.tools.run import run_cmd
 
@@ -121,8 +122,8 @@ def get_cpu_vendor():
             arch = res.group('vendor')
         if arch in VENDORS:
             vendor = VENDORS[arch]
-            tup = (vendor, vendor_regex.pattern, PROC_CPUINFO_FP)
-            _log.debug("Determined CPU vendor on Linux as being '%s' via regex '%s' in %s" % tup)
+            _log.debug("Determined CPU vendor on Linux as being '%s' via regex '%s' in %s",
+                       vendor, vendor_regex.pattern, PROC_CPUINFO_FP)
 
     elif os_type == DARWIN:
         cmd = "sysctl -n machdep.cpu.vendor"
@@ -157,8 +158,8 @@ def get_cpu_family():
             power_regex = re.compile(r"^cpu\s+:\s*POWER.*", re.M)
             if power_regex.search(cpuinfo_txt):
                 family = POWER
-                tup = (power_regex.pattern, PROC_CPUINFO_FP, family)
-                _log.debug("Determined CPU family using regex '%s' in %s: %s" % tup)
+                _log.debug("Determined CPU family using regex '%s' in %s: %s",
+                           power_regex.pattern, PROC_CPUINFO_FP, family)
 
     if family is None:
         family = UNKNOWN
@@ -182,8 +183,8 @@ def get_cpu_model():
         res = model_regex.search(txt)
         if res is not None:
             model = res.group('model').strip()
-            tup = (model_regex.pattern, PROC_CPUINFO_FP, model)
-            _log.debug("Determined CPU model on Linux using regex '%s' in %s: %s" % tup)
+            _log.debug("Determined CPU model on Linux using regex '%s' in %s: %s",
+                       model_regex.pattern, PROC_CPUINFO_FP, model)
 
     elif os_type == DARWIN:
         cmd = "sysctl -n machdep.cpu.brand_string"
@@ -348,7 +349,7 @@ def get_os_version():
                 if not known_sp:
                     suff = '_UNKNOWN_SP'
             else:
-                _log.error("Don't know how to determine subversions for SLES %s" % os_version)
+                raise EasyBuildError("Don't know how to determine subversions for SLES %s", os_version)
 
         return os_version
     else:
@@ -413,8 +414,8 @@ def get_glibc_version():
             _log.debug("Found glibc version %s" % glibc_version)
             return glibc_version
         else:
-            tup = (glibc_ver_str, glibc_ver_regex.pattern)
-            _log.error("Failed to determine glibc version from '%s' using pattern '%s'." % tup)
+            raise EasyBuildError("Failed to determine glibc version from '%s' using pattern '%s'.",
+                                 glibc_ver_str, glibc_ver_regex.pattern)
     else:
         # no glibc on OS X standard
         _log.debug("No glibc on a non-Linux system, so can't determine version.")
@@ -447,7 +448,7 @@ def use_group(group_name):
     try:
         group_id = grp.getgrnam(group_name).gr_gid
     except KeyError, err:
-        _log.error("Failed to get group ID for '%s', group does not exist (err: %s)" % (group_name, err))
+        raise EasyBuildError("Failed to get group ID for '%s', group does not exist (err: %s)", group_name, err)
 
     group = (group_name, group_id)
     try:
@@ -460,7 +461,7 @@ def use_group(group_name):
             err_msg += "change the primary group before using EasyBuild, using 'newgrp %s'." % group_name
         else:
             err_msg += "current user '%s' is not in group %s (members: %s)" % (user, group, grp_members)
-        _log.error(err_msg)
+        raise EasyBuildError(err_msg)
     _log.info("Using group '%s' (gid: %s)" % group)
 
     return group
@@ -476,7 +477,7 @@ def det_parallelism(par, maxpar):
             try:
                 par = int(par)
             except ValueError, err:
-                _log.error("Specified level of parallelism '%s' is not an integer value: %s" % (par, err))
+                raise EasyBuildError("Specified level of parallelism '%s' is not an integer value: %s", par, err)
     else:
         par = get_avail_core_count()
         # check ulimit -u
@@ -491,7 +492,7 @@ def det_parallelism(par, maxpar):
                 par = par_guess
                 _log.info("Limit parallel builds to %s because max user processes is %s" % (par, out))
         except ValueError, err:
-            _log.exception("Failed to determine max user processes (%s, %s): %s" % (ec, out, err))
+            raise EasyBuildError("Failed to determine max user processes (%s, %s): %s", ec, out, err)
 
     if maxpar is not None and maxpar < par:
         _log.info("Limiting parallellism from %s to %s" % (par, maxpar))

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -96,7 +96,7 @@ def regtest(easyconfig_paths, build_specs=None):
         for path in easyconfig_paths:
             ecfiles += find_easyconfigs(path, ignore_dirs=build_option('ignore_dirs'))
     else:
-        _log.error("No easyconfig paths specified.")
+        raise EasyBuildError("No easyconfig paths specified.")
 
     test_results = []
 

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -28,10 +28,8 @@ Toolchain compiler module, provides abstract class for compilers.
 @author: Stijn De Weirdt (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-
-import os
-
 from easybuild.tools import systemtools
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES
 from easybuild.tools.toolchain.toolchain import Toolchain
@@ -186,7 +184,7 @@ class Compiler(Toolchain):
                         # only warn if prefix is set, not all languages may be supported (e.g., no Fortran for CUDA)
                         self.log.warn("_set_compiler_vars: %s compiler variable %s undefined" % (prefix, var))
                     else:
-                        self.log.raiseException("_set_compiler_vars: compiler variable %s undefined" % var)
+                        raise EasyBuildError("_set_compiler_vars: compiler variable %s undefined", var)
 
                 self.variables[pref_var] = value
                 if is32bit:
@@ -273,7 +271,7 @@ class Compiler(Toolchain):
             self.options.options_map['optarch'] = optarch
 
         if 'optarch' in self.options.options_map and self.options.options_map.get('optarch', None) is None:
-            self.log.raiseException("_get_optimal_architecture: don't know how to set optarch for %s." % self.arch)
+            raise EasyBuildError("_get_optimal_architecture: don't know how to set optarch for %s", self.arch)
 
     def comp_family(self, prefix=None):
         """
@@ -286,4 +284,4 @@ class Compiler(Toolchain):
         if comp_family:
             return comp_family
         else:
-            self.log.raiseException('comp_family: COMPILER_%sFAMILY is undefined.' % infix)
+            raise EasyBuildError("comp_family: COMPILER_%sFAMILY is undefined", infix)

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -29,6 +29,7 @@ Toolchain linalg module. Contains all (scalable) linear algebra related classes
 @author: Kenneth Hoste (Ghent University)
 """
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.toolchain import Toolchain
 
 
@@ -95,7 +96,7 @@ class LinAlg(Toolchain):
     def _set_blas_variables(self):
         """Set BLAS related variables"""
         if self.BLAS_LIB is None:
-            self.log.raiseException("_set_blas_variables: BLAS_LIB not set")
+            raise EasyBuildError("_set_blas_variables: BLAS_LIB not set")
 
         self.BLAS_LIB = self.variables.nappend('LIBBLAS', [x % self.BLAS_LIB_MAP for x in self.BLAS_LIB])
         self.variables.add_begin_end_linkerflags(self.BLAS_LIB,
@@ -143,7 +144,7 @@ class LinAlg(Toolchain):
             self.variables.join('LAPACK_INC_DIR', 'BLAS_INC_DIR')
         else:
             if self.LAPACK_LIB is None:
-                self.log.raiseException("_set_lapack_variables: LAPACK_LIB not set")
+                raise EasyBuildError("_set_lapack_variables: LAPACK_LIB not set")
             self.LAPACK_LIB = self.variables.nappend('LIBLAPACK_ONLY', self.LAPACK_LIB)
             self.variables.add_begin_end_linkerflags(self.LAPACK_LIB,
                                                      toggle_startstopgroup=self.LAPACK_LIB_GROUP,
@@ -222,7 +223,7 @@ class LinAlg(Toolchain):
         """Set ScaLAPACK related variables"""
 
         if self.SCALAPACK_LIB is None:
-            self.log.raiseException("_set_blas_variables: SCALAPACK_LIB not set")
+            raise EasyBuildError("_set_blas_variables: SCALAPACK_LIB not set")
 
         lib_map = {}
         if hasattr(self, 'BLAS_LIB_MAP') and self.BLAS_LIB_MAP is not None:
@@ -268,7 +269,7 @@ class LinAlg(Toolchain):
             if getattr(self, 'LIB_MULTITHREAD', None) is not None:
                 self.variables.nappend('LIBSCALAPACK_MT', self.LIB_MULTITHREAD)
         else:
-            self.log.raiseException("_set_scalapack_variables: LIBSCALAPACK without SCALAPACK_REQUIRES not implemented")
+            raise EasyBuildError("_set_scalapack_variables: LIBSCALAPACK without SCALAPACK_REQUIRES not implemented")
 
 
         self.variables.join('SCALAPACK_STATIC_LIBS', 'LIBSCALAPACK')
@@ -279,4 +280,3 @@ class LinAlg(Toolchain):
 
         self._add_dependency_variables(self.SCALAPACK_MODULE_NAME,
                                        ld=self.SCALAPACK_LIB_DIR, cpp=self.SCALAPACK_INCLUDE_DIR)
-

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -33,6 +33,7 @@ import tempfile
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import write_file
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES, MPI_COMPILER_TEMPLATE, SEQ_COMPILER_TEMPLATE
 from easybuild.tools.toolchain.toolchain import Toolchain
@@ -106,7 +107,7 @@ class Mpi(Toolchain):
 
             value = getattr(self, 'MPI_COMPILER_%s' % var.upper(), None)
             if value is None:
-                self.log.raiseException("_set_mpi_compiler_variables: mpi compiler variable %s undefined" % var)
+                raise EasyBuildError("_set_mpi_compiler_variables: mpi compiler variable %s undefined", var)
             self.variables.nappend_el(var, value)
 
             # complete compiler variable template to produce e.g. 'mpicc -cc=icc -X -Y' from 'mpicc -cc=%(CC_base)'
@@ -159,7 +160,7 @@ class Mpi(Toolchain):
         if self.MPI_FAMILY:
             return self.MPI_FAMILY
         else:
-            self.log.raiseException("mpi_family: MPI_FAMILY is undefined.")
+            raise EasyBuildError("mpi_family: MPI_FAMILY is undefined.")
 
     # FIXME: deprecate this function, use mympirun instead
     # this requires that either mympirun is packaged together with EasyBuild, or that vsc-tools is a dependency of EasyBuild
@@ -213,7 +214,7 @@ class Mpi(Toolchain):
                     os.remove(fn)
                 write_file(fn, "localhost ifhn=localhost")
             except OSError, err:
-                self.log.error("Failed to create file %s: %s" % (fn, err))
+                raise EasyBuildError("Failed to create file %s: %s", fn, err)
 
             params.update({'mpdbf': "--file=%s" % fn})
 
@@ -224,11 +225,11 @@ class Mpi(Toolchain):
                     os.remove(fn)
                 write_file(fn, "localhost\n" * nr_ranks)
             except OSError, err:
-                self.log.error("Failed to create file %s: %s" % (fn, err))
+                raise EasyBuildError("Failed to create file %s: %s", fn, err)
 
             params.update({'nodesfile': "-machinefile %s" % fn})
 
         if mpi_family in mpi_cmds.keys():
             return mpi_cmds[mpi_family] % params
         else:
-            self.log.error("Don't know how to create an MPI command for MPI library of type '%s'." % mpi_family)
+            raise EasyBuildError("Don't know how to create an MPI command for MPI library of type '%s'.", mpi_family)

--- a/easybuild/tools/toolchain/options.py
+++ b/easybuild/tools/toolchain/options.py
@@ -37,6 +37,8 @@ Map values can be string with named templates
 
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
+
 
 class ToolchainOptions(dict):
     def __init__(self):
@@ -62,9 +64,9 @@ class ToolchainOptions(dict):
         self.log.debug("_add_options: adding options %s" % options)
         for name, value in options.items():
             if not isinstance(value, (list, tuple,)) and len(value) == 2:
-                self.log.raiseException("_add_options: option name %s has to be 2 element list (%s)" % (name, value))
+                raise EasyBuildError("_add_options: option name %s has to be 2 element list (%s)", name, value)
             if name in self:
-                self.log.debug("_add_options: redefining previous name %s (previous value %s)" % (name, self.get(name)))
+                self.log.debug("_add_options: redefining previous name %s (previous value %s)", name, self.get(name))
             self.__setitem__(name, value[0])
             self.description.__setitem__(name, value[1])
 
@@ -75,9 +77,9 @@ class ToolchainOptions(dict):
         for name in options_map.keys():
             if not name in self:
                 if name.startswith('_opt_'):
-                    self.log.debug("_add_options_map: no option with name %s defined, but allowed" % name)
+                    self.log.debug("_add_options_map: no option with name %s defined, but allowed", name)
                 else:
-                    self.log.raiseException("_add_options_map: no option with name %s defined" % name)
+                    raise EasyBuildError("_add_options_map: no option with name %s defined", name)
 
         self.options_map.update(options_map)
 

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -35,6 +35,7 @@ import os
 import re
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, install_path
 from easybuild.tools.environment import setvar
 from easybuild.tools.modules import get_software_root, get_software_version, modules_tool
@@ -81,13 +82,13 @@ class Toolchain(object):
         if name is None:
             name = self.NAME
         if name is None:
-            self.log.error("Toolchain init: no name provided")
+            raise EasyBuildError("Toolchain init: no name provided")
         self.name = name
 
         if version is None:
             version = self.VERSION
         if version is None:
-            self.log.error("Toolchain init: no version provided")
+            raise EasyBuildError("Toolchain init: no version provided")
         self.version = version
 
         self.vars = None
@@ -128,7 +129,7 @@ class Toolchain(object):
         elif typ == list:
             return self.variables[name].flatten()
         else:
-            self.log.error("get_variable: Don't know how to create value of type %s." % typ)
+            raise EasyBuildError("get_variable: Don't know how to create value of type %s.", typ)
 
     def set_variables(self):
         """Do nothing? Everything should have been set by others
@@ -187,18 +188,18 @@ class Toolchain(object):
         """Try to get the software root for name"""
         root = get_software_root(name)
         if root is None:
-            self.log.error("get_software_root software root for %s was not found in environment" % name)
+            raise EasyBuildError("get_software_root software root for %s was not found in environment", name)
         else:
-            self.log.debug("get_software_root software root %s for %s was found in environment" % (root, name))
+            self.log.debug("get_software_root software root %s for %s was found in environment", root, name)
         return root
 
     def _get_software_version(self, name):
         """Try to get the software root for name"""
         version = get_software_version(name)
         if version is None:
-            self.log.error("get_software_version software version for %s was not found in environment" % name)
+            raise EasyBuildError("get_software_version software version for %s was not found in environment", name)
         else:
-            self.log.debug("get_software_version software version %s for %s was found in environment" % (version, name))
+            self.log.debug("get_software_version software version %s for %s was found in environment", version, name)
 
         return version
 
@@ -221,7 +222,7 @@ class Toolchain(object):
     def det_short_module_name(self):
         """Determine module name for this toolchain."""
         if self.mod_short_name is None:
-            self.log.error("Toolchain module name was not set yet (using set_module_info).")
+            raise EasyBuildError("Toolchain module name was not set yet (using set_module_info).")
         return self.mod_short_name
 
     def _toolchain_exists(self):
@@ -234,7 +235,7 @@ class Toolchain(object):
             return True
         else:
             if self.mod_short_name is None:
-                self.log.error("Toolchain module name was not set yet (using set_module_info).")
+                raise EasyBuildError("Toolchain module name was not set yet (using set_module_info).")
             # check whether a matching module exists if self.mod_short_name contains a module name
             return self.modules_tool.exist([self.mod_full_name])[0]
 
@@ -247,7 +248,7 @@ class Toolchain(object):
             else:
                 # used to be warning, but this is a severe error imho
                 known_opts = ','.join(self.options.keys())
-                self.log.error("Undefined toolchain option %s specified (known options: %s)" % (opt, known_opts))
+                raise EasyBuildError("Undefined toolchain option %s specified (known options: %s)", opt, known_opts)
 
     def get_dependency_version(self, dependency):
         """ Generate a version string for a dependency on a module using this toolchain """
@@ -267,7 +268,7 @@ class Toolchain(object):
 
         if 'version' in dependency:
             version = "".join([dependency['version'], toolchain, suffix])
-            self.log.debug("get_dependency_version: version in dependency return %s" % version)
+            self.log.debug("get_dependency_version: version in dependency return %s", version)
             return version
         else:
             toolchain_suffix = "".join([toolchain, suffix])
@@ -275,11 +276,11 @@ class Toolchain(object):
             # Find the most recent (or default) one
             if len(matches) > 0:
                 version = matches[-1][-1]
-                self.log.debug("get_dependency_version: version not in dependency return %s" % version)
+                self.log.debug("get_dependency_version: version not in dependency return %s", version)
                 return
             else:
-                tup = (dependency['name'], toolchain_suffix)
-                self.log.error("No toolchain version for dependency name %s (suffix %s) found" % tup)
+                raise EasyBuildError("No toolchain version for dependency name %s (suffix %s) found",
+                                     dependency['name'], toolchain_suffix)
 
     def add_dependencies(self, dependencies):
         """ Verify if the given dependencies exist and add them """
@@ -289,8 +290,7 @@ class Toolchain(object):
         for dep, dep_mod_name, dep_exists in zip(dependencies, dep_mod_names, deps_exist):
             self.log.debug("add_dependencies: MODULEPATH: %s" % os.environ['MODULEPATH'])
             if not dep_exists:
-                tup = (dep_mod_name, dep)
-                self.log.error("add_dependencies: no module '%s' found for dependency %s" % tup)
+                raise EasyBuildError("add_dependencies: no module '%s' found for dependency %s", dep_mod_name, dep)
             else:
                 self.dependencies.append(dep)
                 self.log.debug('add_dependencies: added toolchain dependency %s' % str(dep))
@@ -328,10 +328,10 @@ class Toolchain(object):
         (If string: comma separated list of variables that will be ignored).
         """
         if self.modules_tool is None:
-            self.log.error("No modules tool defined in Toolchain instance.")
+            raise EasyBuildError("No modules tool defined in Toolchain instance.")
 
         if not self._toolchain_exists():
-            self.log.error("No module found for toolchain: %s" % self.mod_short_name)
+            raise EasyBuildError("No module found for toolchain: %s", self.mod_short_name)
 
         if self.name == DUMMY_TOOLCHAIN_NAME:
             if self.version == DUMMY_TOOLCHAIN_VERSION:
@@ -373,8 +373,8 @@ class Toolchain(object):
         if all(map(self.is_dep_in_toolchain_module, toolchain_definition)):
             self.log.info("List of toolchain dependency modules and toolchain definition match!")
         else:
-            self.log.error("List of toolchain dependency modules and toolchain definition do not match " \
-                           "(%s vs %s)" % (self.toolchain_dep_mods, toolchain_definition))
+            raise EasyBuildError("List of toolchain dependency modules and toolchain definition do not match "
+                                 "(%s vs %s)", self.toolchain_dep_mods, toolchain_definition)
 
         # Generate the variables to be set
         self.set_variables()
@@ -426,8 +426,7 @@ class Toolchain(object):
         donotsetlist = []
         if isinstance(donotset, str):
             # TODO : more legacy code that should be using proper type
-            self.log.error("_setenv_variables: using commas-separated list. should be deprecated.")
-            donotsetlist = donotset.split(',')
+            raise EasyBuildError("_setenv_variables: using commas-separated list. should be deprecated.")
         elif isinstance(donotset, list):
             donotsetlist = donotset
 

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -40,6 +40,7 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import get_subclasses, nub
 
 import easybuild.tools.toolchain
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.toolchain import Toolchain
 from easybuild.tools.utilities import import_available_modules
 
@@ -83,13 +84,13 @@ def search_toolchain(name):
                     if res:
                         tc_const_name = res.group(1)
                         tc_const_value = getattr(mod_class_mod, elem)
-                        tup = (tc_const_name, tc_const_value, mod_class_mod.__name__, package.__name__)
-                        _log.debug("Found constant %s ('%s') in module %s, adding it to %s" % tup)
+                        _log.debug("Found constant %s ('%s') in module %s, adding it to %s",
+                                   tc_const_name, tc_const_value, mod_class_mod.__name__, package.__name__)
                         if hasattr(package, tc_const_name):
                             cur_value = getattr(package, tc_const_name)
                             if not tc_const_value == cur_value:
-                                tup = (package.__name__, tc_const_name, cur_value, tc_const_value)
-                                _log.error("Constant %s.%s defined as '%s', can't set it to '%s'." % tup)
+                                raise EasyBuildError("Constant %s.%s defined as '%s', can't set it to '%s'.",
+                                                     package.__name__, tc_const_name, cur_value, tc_const_value)
                         else:
                             setattr(package, tc_const_name, tc_const_value)
 
@@ -124,7 +125,7 @@ def get_toolchain(tc, tcopts, mns):
         tc_class, all_tcs = search_toolchain(tc['name'])
         if not tc_class:
             all_tcs_names = ",".join([x.NAME for x in all_tcs])
-            _log.error("Toolchain %s not found, available toolchains: %s" % (tc['name'], all_tcs_names))
+            raise EasyBuildError("Toolchain %s not found, available toolchains: %s", tc['name'], all_tcs_names)
         tc_inst = tc_class(version=tc['version'], mns=mns)
         tc_dict = tc_inst.as_dict()
         _log.debug("Obtained new toolchain instance for %s: %s" % (key, tc_dict))

--- a/easybuild/tools/toolchain/variables.py
+++ b/easybuild/tools/toolchain/variables.py
@@ -29,6 +29,7 @@ Toolchain specific variables
 @author: Kenneth Hoste (Ghent University)
 """
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.variables import StrList, AbsPathList
 
 
@@ -141,7 +142,7 @@ class LinkerFlagList(StrList):
                 else:
                     self.insert(idx, toggle_map[name])
             else:
-                self.log.raiseException("%s name %s not found in map %s" % (descr, name, toggle_map))
+                raise EasyBuildError("%s name %s not found in map %s", descr, name, toggle_map)
 
     def toggle_startgroup(self):
         """Append start group"""

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -29,9 +29,12 @@ e.g., in compiling or linking
 @author: Stijn De Weirdt (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-from vsc.utils import fancylogger
 import copy
 import os
+from vsc.utils import fancylogger
+
+from easybuild.tools.build_log import EasyBuildError
+
 
 _log = fancylogger.getLogger('variables', fname=False)
 
@@ -62,20 +65,20 @@ def join_map_class(map_classes):
     """Join all class_maps into single class_map"""
     res = {}
     for map_class in map_classes:
-        for k, v in map_class.items():
-            if isinstance(k, (str,)):
-                var_name = k
-                if isinstance(v, (tuple, list)):
+        for key, val in map_class.items():
+            if isinstance(key, (str,)):
+                var_name = key
+                if isinstance(val, (tuple, list)):
                     # second element is documentation
-                    klass = v[0]
+                    klass = val[0]
                 res[var_name] = klass
-            elif type(k) in (type,):
+            elif type(key) in (type,):
                 # k is the class, v a list of tuples (name,doc)
-                klass = k
+                klass = key
                 default = res.setdefault(klass, [])
-                default.extend([tpl[0] for tpl in v])
+                default.extend([tpl[0] for tpl in val])
             else:
-                _log.raiseException("join_map_class: impossible to join key %s value %s" % (k, v))
+                raise EasyBuildError("join_map_class: impossible to join key %s value %s", key, val)
 
     return res
 
@@ -304,7 +307,7 @@ class ListOfLists(list):
         res = []
         if value is None:
             # TODO ? append_empty ?
-            self.log.raiseException("extend_el with None value unimplemented")
+            raise EasyBuildError("extend_el with None value unimplemented")
         else:
             for el in value:
                 if not self._str_ok(el):
@@ -484,7 +487,7 @@ class Variables(dict):
                 for el in self.get(other):
                     self.nappend(name, el)
             else:
-                self.log.raiseException("join: name %s; other %s not found in self." % (name, other))
+                raise EasyBuildError("join: name %s; other %s not found in self.", name, other)
 
     def append(self, name, value):
         """Append value to element name (alias for nappend)"""

--- a/setup.py
+++ b/setup.py
@@ -106,5 +106,5 @@ implement support for installing particular (groups of) software packages.""",
     provides=["eb"] + easybuild_packages,
     test_suite="test.framework.suite",
     zip_safe=False,
-    install_requires=["vsc-base >= 2.1.0"],
+    install_requires=["vsc-base >= 2.1.1"],
 )

--- a/setup.py
+++ b/setup.py
@@ -106,5 +106,5 @@ implement support for installing particular (groups of) software packages.""",
     provides=["eb"] + easybuild_packages,
     test_suite="test.framework.suite",
     zip_safe=False,
-    install_requires=["vsc-base >= 2.0.3"],
+    install_requires=["vsc-base >= 2.1.0"],
 )

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -35,7 +35,7 @@ from unittest import TestLoader
 from unittest import main as unittestmain
 from vsc.utils.fancylogger import getLogger, getRootLoggerName, logToFile, setLogFormat
 
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError
 from easybuild.tools.filetools import read_file, write_file
 
 
@@ -46,6 +46,11 @@ def raise_easybuilderror(msg, *args, **kwargs):
 
 class BuildLogTest(EnhancedTestCase):
     """Tests for EasyBuild log infrastructure."""
+
+    def tearDown(self):
+        """Cleanup after test."""
+        # restore default logging format
+        setLogFormat(LOGGING_FORMAT)
 
     def test_easybuilderror(self):
         """Tests for EasyBuildError."""

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -1,0 +1,96 @@
+# #
+# Copyright 2015-2015 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Unit tests for EasyBuild log infrastructure
+
+@author: Kenneth Hoste (Ghent University)
+"""
+import os
+import re
+import tempfile
+from test.framework.utilities import EnhancedTestCase, init_config
+from unittest import TestLoader
+from unittest import main as unittestmain
+from vsc.utils.fancylogger import getLogger, getRootLoggerName, logToFile, setLogFormat
+
+from easybuild.tools.build_log import EasyBuildError
+
+
+def raise_easybuilderror(msg, *args, **kwargs):
+    """Utility function: just raise a EasyBuildError."""
+    raise EasyBuildError(msg, *args, **kwargs)
+
+
+class BuildLogTest(EnhancedTestCase):
+    """Tests for EasyBuild log infrastructure."""
+
+    def test_easybuilderror(self):
+        """Tests for EasyBuildError."""
+        fd, tmplog = tempfile.mkstemp()
+        os.close(fd)
+
+        # auto-logging on raised EasyBuildError relies on deprecated functionality being used
+        # this should be removed for testing EasyBuild v3.x
+        os.environ['EASYBUILD_DEPRECATED'] = '2.1'
+        init_config()
+
+        # set log format, for each regex searching
+        setLogFormat("%(name)s :: %(message)s")
+
+        # if no logger is available, and no logger is specified, use default 'root' fancylogger
+        logToFile(tmplog, enable=True)
+        self.assertErrorRegex(EasyBuildError, 'BOOM', raise_easybuilderror, 'BOOM')
+        logToFile(tmplog, enable=False)
+
+        # replace log_re for EasyBuild v3.x
+        #log_re = re.compile("^%s :: EasyBuild crashed .*: BOOM$" % getRootLoggerName(), re.M)
+        root = getRootLoggerName()
+        log_re = re.compile("^%(root)s :: .*\n%(root)s :: EasyBuild crashed .*: BOOM$" % {'root': root}, re.M)
+        logtxt = open(tmplog, 'r').read()
+        self.assertTrue(log_re.match(logtxt), "%s matches %s" % (log_re.pattern, logtxt))
+
+        # test formatting of message
+        self.assertErrorRegex(EasyBuildError, 'BOOMBAF', raise_easybuilderror, 'BOOM%s', 'BAF')
+
+        os.remove(tmplog)
+
+    def test_easybuildlog(self):
+        """Tests for EasyBuildLog."""
+        log = getLogger('test_easybuildlog')
+
+        # test deprecated behaviour: raise EasyBuildError on log.error and log.exception
+        os.environ['EASYBUILD_DEPRECATED'] = '2.1'
+        init_config()
+
+        log.warning("No raise for warnings")
+        self.assertErrorRegex(EasyBuildError, 'EasyBuild crashed with an error', log.error, 'foo')
+        self.assertErrorRegex(EasyBuildError, 'EasyBuild encountered an exception', log.exception, 'bar')
+
+def suite():
+    """ returns all the testcases in this module """
+    return TestLoader().loadTestsFromTestCase(BuildLogTest)
+
+if __name__ == '__main__':
+    unittestmain()

--- a/test/framework/sandbox/easybuild/easyblocks/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/toy.py
@@ -33,9 +33,11 @@ import platform
 import shutil
 
 from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
+
 
 class EB_toy(EasyBlock):
     """Support for building/installing toy."""
@@ -55,7 +57,7 @@ class EB_toy(EasyBlock):
         # make sure Python system dep is handled correctly when specified
         if self.cfg['allow_system_deps']:
             if get_software_root('Python') != 'Python' or get_software_version('Python') != platform.python_version():
-                self.log.error("Sanity check on allowed Python system dep failed.")
+                raise EasyBlock("Sanity check on allowed Python system dep failed.")
         os.rename('%s.source' % name, '%s.c' % name)
 
     def build_step(self, name=None):

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -54,6 +54,7 @@ fancylogger.setLogLevelError()
 
 # toolkit should be first to allow hacks to work
 import test.framework.asyncprocess as a
+import test.framework.build_log as bl
 import test.framework.config as c
 import test.framework.easyblock as b
 import test.framework.easyconfig as e
@@ -99,7 +100,7 @@ log = fancylogger.getLogger()
 
 # call suite() for each module and then run them all
 # note: make sure the options unit tests run first, to avoid running some of them with a readily initialized config
-tests = [gen, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, l, f_c, sc, tw, p]
+tests = [gen, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, l, f_c, sc, tw, p]
 
 SUITE = unittest.TestSuite([x.suite() for x in tests])
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -240,7 +240,7 @@ class ToyBuildTest(EnhancedTestCase):
             'verify': False,
             'verbose': False,
         }
-        err_regex = r"crashed with an error.*Traceback[\S\s]*toy_buggy.py.*build_step[\S\s]*global name 'run_cmd'"
+        err_regex = r"Traceback[\S\s]*toy_buggy.py.*build_step[\S\s]*global name 'run_cmd'"
         self.assertErrorRegex(EasyBuildError, err_regex, self.test_toy_build, **kwargs)
 
     def test_toy_build_formatv2(self):


### PR DESCRIPTION
replaces #1183
depends on ~~https://github.com/hpcugent/vsc-base/pull/160~~ https://github.com/hpcugent/vsc-base/pull/163

update: see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html#report-errors-by-raising-easybuilderror-rather-than-using-log-methods