### PR TITLE
reset keep toolchain component class 'constants' every time

### DIFF
--- a/easybuild/toolchains/compiler/cuda.py
+++ b/easybuild/toolchains/compiler/cuda.py
@@ -96,7 +96,7 @@ class Cuda(Compiler):
         self.variables.nappend('CUDA_CXXFLAGS', cuda_flags)
 
         # add gencode compiler flags to list of flags for compiler variables
-        for gencode_val in self.options['cuda_gencode']:
+        for gencode_val in self.options.get('cuda_gencode', []):
             gencode_option = 'gencode %s' % gencode_val
             self.variables.nappend('CUDA_CFLAGS', gencode_option)
             self.variables.nappend('CUDA_CXXFLAGS', gencode_option)

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -91,7 +91,7 @@ class IntelIccIfort(Compiler):
 
     def __init__(self, *args, **kwargs):
         """Toolchain constructor."""
-        self.CLASS_CONSTANTS_TO_RESTORE.append('LIB_MULTITHREAD')
+        self.add_class_constants_to_restore(['LIB_MULTITHREAD'])
         super(IntelIccIfort, self).__init__(*args, **kwargs)
 
     def _set_compiler_vars(self):

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -91,7 +91,8 @@ class IntelIccIfort(Compiler):
 
     def __init__(self, *args, **kwargs):
         """Toolchain constructor."""
-        self.add_class_constants_to_restore(['LIB_MULTITHREAD'])
+        class_constants = kwargs.setdefault('class_constants', [])
+        class_constants.append('LIB_MULTITHREAD')
         super(IntelIccIfort, self).__init__(*args, **kwargs)
 
     def _set_compiler_vars(self):

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -88,8 +88,11 @@ class IntelIccIfort(Compiler):
     }
 
     LIB_MULTITHREAD = ['iomp5', 'pthread']  # iomp5 is OpenMP related
-    # keep track of original value, needs to be restored every time since we append to class 'constant' LIB_MULTITHREAD
-    _INIT_LIB_MULTITHREAD = LIB_MULTITHREAD[:]
+
+    def __init__(self, *args, **kwargs):
+        """Toolchain constructor."""
+        self.CLASS_CONSTANTS_TO_RESTORE.append('LIB_MULTITHREAD')
+        super(IntelIccIfort, self).__init__(*args, **kwargs)
 
     def _set_compiler_vars(self):
         """Intel compilers-specific adjustments after setting compiler variables."""
@@ -106,9 +109,6 @@ class IntelIccIfort(Compiler):
             raise EasyBuildError("_set_compiler_vars: mismatch between icc version %s and ifort version %s",
                                  icc_version, ifort_version)
 
-        # reset LIB_MULTITHREAD every time,
-        # to avoid problems when multiple Intel compilers versions are used in a single session
-        self.LIB_MULTITHREAD = self._INIT_LIB_MULTITHREAD[:]
         if LooseVersion(icc_version) < LooseVersion('2011'):
             self.LIB_MULTITHREAD.insert(1, "guide")
 

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -87,7 +87,9 @@ class IntelIccIfort(Compiler):
         'dynamic':'-Bdynamic',
     }
 
-    LIB_MULTITHREAD = None
+    LIB_MULTITHREAD = ['iomp5', 'pthread']  # iomp5 is OpenMP related
+    # keep track of original value, needs to be restored every time since we append to class 'constant' LIB_MULTITHREAD
+    _INIT_LIB_MULTITHREAD = LIB_MULTITHREAD[:]
 
     def _set_compiler_vars(self):
         """Intel compilers-specific adjustments after setting compiler variables."""
@@ -106,7 +108,7 @@ class IntelIccIfort(Compiler):
 
         # reset LIB_MULTITHREAD every time,
         # to avoid problems when multiple Intel compilers versions are used in a single session
-        self.LIB_MULTITHREAD = ['iomp5', 'pthread']  # iomp5 is OpenMP related
+        self.LIB_MULTITHREAD = self._INIT_LIB_MULTITHREAD[:]
         if LooseVersion(icc_version) < LooseVersion('2011'):
             self.LIB_MULTITHREAD.insert(1, "guide")
 

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -87,7 +87,7 @@ class IntelIccIfort(Compiler):
         'dynamic':'-Bdynamic',
     }
 
-    LIB_MULTITHREAD = ['iomp5', 'pthread']  ## iomp5 is OpenMP related
+    LIB_MULTITHREAD = None
 
     def _set_compiler_vars(self):
         """Intel compilers-specific adjustments after setting compiler variables."""
@@ -104,6 +104,9 @@ class IntelIccIfort(Compiler):
             raise EasyBuildError("_set_compiler_vars: mismatch between icc version %s and ifort version %s",
                                  icc_version, ifort_version)
 
