### PR TITLE
add --installpath-modules and --installpath-software configuration options

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -334,8 +334,7 @@ def install_path(typ=None):
     res = variables[key]
     if res is None:
         key = 'subdir_%s' % typ
-        subdir = variables[key]
-        res = os.path.join(variables['installpath'], subdir)
+        res = os.path.join(variables['installpath'], variables[key])
         _log.debug("%s install path as specified by 'installpath' and '%s': %s", typ, key, res)
     else:
         _log.debug("%s install path as specified by '%s': %s", typ, key, res)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -324,14 +324,21 @@ def install_path(typ=None):
     elif typ == 'mod':
         typ = 'modules'
 
+    known_types = ['modules', 'software']
+    if typ not in known_types:
+        raise EasyBuildError("Unknown type specified in install_path(): %s (known: %s)", typ, ', '.join(known_types))
+
     variables = ConfigurationVariables()
 
-    res = None
-    if variables.get('installpath_%s' % typ, None) is None:
-        suffix = variables['subdir_%s' % typ]
-        res = os.path.join(variables['installpath'], suffix)
+    key = 'installpath_%s' % typ
+    res = variables[key]
+    if res is None:
+        key = 'subdir_%s' % typ
+        subdir = variables[key]
+        res = os.path.join(variables['installpath'], subdir)
+        _log.debug("%s install path as specified by 'installpath' and '%s': %s", typ, key, res)
     else:
-        res = variables['installpath_%s' % typ]
+        _log.debug("%s install path as specified by '%s': %s", typ, key, res)
 
     return res
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -181,6 +181,8 @@ class ConfigurationVariables(FrozenDictKnownKeys):
         'buildpath',
         'config',
         'installpath',
+        'installpath_modules',
+        'installpath_software',
         'logfile_format',
         'moduleclasses',
         'module_naming_scheme',
@@ -323,8 +325,15 @@ def install_path(typ=None):
         typ = 'modules'
 
     variables = ConfigurationVariables()
-    suffix = variables['subdir_%s' % typ]
-    return os.path.join(variables['installpath'], suffix)
+
+    res = None
+    if variables.get('installpath_%s' % typ, None) is None:
+        suffix = variables['subdir_%s' % typ]
+        res = os.path.join(variables['installpath'], suffix)
+    else:
+        res = variables['installpath_%s' % typ]
+
+    return res
 
 
 def get_repository():

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -236,8 +236,10 @@ class EasyBuildOptions(GeneralOption):
                             'strlist', 'store', ['.git', '.svn']),
             'installpath': ("Install path for software and modules",
                             None, 'store', mk_full_default_path('installpath')),
-            'installpath-modules': ("Install path for modules", None, 'store', None),
-            'installpath-software': ("Install path for software", None, 'store', None),
+            'installpath-modules': ("Install path for modules (if None, combine --installpath and --subdir-modules)",
+                                    None, 'store', None),
+            'installpath-software': ("Install path for software (if None, combine --installpath and --subdir-software)",
+                                     None, 'store', None),
             # purposely take a copy for the default logfile format
             'logfile-format': ("Directory name and format of the log file",
                                'strtuple', 'store', DEFAULT_LOGFILE_FORMAT[:], {'metavar': 'DIR,FORMAT'}),
@@ -372,14 +374,12 @@ class EasyBuildOptions(GeneralOption):
             val = getattr(self.options, opt.replace('-', '_'))
             if val and len(val) != 2:
                 msg = "--%s requires NAME,VERSION (given %s)" % (opt, ','.join(val))
-                self.log.warning(msg)
                 error_msgs.append(msg)
 
         if self.options.umask:
             umask_regex = re.compile('^[0-7]{3}$')
             if not umask_regex.match(self.options.umask):
                 msg = "--umask value should be 3 digits (0-7) (regex pattern '%s')" % umask_regex.pattern
-                self.log.warning(msg)
                 error_msgs.append(msg)
 
         # subdir options must be relative
@@ -389,12 +389,10 @@ class EasyBuildOptions(GeneralOption):
             if os.path.isabs(getattr(self.options, subdir_opt)):
                 msg = "Configuration option '%s' must specify a *relative* path (use 'installpath-%s' instead?): '%s'"
                 msg = msg % (subdir_opt, typ, val)
-                self.log.warning(msg)
                 error_msgs.append(msg)
 
         if error_msgs:
-            raise EasyBuildError("Found problems validating the options, treating warnings in log file as fatal: %s",
-                                 '\n'.join(error_msgs))
+            raise EasyBuildError("Found problems validating the options: %s", '\n'.join(error_msgs))
 
     def postprocess(self):
         """Do some postprocessing, in particular print stuff"""

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -236,6 +236,8 @@ class EasyBuildOptions(GeneralOption):
                             'strlist', 'store', ['.git', '.svn']),
             'installpath': ("Install path for software and modules",
                             None, 'store', mk_full_default_path('installpath')),
+            'installpath-modules': ("Install path for modules", None, 'store', None),
+            'installpath-software': ("Install path for software", None, 'store', None),
             # purposely take a copy for the default logfile format
             'logfile-format': ("Directory name and format of the log file",
                                'strtuple', 'store', DEFAULT_LOGFILE_FORMAT[:], {'metavar': 'DIR,FORMAT'}),

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -179,6 +179,40 @@ class EasyBuildConfigTest(EnhancedTestCase):
         del os.environ['EASYBUILD_PREFIX']
         del os.environ['EASYBUILD_SUBDIR_SOFTWARE']
 
