### PR TITLE
enhance --search: only consider actual filename (not entire path), use regex syntax

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -342,6 +342,8 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False):
         raise EasyBuildError("search_file: ignore_dirs (%s) should be of type list, not %s",
                              ignore_dirs, type(ignore_dirs))
 
+    query = re.compile(query.lower())
+
     var_lines = []
     hit_lines = []
     var_index = 1
@@ -349,18 +351,16 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False):
     for path in paths:
         hits = []
         hit_in_path = False
-        print_msg("Searching (case-insensitive) for '%s' in %s " % (query, path), log=_log, silent=silent)
+        print_msg("Searching (case-insensitive) for '%s' in %s " % (query.pattern, path), log=_log, silent=silent)
 
-        query = query.lower()
         for (dirpath, dirnames, filenames) in os.walk(path, topdown=True):
             for filename in filenames:
-                filename = os.path.join(dirpath, filename)
-                if filename.lower().find(query) != -1:
+                if query.search(filename.lower()):
                     if not hit_in_path:
                         var = "CFGS%d" % var_index
                         var_index += 1
                         hit_in_path = True
-                    hits.append(filename)
+                    hits.append(os.path.join(dirpath, filename))
 
             # do not consider (certain) hidden directories
             # note: we still need to consider e.g., .local !

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -342,7 +342,8 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False):
         raise EasyBuildError("search_file: ignore_dirs (%s) should be of type list, not %s",
                              ignore_dirs, type(ignore_dirs))
 
-    query = re.compile(query.lower())
+    # compile regex, case-insensitive
+    query = re.compile(query, re.I)
 
     var_lines = []
     hit_lines = []
@@ -355,7 +356,7 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False):
 
         for (dirpath, dirnames, filenames) in os.walk(path, topdown=True):
             for filename in filenames:
-                if query.search(filename.lower()):
+                if query.search(filename):
                     if not hit_in_path:
                         var = "CFGS%d" % var_index
                         var_index += 1

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -574,6 +574,26 @@ class CommandLineOptionsTest(EnhancedTestCase):
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)
 
+        write_file(self.logfile, '')
+
+        args = [
+            '--search=^gcc.*2.eb',
+            '--robot=%s' % os.path.join(os.path.dirname(__file__), 'easyconfigs'),
+            '--unittest-file=%s' % self.logfile,
+        ]
+        self.eb_main(args, logfile=dummylogfn)
+        logtxt = read_file(self.logfile)
+
+        info_msg = r"Searching \(case-insensitive\) for '\^gcc.\*2.eb' in"
+        self.assertTrue(re.search(info_msg, logtxt), "Info message when searching for easyconfigs in '%s'" % logtxt)
+        for ec in ['GCC-4.7.2.eb', 'GCC-4.8.2.eb', 'GCC-4.9.2.eb']:
+            self.assertTrue(re.search(r" \* \S*%s$" % ec, logtxt, re.M), "Found easyconfig %s in '%s'" % (ec, logtxt))
+
+        if os.path.exists(dummylogfn):
+            os.remove(dummylogfn)
+
+        write_file(self.logfile, '')
+
         for search_arg in ['-S', '--search-short']:
             open(self.logfile, 'w').write('')
             args = [


### PR DESCRIPTION
This change is motivated by the output of `--search` that was produced by `eb --search python`, which in practice resulted in *all* easyconfigs to be listed (since it's not unlikely that 'python' is part of the full path).

With this change, this works as expected:

```
eb -S '^Python-[23].*eb' 
```