### PR TITLE
modified the git commit message

### DIFF
--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -139,10 +139,9 @@ class GitRepository(FileRepository):
         Commit working copy to git repository
         """
         self.log.debug("committing in git: %s" % msg)
-        completemsg = "EasyBuild-commit from %s (time: %s, user: %s) \n%s" % (socket.gethostname(),
+        completemsg = "%s \nEasyBuild-commit from %s (time: %s, user: %s) " % (socket.gethostname(),
                                                                               time.strftime("%Y-%m-%d_%H-%M-%S"),
-                                                                              getpass.getuser(),
-                                                                              msg)
+                                                                              getpass.getuser())
         self.log.debug("git status: %s" % self.client.status())
         try:
             self.client.commit('-am "%s"' % completemsg)

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -139,7 +139,7 @@ class GitRepository(FileRepository):
         Commit working copy to git repository
         """
         self.log.debug("committing in git: %s" % msg)
-        completemsg = "%s \nEasyBuild-commit from %s (time: %s, user: %s) " % (socket.gethostname(),
+        completemsg = "%s EasyBuild-commit from %s (time: %s, user: %s) " % (socket.gethostname(),
                                                                               time.strftime("%Y-%m-%d_%H-%M-%S"),
                                                                               getpass.getuser())
         self.log.debug("git status: %s" % self.client.status())


### PR DESCRIPTION
now the commit message prints first the build machine hostname and date. I think it's more useful (at least for me) to print first the installed software