### PR TITLE
Problem with timeout being considered a String

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -255,7 +255,7 @@ def download_file(filename, url, path):
 
     _log.debug("Trying to download %s from %s to %s", filename, url, path)
 
-    timeout = build_option('download_timeout')
+    timeout = float(build_option('download_timeout'))
     if timeout is None:
         # default to 10sec timeout if none was specified
         # default system timeout (used is nothing is specified) may be infinite (?)


### PR DESCRIPTION
I needed this quick patch to get the download-timeout to work

should it be an int? the error was download_timeout not a Float was the only reason I did it this way.