### PR TITLE
define $CRAYPE_LINK_TYPE if 'dynamic' toolchain option is enabled

### DIFF
--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -68,10 +68,9 @@ class CrayPECompiler(Compiler):
     }
 
     COMPILER_UNIQUE_OPTION_MAP = {
-        #handled shared and dynamic always via CRAYPE_LINK_TYPE environment variable, dont pass flags to wrapper.
+        # handle shared and dynamic always via $CRAYPE_LINK_TYPE environment variable, don't pass flags to wrapper
         'shared': '',
         'dynamic': '',
-        'static': 'static',
         'verbose': 'craype-verbose',
         'mpich-mt': 'craympich-mt',
     }
@@ -119,6 +118,7 @@ class CrayPECompiler(Compiler):
         super(CrayPECompiler, self).prepare(*args, **kwargs)
 
         if self.options['dynamic'] or self.options['shared']:
+            self.log.debug("Enabling building of shared libs/dynamically linked executables via $CRAYPE_LINK_TYPE")
             env.setvar('CRAYPE_LINK_TYPE', 'dynamic')
 
 

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -37,6 +37,7 @@ Cray's LibSci (BLAS/LAPACK et al), FFT library, etc.
 @author: Petar Forai (IMP/IMBA, Austria)
 @author: Kenneth Hoste (Ghent University)
 """
+import easybuild.tools.environment as env
 from easybuild.toolchains.compiler.gcc import TC_CONSTANT_GCC, Gcc
 from easybuild.toolchains.compiler.inteliccifort import TC_CONSTANT_INTELCOMP, IntelIccIfort
 from easybuild.tools.build_log import EasyBuildError
@@ -111,6 +112,13 @@ class CrayPECompiler(Compiler):
 
         # no compiler flag when optarch toolchain option is enabled
         self.options.options_map['optarch'] = ''
+
+    def prepare(self, *args, **kwargs):
+        """Prepare to use this toolchain; define $CRAYPE_LINK_TYPE if 'dynamic' toolchain option is enabled."""
+        super(CrayPECompiler, self).prepare(*args, **kwargs)
+
+        if self.options['dynamic']:
+            env.setvar('CRAYPE_LINK_TYPE', 'dynamic')
 
 
 class CrayPEGCC(CrayPECompiler):


### PR DESCRIPTION
@pforai: not sure what to do with the `-dynamic` flag being passed to the compiler; should we keep that in place?

And should we also define `$CRAYPE_LINK_TYPE` if the `shared` toolchain option is defined?

Does it still make sense to have both `dynamic` and `shared` as separate toolchain options?