### PR TITLE
stop making ModulesTool class a singleton

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1029,8 +1029,7 @@ class EasyBlock(object):
         fake_mod_path = self.make_module_step(True)
 
         # load fake module
-        modtool = modules_tool()
-        modtool.prepend_module_path(fake_mod_path)
+        self.modules_tool.prepend_module_path(fake_mod_path)
         self.load_module(purge=purge)
 
         return (fake_mod_path, env)
@@ -1044,9 +1043,8 @@ class EasyBlock(object):
         # self.full_mod_name might not be set (e.g. during unit tests)
         if fake_mod_path and self.full_mod_name is not None:
             try:
-                modtool = modules_tool()
-                modtool.unload([self.full_mod_name])
-                modtool.remove_module_path(fake_mod_path)
+                self.modules_tool.unload([self.full_mod_name])
+                self.modules_tool.remove_module_path(fake_mod_path)
                 rmtree2(os.path.dirname(fake_mod_path))
             except OSError, err:
                 raise EasyBuildError("Failed to clean up fake module dir %s: %s", fake_mod_path, err)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -136,8 +136,6 @@ class ModulesTool(object):
     # modules tool user cache directory
     USER_CACHE_DIR = None
 
-    __metaclass__ = Singleton
-
     def __init__(self, mod_paths=None, testing=False):
         """
         Create a ModulesTool object

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -42,7 +42,7 @@ from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.tools import config
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir, read_file, write_file
-from easybuild.tools.modules import get_software_root, get_software_version, get_software_libdir, modules_tool
+from easybuild.tools.modules import Lmod, get_software_root, get_software_version, get_software_libdir, modules_tool
 
 
 # number of modules included for testing purposes
@@ -347,8 +347,13 @@ class ModulesTest(EnhancedTestCase):
         os.environ['MODULEPATH'] = os.path.join(self.test_prefix, 'Core')
         modtool = modules_tool()
 
+        if isinstance(modtool, Lmod):
+            load_err_msg = "cannot[\s\n]*be[\s\n]*loaded"
+        else:
+            load_err_msg = "Unable to locate a modulefile"
+
         # GCC/4.6.3 is *not* an available Core module
-        self.assertErrorRegex(EasyBuildError, "Unable to locate a modulefile", modtool.load, ['GCC/4.6.3'])
+        self.assertErrorRegex(EasyBuildError, load_err_msg, modtool.load, ['GCC/4.6.3'])
 
         # GCC/4.7.2 is one of the available Core modules
         modtool.load(['GCC/4.7.2'])
@@ -370,7 +375,7 @@ class ModulesTest(EnhancedTestCase):
         modtool.load(['GCC/4.7.2'])
 
         # OpenMPI/1.6.4 is *not* available with current $MODULEPATH (loaded GCC/4.7.2 was not a hierarchical module)
-        self.assertErrorRegex(EasyBuildError, "Unable to locate a modulefile", modtool.load, ['OpenMPI/1.6.4'])
+        self.assertErrorRegex(EasyBuildError, load_err_msg, modtool.load, ['OpenMPI/1.6.4'])
 
 
 def suite():

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -41,7 +41,7 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.tools import config
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import read_file, write_file
+from easybuild.tools.filetools import mkdir, read_file, write_file
 from easybuild.tools.modules import get_software_root, get_software_version, get_software_libdir, modules_tool
 
 
@@ -321,6 +321,56 @@ class ModulesTest(EnhancedTestCase):
         deps = ['GCC/4.7.2', 'OpenMPI/1.6.4']
         path = modtool.path_to_top_of_module_tree(init_modpaths, 'FFTW/3.3.3', full_mod_subdir, deps)
         self.assertEqual(path, ['OpenMPI/1.6.4', 'GCC/4.7.2'])
+
+    def test_modules_tool_stateless(self):
+        """Check whether ModulesTool instance is stateless between runs."""
+        test_modules_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
+
+        # copy test Core/Compiler modules, we need to rewrite the 'module use' statement in the one we're going to load
+        shutil.copytree(os.path.join(test_modules_path, 'Core'), os.path.join(self.test_prefix, 'Core'))
+        shutil.copytree(os.path.join(test_modules_path, 'Compiler'), os.path.join(self.test_prefix, 'Compiler'))
+
+        modtxt = read_file(os.path.join(self.test_prefix, 'Core', 'GCC', '4.7.2'))
+        modpath_extension = os.path.join(self.test_prefix, 'Compiler', 'GCC', '4.7.2')
+        modtxt = re.sub('module use .*', 'module use %s' % modpath_extension, modtxt, re.M)
+        write_file(os.path.join(self.test_prefix, 'Core', 'GCC', '4.7.2'), modtxt)
+
+        modtxt = read_file(os.path.join(self.test_prefix, 'Compiler', 'GCC', '4.7.2', 'OpenMPI', '1.6.4'))
+        modpath_extension = os.path.join(self.test_prefix, 'MPI', 'GCC', '4.7.2', 'OpenMPI', '1.6.4')
+        mkdir(modpath_extension, parents=True)
+        modtxt = re.sub('module use .*', 'module use %s' % modpath_extension, modtxt, re.M)
+        write_file(os.path.join(self.test_prefix, 'Compiler', 'GCC', '4.7.2', 'OpenMPI', '1.6.4'), modtxt)
+
+        # force reset of any singletons by reinitiating config
+        init_config()
+
+        os.environ['MODULEPATH'] = os.path.join(self.test_prefix, 'Core')
+        modtool = modules_tool()
+
+        # GCC/4.6.3 is *not* an available Core module
+        self.assertErrorRegex(EasyBuildError, "Unable to locate a modulefile", modtool.load, ['GCC/4.6.3'])
+
+        # GCC/4.7.2 is one of the available Core modules
+        modtool.load(['GCC/4.7.2'])
+
+        # OpenMPI/1.6.4 becomes available after loading GCC/4.7.2 module
+        modtool.load(['OpenMPI/1.6.4'])
+        modtool.purge()
+
+        # reset $MODULEPATH, obtain new ModulesTool instance,
+        # which should not remember anything w.r.t. previous $MODULEPATH value
+        os.environ['MODULEPATH'] = test_modules_path
+        modtool = modules_tool()
+
+        # GCC/4.6.3 is available
+        modtool.load(['GCC/4.6.3'])
+        modtool.purge()
+
+        # GCC/4.7.2 is available (note: also as non-Core module outside of hierarchy)
+        modtool.load(['GCC/4.7.2'])
+
+        # OpenMPI/1.6.4 is *not* available with current $MODULEPATH (loaded GCC/4.7.2 was not a hierarchical module)
+        self.assertErrorRegex(EasyBuildError, "Unable to locate a modulefile", modtool.load, ['OpenMPI/1.6.4'])
 
 
 def suite():

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -101,7 +101,6 @@ class ModulesToolTest(EnhancedTestCase):
 
         os.environ[BrokenMockModulesTool.COMMAND_ENVIRONMENT] = MockModulesTool.COMMAND
         os.environ['module'] = "() { /bin/echo $*\n}"
-        BrokenMockModulesTool._instances.pop(BrokenMockModulesTool, None)
         bmmt = BrokenMockModulesTool(mod_paths=[], testing=True)
         cmd_abspath = which(MockModulesTool.COMMAND)
 
@@ -135,13 +134,11 @@ class ModulesToolTest(EnhancedTestCase):
 
         # redefine 'module' function with correct module command
         os.environ['module'] = "() {  eval `/bin/echo $*`\n}"
-        MockModulesTool._instances.pop(MockModulesTool)
         mt = MockModulesTool(testing=True)
         self.assertTrue(isinstance(mt.loaded_modules(), list))  # dummy usage
 
         # a warning should be logged if the 'module' function is undefined
         del os.environ['module']
-        MockModulesTool._instances.pop(MockModulesTool)
         mt = MockModulesTool(testing=True)
         f = open(self.logfile, 'r')
         logtxt = f.read()


### PR DESCRIPTION
With the `ModulesTool` class being a singleton, things go horribly wrong when builds are performed with different toolchains in a single session, when an alternative module naming scheme like `HierarchicalMNS` is used. This issue was reported by @geimer.

The problem is that the `ModulesTool` class remember the `$MODULEPATH` values (via the `mod_paths` class variable), which is not compatible with the concept of a 'dynamic' `$MODULEPATH` that is required when using a hierarchical module naming scheme.

Disabling the singleton property for `ModulesTool` should only have a (very minor) impact on performance, and has to adverse effects on functionality.