+    def test_install_path(self):
+        """Test install_path function."""
+        # defaults
+        self.assertEqual(install_path(), os.path.join(self.test_installpath, 'software'))
+        self.assertEqual(install_path('software'), os.path.join(self.test_installpath, 'software'))
+        self.assertEqual(install_path(typ='mod'), os.path.join(self.test_installpath, 'modules'))
+        self.assertEqual(install_path('modules'), os.path.join(self.test_installpath, 'modules'))
+
+        self.assertErrorRegex(EasyBuildError, "Unknown type specified", install_path, typ='foo')
+
+        args = [
+            '--subdir-software', 'SOFT',
+            '--installpath', '/foo',
+        ]
+        os.environ['EASYBUILD_SUBDIR_MODULES'] = 'MOD'
+        init_config(args=args)
+        self.assertEqual(install_path(), os.path.join('/foo', 'SOFT'))
+        self.assertEqual(install_path(typ='mod'), os.path.join('/foo', 'MOD'))
+        del os.environ['EASYBUILD_SUBDIR_MODULES']
+
+        args = [
+            '--installpath', '/prefix',
+            '--installpath-modules', '/foo',
+        ]
+        os.environ['EASYBUILD_INSTALLPATH_SOFTWARE'] = '/bar/baz'
+        init_config(args=args)
+        self.assertEqual(install_path(), os.path.join('/bar', 'baz'))
+        self.assertEqual(install_path(typ='mod'), '/foo')
+
+        del os.environ['EASYBUILD_INSTALLPATH_SOFTWARE']
+        init_config(args=args)
+        self.assertEqual(install_path(), os.path.join('/prefix', 'software'))
+        self.assertEqual(install_path(typ='mod'), '/foo')
+
     def test_generaloption_config_file(self):
         """Test use of new-style configuration file."""
         self.purge_environment()

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -159,11 +159,14 @@ class EasyBuildConfigTest(EnhancedTestCase):
 
         os.environ['EASYBUILD_PREFIX'] = prefix
         os.environ['EASYBUILD_SUBDIR_SOFTWARE'] = subdir_software
+        installpath_modules = tempfile.mkdtemp(prefix='installpath-modules')
+        os.environ['EASYBUILD_INSTALLPATH_MODULES'] = installpath_modules
 
         options = init_config(args=args)
 
         self.assertEqual(build_path(), os.path.join(prefix, 'build'))
         self.assertEqual(install_path(), os.path.join(install, subdir_software))
+        self.assertEqual(install_path('mod'), installpath_modules)
 
         del os.environ['EASYBUILD_PREFIX']
         del os.environ['EASYBUILD_SUBDIR_SOFTWARE']
@@ -187,16 +190,19 @@ class EasyBuildConfigTest(EnhancedTestCase):
         ])
         write_file(config_file, cfgtxt)
 
+        installpath_software = tempfile.mkdtemp(prefix='installpath-software')
         args = [
             '--configfiles', config_file,
             '--debug',
             '--buildpath', testpath1,
+            '--installpath-software', installpath_software,
         ]
         options = init_config(args=args)
 
         self.assertEqual(build_path(), testpath1)  # via command line
         self.assertEqual(source_paths(), [os.path.join(os.getenv('HOME'), '.local', 'easybuild', 'sources')])  # default
-        self.assertEqual(install_path(), os.path.join(testpath2, 'software'))  # via config file
+        self.assertEqual(install_path(), installpath_software)  # via cmdline arg
+        self.assertEqual(install_path('mod'), os.path.join(testpath2, 'modules'))  # via config file
 
         # copy test easyconfigs to easybuild/easyconfigs subdirectory of temp directory
         # to check whether easyconfigs install path is auto-included in robot path
@@ -210,12 +216,14 @@ class EasyBuildConfigTest(EnhancedTestCase):
         sys.path.insert(0, tmpdir)  # prepend to give it preference over possible other installed easyconfigs pkgs
 
         # test with config file passed via environment variable
+        installpath_modules = tempfile.mkdtemp(prefix='installpath-modules')
         cfgtxt = '\n'.join([
             '[config]',
             'buildpath = %s' % testpath1,
             'sourcepath = %(DEFAULT_REPOSITORYPATH)s',
             'repositorypath = %(DEFAULT_REPOSITORYPATH)s,somesubdir',
             'robot-paths=/tmp/foo:%(sourcepath)s:%(DEFAULT_ROBOT_PATHS)s',
+            'installpath-modules=%s' % installpath_modules,
         ])
         write_file(config_file, cfgtxt)
 
@@ -228,6 +236,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
 
         topdir = os.path.join(os.getenv('HOME'), '.local', 'easybuild')
         self.assertEqual(install_path(), os.path.join(topdir, 'software'))  # default
+        self.assertEqual(install_path('mod'), installpath_modules),  # via config file
         self.assertEqual(source_paths(), [testpath2])  # via command line
         self.assertEqual(build_path(), testpath1)  # via config file
         self.assertEqual(get_repositorypath(), [os.path.join(topdir, 'ebfiles_repo'), 'somesubdir'])  # via config file
@@ -248,6 +257,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
 
         self.assertEqual(source_paths(), [testpath2])  # via environment variable $EASYBUILD_SOURCEPATHS
         self.assertEqual(install_path(), os.path.join(testpath3, 'software'))  # via command line
+        self.assertEqual(install_path('mod'), installpath_modules),  # via config file
         self.assertEqual(build_path(), testpath1)  # via config file
 
         del os.environ['EASYBUILD_CONFIGFILES']


### PR DESCRIPTION
fix for https://github.com/hpcugent/easybuild/issues/105

Required to be able to install software and modules in totally different paths; this will come in useful when adding support for only (re)installing modules, so modules in using a different naming scheme can be installed in a different path, without having to reinstall the software.