### PR TITLE
fix issue with cleaning up (no) logfile if --logtostdout/-l is used

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -201,7 +201,8 @@ def stop_logging(logfile, logtostdout=False):
     """Stop logging."""
     if logtostdout:
         fancylogger.logToScreen(enable=False, stdout=True)
-    fancylogger.logToFile(logfile, enable=False)
+    if logfile is not None:
+        fancylogger.logToFile(logfile, enable=False)
 
 
 def get_log(name=None):

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -324,9 +324,18 @@ class CommandLineOptionsTest(EnhancedTestCase):
             # cleanup
             os.remove(fn)
 
+        stdoutorig = sys.stdout
+        sys.stdout = open("/dev/null", 'w')
+
+        toy_ecfile = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'toy-0.0.eb')
+        self.logfile = None
+        out = self.eb_main([toy_ecfile, '--debug', '-l', '--force'], raise_error=True)
+
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)
-        fancylogger.logToFile(self.logfile)
+
+        sys.stdout.close()
+        sys.stdout = stdoutorig
 
     def test_avail_easyconfig_params(self):
         """Test listing available easyconfig parameters."""

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -196,9 +196,10 @@ class EnhancedTestCase(_EnhancedTestCase):
         if logfile is None:
             logfile = self.logfile
         # clear log file
-        f = open(logfile, 'w')
-        f.write('')
-        f.close()
+        if logfile:
+            f = open(logfile, 'w')
+            f.write('')
+            f.close()
 
         env_before = copy.deepcopy(os.environ)
 
@@ -211,7 +212,10 @@ class EnhancedTestCase(_EnhancedTestCase):
             if verbose:
                 print "err: %s" % err
 
-        logtxt = read_file(logfile)
+        if logfile:
+            logtxt = read_file(logfile)
+        else:
+            logtxt = None
 
         os.chdir(self.cwd)
 


### PR DESCRIPTION
This problem surfaces since https://github.com/hpcugent/vsc-base/pull/177 was merged into vsc-base:

```
======================================================================
ERROR: test_zzz_logtostdout (__main__.CommandLineOptionsTest)
Testing redirecting log to stdout.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/options.py", line 333, in test_zzz_logtostdout
    out = self.eb_main([toy_ecfile, '--debug', '-l', '--force'], raise_error=True)
  File "test/framework/utilities.py", line 232, in eb_main
    raise myerr
AttributeError: 'NoneType' object has no attribute 'rfind'

----------------------------------------------------------------------
Ran 1 test in 2.069s
```