### PR TITLE
don't modify values of 'paths' list passed as argument to prepend_paths

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -226,18 +226,21 @@ class ModuleGeneratorTcl(ModuleGenerator):
             self.log.debug("Wrapping %s into a list before using it to prepend path %s" % (paths, key))
             paths = [paths]
 
-        for i, path in enumerate(paths):
+        abspaths = []
+        for path in paths:
             if os.path.isabs(path) and not allow_abs:
                 raise EasyBuildError("Absolute path %s passed to prepend_paths which only expects relative paths.",
                                      path)
             elif not os.path.isabs(path):
                 # prepend $root (= installdir) for (non-empty) relative paths
                 if path:
-                    paths[i] = os.path.join('$root', path)
+                    abspaths.append(os.path.join('$root', path))
                 else:
-                    paths[i] = '$root'
+                    abspaths.append('$root')
+            else:
+                abspaths.append(path)
 
-        statements = [template % (key, p) for p in paths]
+        statements = [template % (key, p) for p in abspaths]
         return ''.join(statements)
 
     def use(self, paths):

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -179,7 +179,10 @@ class ModuleGeneratorTest(EnhancedTestCase):
                 "prepend-path\tkey\t\t$root/path2\n",
                 "prepend-path\tkey\t\t$root\n",
             ])
-            self.assertEqual(expected, self.modgen.prepend_paths("key", ["path1", "path2", '']))
+            paths = ['path1', 'path2', '']
+            self.assertEqual(expected, self.modgen.prepend_paths("key", paths))
+            # 2nd call should still give same result, no side-effects like manipulating passed list 'paths'!
+            self.assertEqual(expected, self.modgen.prepend_paths("key", paths))
 
             expected = "prepend-path\tbar\t\t$root/foo\n"
             self.assertEqual(expected, self.modgen.prepend_paths("bar", "foo"))


### PR DESCRIPTION
I ran into this issue when using the updated `PythonPackage` easyblock from https://github.com/hpcugent/easybuild-easyblocks/pull/628....