+        # reset LIB_MULTITHREAD every time,
+        # to avoid problems when multiple Intel compilers versions are used in a single session
+        self.LIB_MULTITHREAD = ['iomp5', 'pthread']  # iomp5 is OpenMP related
         if LooseVersion(icc_version) < LooseVersion('2011'):
             self.LIB_MULTITHREAD.insert(1, "guide")
 

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -60,7 +60,8 @@ class Acml(LinAlg):
 
     def __init__(self, *args, **kwargs):
         """Toolchain constructor."""
-        self.add_class_constants_to_restore(['BLAS_LIB', 'BLAS_LIB_MT'])
+        class_constants = kwargs.setdefault('class_constants', [])
+        class_constants.extend(['BLAS_LIB', 'BLAS_LIB_MT'])
         super(Acml, self).__init__(*args, **kwargs)
 
     def _set_blas_variables(self):

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -43,6 +43,7 @@ class Acml(LinAlg):
     Provides ACML BLAS/LAPACK support.
     """
     BLAS_MODULE_NAME = ['ACML']
+    # full list of libraries is highly dependent on ACML version and toolchain compiler (ifort, gfortran, ...)
     BLAS_LIB = ['acml']
     BLAS_LIB_MT = ['acml_mp']
 

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -60,7 +60,7 @@ class Acml(LinAlg):
 
     def __init__(self, *args, **kwargs):
         """Toolchain constructor."""
-        self.CLASS_CONSTANTS_TO_RESTORE.extend(['BLAS_LIB', 'BLAS_LIB_MT'])
+        self.add_class_constants_to_restore(['BLAS_LIB', 'BLAS_LIB_MT'])
         super(Acml, self).__init__(*args, **kwargs)
 
     def _set_blas_variables(self):

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -45,9 +45,6 @@ class Acml(LinAlg):
     BLAS_MODULE_NAME = ['ACML']
     BLAS_LIB = ['acml']
     BLAS_LIB_MT = ['acml_mp']
-    # keep track of original values, need to be restored every time since we append to class 'constants' BLAS_LIB*
-    _INIT_BLAS_LIB = BLAS_LIB[:]
-    _INIT_BLAS_LIB_MT = BLAS_LIB_MT[:]
 
     # is completed in _set_blas_variables, depends on compiler used
     BLAS_LIB_DIR = []
@@ -59,6 +56,11 @@ class Acml(LinAlg):
         TC_CONSTANT_INTELCOMP: ['ifort64', 'ifort64_mp'],
         TC_CONSTANT_GCC: ['gfortran64', 'gfortran64_mp'],
     }
+
+    def __init__(self, *args, **kwargs):
+        """Toolchain constructor."""
+        self.CLASS_CONSTANTS_TO_RESTORE.extend(['BLAS_LIB', 'BLAS_LIB_MT'])
+        super(Acml, self).__init__(*args, **kwargs)
 
     def _set_blas_variables(self):
         """Fix the map a bit"""
@@ -74,11 +76,6 @@ class Acml(LinAlg):
         except:
             raise EasyBuildError("_set_blas_variables: ACML set LDFLAGS/CPPFLAGS unknown entry in ACML_SUBDIRS_MAP "
                                  "with compiler family %s", self.COMPILER_FAMILY)
-
-        # reset BLAS_LIB(_MT) every time, to avoid problems when multiple ACML versions are used in a single session
-        # full list of libraries is highly dependent on ACML version and toolchain compiler (ifort, gfortran, ...)
-        self.BLAS_LIB = self._INIT_BLAS_LIB[:]
-        self.BLAS_LIB_MT = self._INIT_BLAS_LIB_MT[:]
 
         # version before 5.x still featured the acml_mv library
         ver = self.get_software_version(self.BLAS_MODULE_NAME)[0]

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -43,9 +43,8 @@ class Acml(LinAlg):
     Provides ACML BLAS/LAPACK support.
     """
     BLAS_MODULE_NAME = ['ACML']
-    # full list of libraries is highly dependent on ACML version and toolchain compiler (ifort, gfortran, ...)
-    BLAS_LIB = ['acml']
-    BLAS_LIB_MT = ['acml_mp']
+    BLAS_LIB = None
+    BLAS_LIB_MT = None
 
     # is completed in _set_blas_variables, depends on compiler used
     BLAS_LIB_DIR = []
@@ -72,6 +71,11 @@ class Acml(LinAlg):
         except:
             raise EasyBuildError("_set_blas_variables: ACML set LDFLAGS/CPPFLAGS unknown entry in ACML_SUBDIRS_MAP "
                                  "with compiler family %s", self.COMPILER_FAMILY)
