### PR TITLE
get rid of $PROFILEREAD hack when running commands, not needed anymore

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -60,29 +60,6 @@ ERROR = 'error'
 strictness = WARN
 
 
-def adjust_cmd(func):
-    """Make adjustments to given command, if required."""
-
-    def inner(cmd, *args, **kwargs):
-        # SuSE hack
-        # - profile is not resourced, and functions (e.g. module) is not inherited
-        if 'PROFILEREAD' in os.environ and (len(os.environ['PROFILEREAD']) > 0):
-            filepaths = ['/etc/profile.d/modules.sh']
-            extra = ''
-            for fp in filepaths:
-                if os.path.exists(fp):
-                    extra = ". %s &&%s" % (fp, extra)
-                else:
-                    _log.warning("Can't find file %s" % fp)
-
-            cmd = "%s %s" % (extra, cmd)
-
-        return func(cmd, *args, **kwargs)
-
-    return inner
-
-
-@adjust_cmd
 def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True, log_output=False, path=None):
     """
     Executes a command cmd
@@ -153,7 +130,6 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
 
 
-@adjust_cmd
 def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, regexp=True, std_qa=None, path=None):
     """
     Executes a command cmd

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -95,30 +95,6 @@ class RunTest(EnhancedTestCase):
         errors = parse_log_for_error("error failed", True)
         self.assertEqual(len(errors), 1)
 
-    def test_run_cmd_suse(self):
-        """Test run_cmd on SuSE systems, which have $PROFILEREAD set."""
-        # avoid warning messages
-        run_log_level = run_log.getEffectiveLevel()
-        run_log.setLevel('ERROR')
-
-        # run_cmd should also work if $PROFILEREAD is set (very relevant for SuSE systems)
-        profileread = os.environ.get('PROFILEREAD', None)
-        os.environ['PROFILEREAD'] = 'profilereadxxx'
-        try:
-            (out, ec) = run_cmd("echo hello")
-        except Exception, err:
-            out, ec = "ERROR: %s" % err, 1
-
-        # make sure it's restored again before we can fail the test
-        if profileread is not None:
-            os.environ['PROFILEREAD'] = profileread
-        else:
-            del os.environ['PROFILEREAD']
-
-        self.assertEqual(out, "hello\n")
-        self.assertEqual(ec, 0)
-        run_log.setLevel(run_log_level)
-
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
We used to make sure that `/etc/profile.d/modules.sh` was being resources on every command being executed when `$PROFILEREAD` was defined (i.e. on SuSE Linux systems).

The only reason why this was needed was to make sure that the `module` function is defined in the environment in which the command is being executed.

However, we don't rely on `module` at all, so there's no longer any need for this.

@pforai: feedback, since you guys are running SuSE?