### PR TITLE
fix purging of loaded modules in unit tests' setUp

### DIFF
--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -138,9 +138,9 @@ class EnhancedTestCase(_EnhancedTestCase):
         reload(easybuild.tools.module_naming_scheme)  # required to run options unit tests stand-alone
 
         modtool = modules_tool()
-        self.reset_modulepath([os.path.join(testdir, 'modules')])
         # purge out any loaded modules with original $MODULEPATH before running each test
         modtool.purge()
+        self.reset_modulepath([os.path.join(testdir, 'modules')])
 
     def tearDown(self):
         """Clean up after running testcase."""


### PR DESCRIPTION
The `module purge` done before each test may fail in some circumstances if `$MODULEPATH` is reset first, so this needs to be done the other way around.