+
+        # reset BLAS_LIB(_MT) every time, to avoid problems when multiple ACML versions are used in a single session
+        # full list of libraries is highly dependent on ACML version and toolchain compiler (ifort, gfortran, ...)
+        self.BLAS_LIB = ['acml']
+        self.BLAS_LIB_MT = ['acml_mp']
 
         # version before 5.x still featured the acml_mv library
         ver = self.get_software_version(self.BLAS_MODULE_NAME)[0]

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -43,8 +43,11 @@ class Acml(LinAlg):
     Provides ACML BLAS/LAPACK support.
     """
     BLAS_MODULE_NAME = ['ACML']
-    BLAS_LIB = None
-    BLAS_LIB_MT = None
+    BLAS_LIB = ['acml']
+    BLAS_LIB_MT = ['acml_mp']
+    # keep track of original values, need to be restored every time since we append to class 'constants' BLAS_LIB*
+    _INIT_BLAS_LIB = BLAS_LIB[:]
+    _INIT_BLAS_LIB_MT = BLAS_LIB_MT[:]
 
     # is completed in _set_blas_variables, depends on compiler used
     BLAS_LIB_DIR = []
@@ -74,8 +77,8 @@ class Acml(LinAlg):
 
         # reset BLAS_LIB(_MT) every time, to avoid problems when multiple ACML versions are used in a single session
         # full list of libraries is highly dependent on ACML version and toolchain compiler (ifort, gfortran, ...)
-        self.BLAS_LIB = ['acml']
-        self.BLAS_LIB_MT = ['acml_mp']
+        self.BLAS_LIB = self._INIT_BLAS_LIB[:]
+        self.BLAS_LIB_MT = self._INIT_BLAS_LIB_MT[:]
 
         # version before 5.x still featured the acml_mv library
         ver = self.get_software_version(self.BLAS_MODULE_NAME)[0]

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -75,7 +75,8 @@ class IntelMKL(LinAlg):
 
     def __init__(self, *args, **kwargs):
         """Toolchain constructor."""
-        self.add_class_constants_to_restore(['BLAS_LIB_MAP', 'SCALAPACK_LIB', 'SCALAPACK_LIB_MT', 'SCALAPACK_LIB_MAP'])
+        class_constants = kwargs.setdefault('class_constants', [])
+        class_constants.extend(['BLAS_LIB_MAP', 'SCALAPACK_LIB', 'SCALAPACK_LIB_MT', 'SCALAPACK_LIB_MAP'])
         super(IntelMKL, self).__init__(*args, **kwargs)
 
     def _set_blas_variables(self):

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -28,7 +28,6 @@ Support for Intel MKL as toolchain linear algebra library.
 @author: Stijn De Weirdt (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-import copy
 from distutils.version import LooseVersion
 
 from easybuild.toolchains.compiler.inteliccifort import TC_CONSTANT_INTELCOMP

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -67,9 +67,9 @@ class IntelMKL(LinAlg):
     BLACS_LIB_STATIC = True
 
     SCALAPACK_MODULE_NAME = ['imkl']
-    SCALAPACK_LIB = ["mkl_scalapack%(lp64_sc)s"]
-    SCALAPACK_LIB_MT = ["mkl_scalapack%(lp64_sc)s"]
-    SCALAPACK_LIB_MAP = {"lp64_sc":"_lp64"}
+    SCALAPACK_LIB = None
+    SCALAPACK_LIB_MT = None
+    SCALAPACK_LIB_MAP = None
     SCALAPACK_REQUIRES = ['LIBBLACS', 'LIBBLAS']
     SCALAPACK_LIB_GROUP = True
     SCALAPACK_LIB_STATIC = True
@@ -101,10 +101,10 @@ class IntelMKL(LinAlg):
 
         if self.options.get('32bit', None):
             # 32bit
-            self.BLAS_LIB_MAP.update({"lp64":''})
+            self.BLAS_LIB_MAP.update({"lp64":''})  # FIXME
         if self.options.get('i8', None):
             # ilp64/i8
-            self.BLAS_LIB_MAP.update({"lp64":'_ilp64'})
+            self.BLAS_LIB_MAP.update({"lp64":'_ilp64'})  # FIXME
             # CPP / CFLAGS
             self.variables.nappend_el('CFLAGS', 'DMKL_ILP64')
 
@@ -150,6 +150,11 @@ class IntelMKL(LinAlg):
         super(IntelMKL, self)._set_blacs_variables()
 
     def _set_scalapack_variables(self):
+        # reset SCALAPACK_LIB* every time, to avoid problems when multiple imkl versions are used in a single session
+        self.SCALAPACK_LIB = ["mkl_scalapack%(lp64_sc)s"]
+        self.SCALAPACK_LIB_MT = ["mkl_scalapack%(lp64_sc)s"]
+        self.SCALAPACK_LIB_MAP = {'lp64_sc': '_lp64'}
+
         imkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         if LooseVersion(imkl_version) < LooseVersion('10.3'):
             self.SCALAPACK_LIB.append("mkl_solver%(lp64)s_sequential")

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -28,7 +28,7 @@ Support for Intel MKL as toolchain linear algebra library.
 @author: Stijn De Weirdt (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-
+import copy
 from distutils.version import LooseVersion
 
 from easybuild.toolchains.compiler.inteliccifort import TC_CONSTANT_INTELCOMP
@@ -76,7 +76,7 @@ class IntelMKL(LinAlg):
     # keep track of original values, need to be restored every time since we append to class 'constants' SCALAPACK_LIB*
     _INIT_SCALAPACK_LIB = SCALAPACK_LIB[:]
     _INIT_SCALAPACK_LIB_MT = SCALAPACK_LIB_MT[:]
-    _INIT_SCALAPACK_LIB_MAP = SCALAPACK_LIB_MAP[:]
+    _INIT_SCALAPACK_LIB_MAP = copy.deepcopy(SCALAPACK_LIB_MAP)
 
     def _set_blas_variables(self):
         """Fix the map a bit"""
@@ -155,9 +155,9 @@ class IntelMKL(LinAlg):
 
     def _set_scalapack_variables(self):
         # reset SCALAPACK_LIB* every time, to avoid problems when multiple imkl versions are used in a single session
-        self.SCALAPACK_LIB = self._INIT_SCALAPACK_LIB
-        self.SCALAPACK_LIB_MT = self._INIT_SCALAPACK_LIB_MT
-        self.SCALAPACK_LIB_MAP = self._INIT_SCALAPACK_LIB_MAP
+        self.SCALAPACK_LIB = self._INIT_SCALAPACK_LIB[:]
+        self.SCALAPACK_LIB_MT = self._INIT_SCALAPACK_LIB_MT[:]
+        self.SCALAPACK_LIB_MAP = copy.deepcopy(self._INIT_SCALAPACK_LIB_MAP)
 
         imkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         if LooseVersion(imkl_version) < LooseVersion('10.3'):

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -67,12 +67,16 @@ class IntelMKL(LinAlg):
     BLACS_LIB_STATIC = True
 
     SCALAPACK_MODULE_NAME = ['imkl']
-    SCALAPACK_LIB = None
-    SCALAPACK_LIB_MT = None
-    SCALAPACK_LIB_MAP = None
     SCALAPACK_REQUIRES = ['LIBBLACS', 'LIBBLAS']
     SCALAPACK_LIB_GROUP = True
     SCALAPACK_LIB_STATIC = True
+    SCALAPACK_LIB = ["mkl_scalapack%(lp64_sc)s"]
+    SCALAPACK_LIB_MT = ["mkl_scalapack%(lp64_sc)s"]
+    SCALAPACK_LIB_MAP = {'lp64_sc': '_lp64'}
+    # keep track of original values, need to be restored every time since we append to class 'constants' SCALAPACK_LIB*
+    _INIT_SCALAPACK_LIB = SCALAPACK_LIB[:]
+    _INIT_SCALAPACK_LIB_MT = SCALAPACK_LIB_MT[:]
+    _INIT_SCALAPACK_LIB_MAP = SCALAPACK_LIB_MAP[:]
 
     def _set_blas_variables(self):
         """Fix the map a bit"""
@@ -151,9 +155,9 @@ class IntelMKL(LinAlg):
 
     def _set_scalapack_variables(self):
         # reset SCALAPACK_LIB* every time, to avoid problems when multiple imkl versions are used in a single session
-        self.SCALAPACK_LIB = ["mkl_scalapack%(lp64_sc)s"]
-        self.SCALAPACK_LIB_MT = ["mkl_scalapack%(lp64_sc)s"]
-        self.SCALAPACK_LIB_MAP = {'lp64_sc': '_lp64'}
+        self.SCALAPACK_LIB = self._INIT_SCALAPACK_LIB
+        self.SCALAPACK_LIB_MT = self._INIT_SCALAPACK_LIB_MT
+        self.SCALAPACK_LIB_MAP = self._INIT_SCALAPACK_LIB_MAP
 
         imkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         if LooseVersion(imkl_version) < LooseVersion('10.3'):

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -67,15 +67,16 @@ class IntelMKL(LinAlg):
     BLACS_LIB_STATIC = True
 
     SCALAPACK_MODULE_NAME = ['imkl']
-    SCALAPACK_REQUIRES = ['LIBBLACS', 'LIBBLAS']
-    SCALAPACK_LIB_GROUP = True
-    SCALAPACK_LIB_STATIC = True
     SCALAPACK_LIB = ["mkl_scalapack%(lp64_sc)s"]
     SCALAPACK_LIB_MT = ["mkl_scalapack%(lp64_sc)s"]
     SCALAPACK_LIB_MAP = {'lp64_sc': '_lp64'}
+    SCALAPACK_REQUIRES = ['LIBBLACS', 'LIBBLAS']
+    SCALAPACK_LIB_GROUP = True
+    SCALAPACK_LIB_STATIC = True
 
     def __init__(self, *args, **kwargs):
         """Toolchain constructor."""
+        self.CLASS_CONSTANTS_TO_RESTORE.append('BLAS_LIB_MAP')
         self.CLASS_CONSTANTS_TO_RESTORE.extend(['SCALAPACK_LIB', 'SCALAPACK_LIB_MT', 'SCALAPACK_LIB_MAP'])
         super(IntelMKL, self).__init__(*args, **kwargs)
 
@@ -106,10 +107,10 @@ class IntelMKL(LinAlg):
 
         if self.options.get('32bit', None):
             # 32bit
-            self.BLAS_LIB_MAP.update({"lp64":''})  # FIXME
+            self.BLAS_LIB_MAP.update({"lp64":''})
         if self.options.get('i8', None):
             # ilp64/i8
-            self.BLAS_LIB_MAP.update({"lp64":'_ilp64'})  # FIXME
+            self.BLAS_LIB_MAP.update({"lp64":'_ilp64'})
             # CPP / CFLAGS
             self.variables.nappend_el('CFLAGS', 'DMKL_ILP64')
 

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -73,10 +73,11 @@ class IntelMKL(LinAlg):
     SCALAPACK_LIB = ["mkl_scalapack%(lp64_sc)s"]
     SCALAPACK_LIB_MT = ["mkl_scalapack%(lp64_sc)s"]
     SCALAPACK_LIB_MAP = {'lp64_sc': '_lp64'}
-    # keep track of original values, need to be restored every time since we append to class 'constants' SCALAPACK_LIB*
-    _INIT_SCALAPACK_LIB = SCALAPACK_LIB[:]
-    _INIT_SCALAPACK_LIB_MT = SCALAPACK_LIB_MT[:]
-    _INIT_SCALAPACK_LIB_MAP = copy.deepcopy(SCALAPACK_LIB_MAP)
+
+    def __init__(self, *args, **kwargs):
+        """Toolchain constructor."""
+        self.CLASS_CONSTANTS_TO_RESTORE.extend(['SCALAPACK_LIB', 'SCALAPACK_LIB_MT', 'SCALAPACK_LIB_MAP'])
+        super(IntelMKL, self).__init__(*args, **kwargs)
 
     def _set_blas_variables(self):
         """Fix the map a bit"""
@@ -154,11 +155,6 @@ class IntelMKL(LinAlg):
         super(IntelMKL, self)._set_blacs_variables()
 
     def _set_scalapack_variables(self):
-        # reset SCALAPACK_LIB* every time, to avoid problems when multiple imkl versions are used in a single session
-        self.SCALAPACK_LIB = self._INIT_SCALAPACK_LIB[:]
-        self.SCALAPACK_LIB_MT = self._INIT_SCALAPACK_LIB_MT[:]
-        self.SCALAPACK_LIB_MAP = copy.deepcopy(self._INIT_SCALAPACK_LIB_MAP)
-
         imkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         if LooseVersion(imkl_version) < LooseVersion('10.3'):
             self.SCALAPACK_LIB.append("mkl_solver%(lp64)s_sequential")

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -76,8 +76,7 @@ class IntelMKL(LinAlg):
 
     def __init__(self, *args, **kwargs):
         """Toolchain constructor."""
-        self.CLASS_CONSTANTS_TO_RESTORE.append('BLAS_LIB_MAP')
-        self.CLASS_CONSTANTS_TO_RESTORE.extend(['SCALAPACK_LIB', 'SCALAPACK_LIB_MT', 'SCALAPACK_LIB_MAP'])
+        self.add_class_constants_to_restore(['BLAS_LIB_MAP', 'SCALAPACK_LIB', 'SCALAPACK_LIB_MT', 'SCALAPACK_LIB_MAP'])
         super(IntelMKL, self).__init__(*args, **kwargs)
 
     def _set_blas_variables(self):

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -77,7 +77,7 @@ class Toolchain(object):
 
     _is_toolchain_for = classmethod(_is_toolchain_for)
 
-    def __init__(self, name=None, version=None, mns=None):
+    def __init__(self, name=None, version=None, mns=None, class_constants=None):
         """Toolchain constructor."""
 
         self.base_init()
@@ -99,9 +99,7 @@ class Toolchain(object):
 
         self.vars = None
 
-        self.add_class_constants_to_restore([])  # make sure self.CLASS_CONSTANTS_TO_RESTORE is initialised
-        self._copy_class_constants()
-        self._restore_class_constants()
+        self._init_class_constants(class_constants)
 
         self.modules_tool = modules_tool()
         self.mns = mns
@@ -116,14 +114,8 @@ class Toolchain(object):
                 self.mod_short_name = self.mns.det_short_module_name(tc_dict)
                 self.init_modpaths = self.mns.det_init_modulepaths(tc_dict)
 
-    def add_class_constants_to_restore(self, names):
-        """Add given constants to list of class constants to restore with each new instance."""
-        if self.CLASS_CONSTANTS_TO_RESTORE is None:
-            self.CLASS_CONSTANTS_TO_RESTORE = names[:]
-        else:
-            self.CLASS_CONSTANTS_TO_RESTORE.extend(names)
-
     def base_init(self):
+        """Initialise missing class attributes (log, options, variables)."""
         if not hasattr(self, 'log'):
             self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
 
@@ -136,6 +128,17 @@ class Toolchain(object):
                 self.variables.LINKER_TOGGLE_START_STOP_GROUP = self.LINKER_TOGGLE_START_STOP_GROUP
             if hasattr(self, 'LINKER_TOGGLE_STATIC_DYNAMIC'):
                 self.variables.LINKER_TOGGLE_STATIC_DYNAMIC = self.LINKER_TOGGLE_STATIC_DYNAMIC
+
+    def _init_class_constants(self, class_constants):
+        """Initialise class 'constants'."""
+        # make sure self.CLASS_CONSTANTS_TO_RESTORE is initialised
+        if class_constants is None:
+            self.CLASS_CONSTANTS_TO_RESTORE = []
+        else:
+            self.CLASS_CONSTANTS_TO_RESTORE = class_constants[:]
+
+        self._copy_class_constants()
+        self._restore_class_constants()
 
     def _copy_class_constants(self):
         """Copy class constants that needs to be restored again when a new instance is created."""

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -59,7 +59,7 @@ class Toolchain(object):
     TOOLCHAIN_FAMILY = None
 
     # list of class 'constants' that should be restored for every new instance of this class
-    CLASS_CONSTANTS_TO_RESTORE = []
+    CLASS_CONSTANTS_TO_RESTORE = None
     CLASS_CONSTANT_COPIES = {}
 
     # class method
@@ -99,6 +99,7 @@ class Toolchain(object):
 
         self.vars = None
 
+        self.add_class_constants_to_restore([])  # make sure self.CLASS_CONSTANTS_TO_RESTORE is initialised
         self._copy_class_constants()
         self._restore_class_constants()
 
@@ -114,6 +115,13 @@ class Toolchain(object):
                 self.mod_full_name = self.mns.det_full_module_name(tc_dict)
                 self.mod_short_name = self.mns.det_short_module_name(tc_dict)
                 self.init_modpaths = self.mns.det_init_modulepaths(tc_dict)
+
+    def add_class_constants_to_restore(self, names):
+        """Add given constants to list of class constants to restore with each new instance."""
+        if self.CLASS_CONSTANTS_TO_RESTORE is None:
+            self.CLASS_CONSTANTS_TO_RESTORE = names[:]
+        else:
+            self.CLASS_CONSTANTS_TO_RESTORE.extend(names)
 
     def base_init(self):
         if not hasattr(self, 'log'):
@@ -139,7 +147,7 @@ class Toolchain(object):
                 if hasattr(self, cst):
                     self.CLASS_CONSTANT_COPIES[key][cst] = copy.deepcopy(getattr(self, cst))
                 else:
-                    raise EasyBuildError("Class constant '%s' to be restored does not exist", cst)
+                    raise EasyBuildError("Class constant '%s' to be restored does not exist in %s", cst, self)
 
             self.log.debug("Copied class constants: %s", self.CLASS_CONSTANT_COPIES[key])
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -46,7 +46,7 @@ from easybuild.tools.modules import get_software_root, get_software_version, get
 
 
 # number of modules included for testing purposes
-TEST_MODULES_COUNT = 58
+TEST_MODULES_COUNT = 63
 
 
 class ModulesTest(EnhancedTestCase):

--- a/test/framework/modules/icc/11.1.073
+++ b/test/framework/modules/icc/11.1.073
@@ -1,0 +1,7 @@
+#%Module
+
+set root /tmp/icc/11.1.073
+
+setenv EBROOTICC "$root"
+setenv EBVERSIONICC "11.1.073"
+setenv  EBDEVELICC "$root/easybuild/icc-11.1.073-easybuild-devel"

--- a/test/framework/modules/ictce/3.2.2.u3
+++ b/test/framework/modules/ictce/3.2.2.u3
@@ -1,0 +1,36 @@
+#%Module
+
+proc ModulesHelp { } {
+    puts stderr {   Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI & Intel MKL. - Homepage: http://software.intel.com/en-us/intel-cluster-toolkit-compiler/
+    }
+}
+
+module-whatis {Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI & Intel MKL. - Homepage: http://software.intel.com/en-us/intel-cluster-toolkit-compiler/}
+
+set root    /tmp/ictce/3.2.2.u3
+
+conflict    ictce
+
+if { ![is-loaded icc/11.1.073] } {
+    module load icc/11.1.073
+}
+
+if { ![is-loaded ifort/11.1.073] } {
+    module load ifort/11.1.073
+}
+
+if { ![is-loaded impi/4.0.0.028] } {
+    module load impi/4.0.0.028
+}
+
+if { ![is-loaded imkl/10.2.6.038] } {
+    module load imkl/10.2.6.038
+}
+
+
+setenv	EBROOTICTCE		"$root"
+setenv	EBVERSIONICTCE		"3.2.2.u3"
+setenv	EBDEVELICTCE		"$root/easybuild/ictce-3.2.2.u3-easybuild-devel"
+
+
+# built with EasyBuild version 1.9.0dev

--- a/test/framework/modules/ifort/11.1.073
+++ b/test/framework/modules/ifort/11.1.073
@@ -1,0 +1,7 @@
+#%Module
+
+set root /tmp/ifort/11.1.073
+
+setenv EBROOTIFORT "$root"
+setenv EBVERSIONIFORT "11.1.073"
+setenv  EBDEVELIFORT "$root/easybuild/ifort-11.1.073-easybuild-devel"

--- a/test/framework/modules/imkl/10.2.6.038
+++ b/test/framework/modules/imkl/10.2.6.038
@@ -1,0 +1,7 @@
+#%Module
+
+set root	/var/folders/8s/_frgh9sj6m744mxt5w5lyztr0000gn/T/eb-SGdeX9/tmptwWn9I
+
+setenv EBROOTIMKL "$root"
+setenv EBVERSIONIMKL "10.2.6.038"
+setenv  EBDEVELIMKL "$root/easybuild/imkl-10.2.6.038-easybuild-devel"

--- a/test/framework/modules/impi/4.0.0.028
+++ b/test/framework/modules/impi/4.0.0.028
@@ -1,0 +1,7 @@
+#%Module
+
+set root /tmp/impi/4.0.0.028
+
+setenv EBROOTIMPI "$root"
+setenv EBVERSIONIMPI "4.0.0.028"
+setenv  EBDEVELIMPI "$root/easybuild/impi-4.0.0.028-easybuild-devel"

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -622,50 +622,65 @@ class ToolchainTest(EnhancedTestCase):
         tmpdir2, imkl_module_path2, imkl_module_txt2 = self.setup_sandbox_for_intel_fftw(imklver='10.2.6.038')
 
         # incl. -lguide
-        libblas_mt_old = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
-        libblas_mt_old += " -Wl,--end-group -Wl,-Bdynamic -liomp5 -lguide -lpthread"
+        libblas_mt_ictce3 = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
+        libblas_mt_ictce3 += " -Wl,--end-group -Wl,-Bdynamic -liomp5 -lguide -lpthread"
 
         # no -lguide
-        libblas_mt_new = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
-        libblas_mt_new += " -Wl,--end-group -Wl,-Bdynamic -liomp5 -lpthread"
+        libblas_mt_ictce4 = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
+        libblas_mt_ictce4 += " -Wl,--end-group -Wl,-Bdynamic -liomp5 -lpthread"
 
         # incl. -lmkl_solver*
-        libscalack_old = "-lmkl_scalapack_lp64 -lmkl_solver_lp64_sequential -lmkl_blacs_intelmpi_lp64"
-        libscalack_old += " -lmkl_intel_lp64 -lmkl_sequential -lmkl_core"
+        libscalack_ictce3 = "-lmkl_scalapack_lp64 -lmkl_solver_lp64_sequential -lmkl_blacs_intelmpi_lp64"
+        libscalack_ictce3 += " -lmkl_intel_lp64 -lmkl_sequential -lmkl_core"
 
         # no -lmkl_solver*
-        libscalack_new = "-lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core"
+        libscalack_ictce4 = "-lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core"
 
-        tc = self.get_toolchain('ictce', version='4.1.13')
-        tc.prepare()
-        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_new)
-        self.assertTrue(libscalack_new in os.environ['LIBSCALAPACK'])
-        modules_tool().purge()
+        libblas_mt_goolfc = "-lopenblas -lgfortran"
+        libscalack_goolfc = "-lscalapack -lopenblas -lgfortran"
 
-        tc = self.get_toolchain('ictce', version='3.2.2.u3')
+        tc = self.get_toolchain('goolfc', version='1.3.12')
         tc.prepare()
-        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_old)
-        self.assertTrue(libscalack_old in os.environ['LIBSCALAPACK'])
+        self.assertEqual(os.environ['LIBBLAS_MT'], libblas_mt_goolfc)
+        self.assertEqual(os.environ['LIBSCALAPACK'], libscalack_goolfc)
         modules_tool().purge()
 
         tc = self.get_toolchain('ictce', version='4.1.13')
         tc.prepare()
-        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_new)
-        self.assertTrue(libscalack_new in os.environ['LIBSCALAPACK'])
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_ictce4)
+        self.assertTrue(libscalack_ictce4 in os.environ['LIBSCALAPACK'])
         modules_tool().purge()
 
         tc = self.get_toolchain('ictce', version='3.2.2.u3')
         tc.prepare()
-        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_old)
-        self.assertTrue(libscalack_old in os.environ['LIBSCALAPACK'])
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_ictce3)
+        self.assertTrue(libscalack_ictce3 in os.environ['LIBSCALAPACK'])
         modules_tool().purge()
 
-        libscalack_new = libscalack_new.replace('_lp64', '_ilp64')
+        tc = self.get_toolchain('ictce', version='4.1.13')
+        tc.prepare()
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_ictce4)
+        self.assertTrue(libscalack_ictce4 in os.environ['LIBSCALAPACK'])
+        modules_tool().purge()
+
+        tc = self.get_toolchain('ictce', version='3.2.2.u3')
+        tc.prepare()
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_ictce3)
+        self.assertTrue(libscalack_ictce3 in os.environ['LIBSCALAPACK'])
+        modules_tool().purge()
+
+        libscalack_ictce4 = libscalack_ictce4.replace('_lp64', '_ilp64')
         tc = self.get_toolchain('ictce', version='4.1.13')
         opts = {'i8': True}
         tc.set_options(opts)
         tc.prepare()
-        self.assertTrue(libscalack_new in os.environ['LIBSCALAPACK'])
+        self.assertTrue(libscalack_ictce4 in os.environ['LIBSCALAPACK'])
+        modules_tool().purge()
+
+        tc = self.get_toolchain('goolfc', version='1.3.12')
+        tc.prepare()
+        self.assertEqual(os.environ['LIBBLAS_MT'], libblas_mt_goolfc)
+        self.assertEqual(os.environ['LIBSCALAPACK'], libscalack_goolfc)
 
         # cleanup
         shutil.rmtree(tmpdir1)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -431,14 +431,14 @@ class ToolchainTest(EnhancedTestCase):
         # check CUDA runtime lib
         self.assertTrue("-lrt -lcudart" in tc.get_variable('LIBS'))
 
-    def setup_sandbox_for_intel_fftw(self):
+    def setup_sandbox_for_intel_fftw(self, imklver='10.3.12.361'):
         """Set up sandbox for Intel FFTW"""
         # hack to make Intel FFTW lib check pass
         # rewrite $root in imkl module so we can put required lib*.a files in place
         tmpdir = tempfile.mkdtemp()
 
         test_modules_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'modules'))
-        imkl_module_path = os.path.join(test_modules_path, 'imkl', '10.3.12.361')
+        imkl_module_path = os.path.join(test_modules_path, 'imkl', imklver)
         imkl_module_txt = open(imkl_module_path, 'r').read()
         regex = re.compile('^(set\s*root).*$', re.M)
         imkl_module_alt_txt = regex.sub(r'\1\t%s' % tmpdir, imkl_module_txt)
@@ -446,7 +446,7 @@ class ToolchainTest(EnhancedTestCase):
 
         fftw_libs = ['fftw3xc_intel', 'fftw3x_cdft', 'mkl_cdft_core', 'mkl_blacs_intelmpi_lp64']
         fftw_libs += ['mkl_blacs_intelmpi_lp64', 'mkl_intel_lp64', 'mkl_sequential', 'mkl_core']
-        for subdir in ['mkl/lib/intel64', 'compiler/lib/intel64']:
+        for subdir in ['mkl/lib/intel64', 'compiler/lib/intel64', 'lib/em64t']:
             os.makedirs(os.path.join(tmpdir, subdir))
             for fftlib in fftw_libs:
                 write_file(os.path.join(tmpdir, subdir, 'lib%s.a' % fftlib), 'foo')
@@ -616,6 +616,43 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(modules.get_software_root('foobar'), '/foo/bar')
         self.assertEqual(modules.get_software_version('toy'), '1.2.3')
 
+    def test_old_new_iccifort(self):
+        """Test whether preparing for old/new Intel compilers works correctly."""
+        tmpdir1, imkl_module_path1, imkl_module_txt1 = self.setup_sandbox_for_intel_fftw(imklver='10.3.12.361')
+        tmpdir2, imkl_module_path2, imkl_module_txt2 = self.setup_sandbox_for_intel_fftw(imklver='10.2.6.038')
+
+        # incl. -lguide
+        libblas_mt_old = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
+        libblas_mt_old += " -Wl,--end-group -Wl,-Bdynamic -liomp5 -lguide -lpthread"
+
+        # no -lguide
+        libblas_mt_new = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
+        libblas_mt_new += " -Wl,--end-group -Wl,-Bdynamic -liomp5 -lpthread"
+
+        tc = self.get_toolchain('ictce', version='4.1.13')
+        tc.prepare()
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_new)
+        modules_tool().purge()
+
+        tc = self.get_toolchain('ictce', version='3.2.2.u3')
+        tc.prepare()
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_old)
+        modules_tool().purge()
+
+        tc = self.get_toolchain('ictce', version='4.1.13')
+        tc.prepare()
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_new)
+        modules_tool().purge()
+
+        tc = self.get_toolchain('ictce', version='3.2.2.u3')
+        tc.prepare()
+        self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_old)
+
+        # cleanup
+        shutil.rmtree(tmpdir1)
+        shutil.rmtree(tmpdir2)
+        write_file(imkl_module_path1, imkl_module_txt1)
+        write_file(imkl_module_path2, imkl_module_txt2)
 
 def suite():
     """ return all the tests"""


### PR DESCRIPTION
This fixes a problem that often occurs when testing large easyconfig PRs that contain easyconfigs with a large variety on toolchains using `--from-pr`, for example https://github.com/hpcugent/easybuild-easyconfigs/pull/1337#issuecomment-108479308 .

If old and new version of Intel compilers are used in the same session, things break because constants aren't exactly constant.

This fixes the problem; I took care of checking the other toolchain components too.

@wpoely86, @pforai, @stdweird: please review?