### PR TITLE
fix origin of raised EasyBuildError in logged error message

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -58,25 +58,17 @@ class EasyBuildError(LoggedException):
     """
     EasyBuildError is thrown when EasyBuild runs into something horribly wrong.
     """
+    LOC_INFO_TOP_PKG_NAMES = ['easybuild', 'vsc']
+    LOC_INFO_LEVEL = 1
+
     # use custom error logging method, to make sure EasyBuildError isn't being raised again to avoid infinite recursion
     # only required because 'error' log method raises (should no longer be needed in EB v3.x)
     LOGGING_METHOD_NAME = '_error_no_raise'
 
     def __init__(self, msg, *args):
         """Constructor: initialise EasyBuildError instance."""
-        # figure out where error was raised from
-        # current frame: this constructor, one frame above: location where this EasyBuildError was created/raised
-        frameinfo = inspect.getouterframes(inspect.currentframe())[1]
-
-        # determine short location of Python module where error was raised from (starting with 'easybuild/' or 'vsc/')
-        path_parts = frameinfo[1].split(os.path.sep)
-        relpath = path_parts.pop()
-        while not (relpath.startswith('easybuild/') or relpath.startswith('vsc/')) and path_parts:
-            relpath = os.path.join(path_parts.pop() or os.path.sep, relpath)
-
-        # include location info at the end of the message
-        # for example: "Nope, giving up (at easybuild/tools/somemodule.py:123 in some_function)"
-        msg = "%s (at %s:%s in %s)" % (msg % args, relpath, frameinfo[2], frameinfo[3])
+        if args:
+            msg = msg % args
         LoggedException.__init__(self, msg)
         self.msg = msg
 

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -31,7 +31,6 @@ EasyBuild logger and log utilities, including our own EasybuildError class.
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 """
-import inspect
 import os
 import sys
 import tempfile

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -68,7 +68,7 @@ class EasyBuildError(LoggedException):
         # current frame: this constructor, one frame above: location where this EasyBuildError was created/raised
         frameinfo = inspect.getouterframes(inspect.currentframe())[1]
 
-        # determine short location of Python module where error was raised from (starting with 'easybuild/')
+        # determine short location of Python module where error was raised from (starting with 'easybuild/' or 'vsc/')
         path_parts = frameinfo[1].split(os.path.sep)
         relpath = path_parts.pop()
         while not (relpath.startswith('easybuild/') or relpath.startswith('vsc/')) and path_parts:

--- a/setup.py
+++ b/setup.py
@@ -106,5 +106,5 @@ implement support for installing particular (groups of) software packages.""",
     provides=["eb"] + easybuild_packages,
     test_suite="test.framework.suite",
     zip_safe=False,
-    install_requires=["vsc-base >= 2.1.1"],
+    install_requires=["vsc-base >= 2.2.0"],
 )

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -65,7 +65,7 @@ class BuildLogTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, 'BOOM', raise_easybuilderror, 'BOOM')
         logToFile(tmplog, enable=False)
 
-        log_re = re.compile("^%s :: EasyBuild crashed .*: BOOM$" % getRootLoggerName(), re.M)
+        log_re = re.compile("^%s :: BOOM \(at %s:[0-9]+ in [a-z_]+\)$" % (getRootLoggerName(), __file__), re.M)
         logtxt = open(tmplog, 'r').read()
         self.assertTrue(log_re.match(logtxt), "%s matches %s" % (log_re.pattern, logtxt))
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -109,7 +109,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         outtxt = self.eb_main([])
 
-        error_msg = "ERROR .* Please provide one or multiple easyconfig files,"
+        error_msg = "ERROR Please provide one or multiple easyconfig files,"
         error_msg += " or use software build options to make EasyBuild search for easyconfigs"
         self.assertTrue(re.search(error_msg, outtxt), "Error message when eb is run without arguments")
 
@@ -922,9 +922,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
         outtxt = self.eb_main(args)
 
         # error message when template is not found
-        error_msg1 = "ERROR .* No easyconfig files found for software nosuchsoftware, and no templates available. I'm all out of ideas."
+        error_msg1 = "ERROR No easyconfig files found for software nosuchsoftware, and no templates available. "
+        error_msg1 += "I'm all out of ideas."
         # error message when template is found
-        error_msg2 = "ERROR .* Unable to find an easyconfig for the given specifications"
+        error_msg2 = "ERROR Unable to find an easyconfig for the given specifications"
         msg = "Error message when eb can't find software with specified name (outtxt: %s)" % outtxt
         self.assertTrue(re.search(error_msg1, outtxt) or re.search(error_msg2, outtxt), msg)
 


### PR DESCRIPTION
update: now depends on https://github.com/hpcugent/vsc-base/pull/165

fixes the issue discussed at https://github.com/hpcugent/easybuild-framework/pull/1218/files#r27470965

before:

```
$ eb foo.eb -ld
...
== 2015-03-31 21:13:22,460 main ERROR EasyBuild crashed with an error (at easybuild/tools/build_log.py:136 in _error_no_raise): Can't find path /Users/kehoste/work/easybuild-framework/foo.eb
ERROR: Can't find path /Users/kehoste/work/easybuild-framework/foo.eb
```

after:

```
$ eb foo.eb -ld
...
== 2015-03-31 21:12:33,311 main ERROR Can't find path /Users/kehoste/work/easybuild-framework/foo.eb (at easybuild/framework/easyconfig/tools.py:316 in parse_easyconfigs)
ERROR: Can't find path /Users/kehoste/work/easybuild-framework/foo.eb (at easybuild/framework/easyconfig/tools.py:316 in parse_easyconfigs)
```