### PR TITLE
fix more bugs in EasyConfig.dump()

### DIFF
--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -79,8 +79,9 @@ def quote_str(val, escape_newline=False, prefer_single_quotes=False):
         # single quotes to escape double quote used in strings
         elif '"' in val:
             return "'%s'" % val
-        # if single quotes are preferred, use single quotes
-        elif prefer_single_quotes and ' ' not in val:
+        # if single quotes are preferred, use single quotes;
+        # unless a space or a single quote are in the string
+        elif prefer_single_quotes and "'" not in val and ' ' not in val:
             return "'%s'" % val
         # fallback on double quotes (required in tcl syntax)
         else:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1154,6 +1154,7 @@ class EasyConfigTest(EnhancedTestCase):
         # test prefer_single_quotes
         self.assertEqual(quote_str("foo", prefer_single_quotes=True), "'foo'")
         self.assertEqual(quote_str('foo bar', prefer_single_quotes=True), '"foo bar"')
+        self.assertEqual(quote_str("foo'bar", prefer_single_quotes=True), '"foo\'bar"')
 
         # non-string values
         n = 42

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -332,7 +332,7 @@ class EasyConfigTest(EnhancedTestCase):
             'homepage = "http://www.example.com"',
             'description = "dummy description"',
             'version = "3.14"',
-            'toolchain = {"name":"GCC","version":"4.6.3"}',
+            'toolchain = {"name": "GCC", "version": "4.6.3"}',
             'patches = %s',
         ]) % str(patches)
         self.prep()
@@ -1162,7 +1162,6 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(quote_str(["foo", "bar"]), ["foo", "bar"])
         self.assertEqual(quote_str(('foo', 'bar')), ('foo', 'bar'))
 
-
     def test_dump(self):
         """Test EasyConfig's dump() method."""
         test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs')
@@ -1266,6 +1265,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         # reparsing the dumped easyconfig file should work
         ecbis = EasyConfig(testec)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -332,7 +332,7 @@ class EasyConfigTest(EnhancedTestCase):
             'homepage = "http://www.example.com"',
             'description = "dummy description"',
             'version = "3.14"',
-            'toolchain = {"name":"GCC", "version": "4.6.3"}',
+            'toolchain = {"name":"GCC","version":"4.6.3"}',
             'patches = %s',
         ]) % str(patches)
         self.prep()
@@ -1190,11 +1190,14 @@ class EasyConfigTest(EnhancedTestCase):
             '',
             "name = 'foo'",
             "version = '0.0.1'",
+            "versionsuffix = '_bar'",
             '',
             "homepage = 'http://foo.com/'",
             'description = "foo description"',
             '',
             "toolchain = {'version': 'dummy', 'name': 'dummy'}",
+            '',
+            "dependencies = [('GCC', '4.6.4', '-test'), ('MPICH', '1.8', '', ('GCC', '4.6.4')), ('bar', '1.0')]",
             '',
             "foo_extra1 = 'foobar'",
         ])
@@ -1216,6 +1219,7 @@ class EasyConfigTest(EnhancedTestCase):
             '',
             "name = 'Foo'",
             "version = '0.0.1'",
+            "versionsuffix = '-test'",
             '',
             "homepage = 'http://foo.com/'",
             'description = "foo description"',
@@ -1223,6 +1227,8 @@ class EasyConfigTest(EnhancedTestCase):
             "toolchain = {'version': 'dummy', 'name': 'dummy'}",
             '',
             "sources = ['foo-0.0.1.tar.gz']",
+            '',
+            "dependencies = [('bar', '1.2.3', '-test')]",
             '',
             "preconfigopts = '--opt1=%s' % name",
             "configopts = '--opt2=0.0.1'",
@@ -1236,7 +1242,6 @@ class EasyConfigTest(EnhancedTestCase):
         os.close(handle)
 
         ec = EasyConfig(None, rawtxt=rawtxt)
-        ec.enable_templating = True
         ec.dump(testec)
         ectxt = read_file(testec)
 
@@ -1246,6 +1251,7 @@ class EasyConfigTest(EnhancedTestCase):
             r"easyblock = 'EB_foo'",
             r"name = 'Foo'",
             r"version = '0.0.1'",
+            r"versionsuffix = '-test'",
             r"homepage = 'http://foo.com/'",
             r'description = "foo description"',  # no templating for description
             r"sources = \[SOURCELOWER_TAR_GZ\]",


### PR DESCRIPTION
With the easybuild-easyconfigs unit tests now also using `dump()`, several shortcomings in it are revealed (cfr. https://jenkins1.ugent.be/view/EasyBuild%20(develop)/job/easybuild-easyconfigs_unit-test_hpcugent_develop/1428/consoleFull).

This PR fixes these issues, such that the easyconfig unit tests are fail-free again:

* avoid templated values referring to the key they define, e.g. `versionsuffix = '_foo'` becomes `versionsuffix = '%(versionsuffix)s'`
* 'unparse' dependency easyconfigs parameters, rather than spitting out the `dict` representing the parsed dependency specs in tuple format, and handle dependencies marked as external module as a special case
* don't quote string containing a single quote using single quotes, since that yields `SyntaxError`s

cc @Caylo