### PR TITLE
remove log handlers that were added during tests, to ensure effective cleanup of log files

### DIFF
--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -39,9 +39,9 @@ from vsc.utils import fancylogger
 
 origLogToFile = fancylogger.logToFile
 def tweakedLogToFile(*args, **kwargs):
-    """Modified logToFile, with 100KB max log file size and no rotation."""
-    kwargs['max_bytes'] = 1024*1024
-    kwargs['backup_count'] = 0
+    """Modified logToFile, with 1MB max log file size and no rotation."""
+    kwargs['max_bytes'] = 1024*1024  # 1MB
+    kwargs['backup_count'] = 0  # don't keep any rotated logs
     return origLogToFile(*args, **kwargs)
 fancylogger.logToFile = tweakedLogToFile
 

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -41,7 +41,7 @@ origLogToFile = fancylogger.logToFile
 def tweakedLogToFile(*args, **kwargs):
     """Modified logToFile, with 100KB max log file size and no rotation."""
     kwargs['max_bytes'] = 1024*1024
-    kwargs['backup_count'] = 1
+    kwargs['backup_count'] = 0
     return origLogToFile(*args, **kwargs)
 fancylogger.logToFile = tweakedLogToFile
 

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -37,6 +37,14 @@ import tempfile
 import unittest
 from vsc.utils import fancylogger
 
+origLogToFile = fancylogger.logToFile
+def tweakedLogToFile(*args, **kwargs):
+    """Modified logToFile, with 100KB max log file size and no rotation."""
+    kwargs['max_bytes'] = 1024*1024
+    kwargs['backup_count'] = 1
+    return origLogToFile(*args, **kwargs)
+fancylogger.logToFile = tweakedLogToFile
+
 # initialize EasyBuild logging, so we disable it
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import set_tmpdir

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -37,14 +37,6 @@ import tempfile
 import unittest
 from vsc.utils import fancylogger
 
-origLogToFile = fancylogger.logToFile
-def tweakedLogToFile(*args, **kwargs):
-    """Modified logToFile, with 1MB max log file size and no rotation."""
-    kwargs['max_bytes'] = 1024*1024  # 1MB
-    kwargs['backup_count'] = 0  # don't keep any rotated logs
-    return origLogToFile(*args, **kwargs)
-fancylogger.logToFile = tweakedLogToFile
-
 # initialize EasyBuild logging, so we disable it
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import set_tmpdir

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -48,7 +48,7 @@ from easybuild.main import main
 from easybuild.tools import config
 from easybuild.tools.config import module_classes, set_tmpdir
 from easybuild.tools.environment import modify_env
-from easybuild.tools.filetools import mkdir, read_file, write_file
+from easybuild.tools.filetools import mkdir, read_file
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import CONFIG_ENV_VAR_PREFIX, EasyBuildOptions
@@ -152,9 +152,9 @@ class EnhancedTestCase(_EnhancedTestCase):
         # restore original Python search path
         sys.path = self.orig_sys_path
 
-        # cleanup: remove test directory, but restores log files (empty)
+        # cleanup: remove test directory, but restore log files (as empty files)
         # log rotation only kicks in when *all* log handles are out of scope (when this TestCase object is removed);
-        # log files should still be in place at that time
+        # log files must still be in place at that time
         try:
             logfiles = []
             for root, _, filenames in os.walk(self.test_prefix):
@@ -165,9 +165,12 @@ class EnhancedTestCase(_EnhancedTestCase):
             shutil.rmtree(self.test_prefix)
 
             for logfile in logfiles:
-                mkdir(os.path.dirname(logfile), parents=True)
-                write_file(logfile, '')
-        except OSError, err:
+                os.makedirs(os.path.dirname(logfile))
+                f = open(logfile, 'w')
+                f.write('')
+                f.close()
+                sys.stderr.write('Restored %s\n' % logfile)
+        except (OSError, IOError), err:
             pass
 
         # restore original 'parent' tmpdir

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -153,7 +153,8 @@ class EnhancedTestCase(_EnhancedTestCase):
         sys.path = self.orig_sys_path
 
         # cleanup: remove test directory, but restores log files (empty)
-        # log rotation only kicks in when *all* log handles are out of scope
+        # log rotation only kicks in when *all* log handles are out of scope (when this TestCase object is removed);
+        # log files should still be in place at that time
         try:
             logfiles = []
             for root, _, filenames in os.walk(self.test_prefix):

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -169,7 +169,6 @@ class EnhancedTestCase(_EnhancedTestCase):
                 f = open(logfile, 'w')
                 f.write('')
                 f.close()
-                sys.stderr.write('Restored %s\n' % logfile)
         except (OSError, IOError), err:
             pass
 
@@ -215,6 +214,8 @@ class EnhancedTestCase(_EnhancedTestCase):
 
         env_before = copy.deepcopy(os.environ)
 
+        log = fancylogger.getLogger(fname=False)
+        orig_log_handlers = log.handlers[:]
         try:
             main((args, logfile, do_build))
         except SystemExit:
@@ -223,6 +224,12 @@ class EnhancedTestCase(_EnhancedTestCase):
             myerr = err
             if verbose:
                 print "err: %s" % err
+
+        # remove any log handlers that were added by main()
+        new_log_handlers = [h for h in log.handlers if h not in orig_log_handlers]
+        for log_handler in new_log_handlers:
+            log_handler.close()
+            log.removeHandler(log_handler)
 
         logtxt = read_file(logfile)
 


### PR DESCRIPTION
Although each test is properly cleaning up the tmp dir that was assigned to it in `tearDown`, the disk space used by the log files was not being freed because of open file handles on the log files.

I looked into properly cleaning up those file handles to trigger the disk space being freed, but this proved to be far from trivial (I concluded this after quite a couple of hours of digging around, accompanied with lots of swearing).

Alternative solution (thanks to @stdweird for the tip): quickly rotate the log files, so that only small bits (max 1MB per log) are left behind in the overall tmp directory used by the running test suite.

This effectively trims the required disk space in /tmp (or equivalent) down from ~3GB to less than 100MB.