### PR TITLE
promote MigrateFromEBToHMNS to a 'production' MNS

### DIFF
--- a/easybuild/tools/module_naming_scheme/migrate_from_eb_to_hmns.py
+++ b/easybuild/tools/module_naming_scheme/migrate_from_eb_to_hmns.py
@@ -23,7 +23,7 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-Implementation of a test module naming scheme that can be used to migrate from EasyBuildMNS to HierarchicalMNS.
+Implementation of a module naming scheme that can be used to migrate from EasyBuildMNS to HierarchicalMNS.
 
 @author: Kenneth Hoste (Ghent University)
 """


### PR DESCRIPTION
already covered by the tests, this change just promotes the `MigrateFromEBToHMNS` module naming scheme from the tests to become part of the framework

It can be used to generate modules that fit the hierarchical module naming scheme implemented by `HierarchicalMNS` for software installations that were performed with the (default) `EasyBuildMNS`, via `--module-only`.