### PR TITLE
exclude 'easyblocks' pkg from sys.path, make sure $EASYBUILD_BOOTSTRAP* env vars are undefined via pop

### DIFF
--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -57,7 +57,7 @@ VSC_BASE = 'vsc-base'
 EASYBUILD_PACKAGES = [VSC_BASE, 'easybuild-framework', 'easybuild-easyblocks', 'easybuild-easyconfigs']
 
 # set print_debug to True for detailed progress info
-print_debug = os.environ.get('EASYBUILD_BOOTSTRAP_DEBUG', False)
+print_debug = os.environ.pop('EASYBUILD_BOOTSTRAP_DEBUG', False)
 
 # don't add user site directory to sys.path (equivalent to python -s), see https://www.python.org/dev/peps/pep-0370/
 os.environ['PYTHONNOUSERSITE'] = '1'
@@ -439,11 +439,11 @@ def main():
         error("Usage: %s <install path>" % sys.argv[0])
     install_path = os.path.abspath(sys.argv[1])
 
-    sourcepath = os.environ.get('EASYBUILD_BOOTSTRAP_SOURCEPATH')
+    sourcepath = os.environ.pop('EASYBUILD_BOOTSTRAP_SOURCEPATH', None)
     if sourcepath is not None:
         info("Fetching sources from %s..." % sourcepath)
 
-    skip_stage0 = os.environ.get('EASYBUILD_BOOTSTRAP_SKIP_STAGE0', False)
+    skip_stage0 = os.environ.pop('EASYBUILD_BOOTSTRAP_SKIP_STAGE0', False)
 
     # create temporary dir for temporary installations
     tmpdir = tempfile.mkdtemp()
@@ -459,7 +459,7 @@ def main():
     for path in orig_sys_path:
         include_path = True
         # exclude path if it's potentially an EasyBuild/VSC package, providing the 'easybuild'/'vsc' namespace, resp.
-        if any([os.path.exists(os.path.join(path, pkg, '__init__.py')) for pkg in ['easybuild', 'vsc']]):
+        if any([os.path.exists(os.path.join(path, pkg, '__init__.py')) for pkg in ['easyblocks', 'easybuild', 'vsc']]):
             include_path = False
         # exclude any .egg paths
         if path.endswith('.egg'):


### PR DESCRIPTION
The `setup.py` of easybuild-easyblocks import directly from the `easyblocks` package (see below), so any paths providing this namespace should also be excluded from the Python search path prior to initiating the bootstrap procedure.

```python
sys.path.append('easybuild')                                                                                            
from easyblocks import VERSION  
```

The `$EASYBUILD_BOOTSTRAP*` environment variables must be unset, since they are not valid EasyBuild configuration options, which EasyBuild trips over since v2.1.0 (see #1253).