### PR TITLE
fix dealing with empty variables in Variables.join method

### DIFF
--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -481,6 +481,10 @@ class Variables(dict):
                 else it is nappend-ed
         """
         self.log.debug("join name %s others %s" % (name, others))
+
+        # make sure name is defined, even if 'others' list is empty
+        self[name] = []
+
         for other in others:
             if other in self:
                 self.log.debug("join other %s in self: other %s" % (other, self.get(other).__repr__()))

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -483,7 +483,7 @@ class Variables(dict):
         self.log.debug("join name %s others %s" % (name, others))
 
         # make sure name is defined, even if 'others' list is empty
-        self[name] = []
+        self.setdefault(name)
 
         for other in others:
             if other in self:

--- a/test/framework/variables.py
+++ b/test/framework/variables.py
@@ -78,6 +78,16 @@ class VariablesTest(EnhancedTestCase):
         cmd = CommandFlagList(["gcc", "bar", "baz"])
         self.assertEqual(str(cmd), "gcc -bar -baz")
 
+    def test_empty_variables(self):
+        """Test playing around with empty variables."""
+        v = Variables()
+        v.nappend('FOO', [])
+        self.assertEqual(v['FOO'], [])
+        v.join('BAR', 'FOO')
+        self.assertEqual(v['BAR'], [])
+        v.join('FOOBAR', 'BAR')
+        self.assertEqual(v['FOOBAR'], [])
+
 def suite():
     """ return all the tests"""
     return TestLoader().loadTestsFromTestCase(VariablesTest)


### PR DESCRIPTION
the tests failed with the patch in variables.py

this popped up when using `BLAS_LIB = []` and `LAPACK_IS_BLAS = True` in the support for the CrayPE compiler drivers (cfr. https://github.com/hpcugent/easybuild-framework/pull/1234)

@stdweird: please review
cc @pforai