### PR TITLE
Move module path extension in module file

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1642,8 +1642,8 @@ class EasyBlock(object):
 
         txt = ''
         txt += self.make_module_description()
-        txt += self.make_module_extend_modpath()
         txt += self.make_module_dep()
+        txt += self.make_module_extend_modpath()
         txt += self.make_module_req()
         txt += self.make_module_extra()
         txt += self.make_module_footer()


### PR DESCRIPTION
This is something that is required if you are using a Toolchain based name space. An example would be gpsmpi, where GCC is a dependency, this ensure that the path is extended by GCC before being extended by gpsmpi