### PR TITLE
Preserve comments in dump() method

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -46,7 +46,7 @@ from vsc.utils.patterns import Singleton
 import easybuild.tools.environment as env
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, get_module_naming_scheme
-from easybuild.tools.filetools import decode_class_name, encode_class_name, read_file
+from easybuild.tools.filetools import decode_class_name, encode_class_name, read_file, write_file
 from easybuild.tools.module_naming_scheme import DEVEL_MODULE_SUFFIX
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes, det_full_ec_version
 from easybuild.tools.module_naming_scheme.utilities import det_hidden_modname, is_valid_module_name
@@ -245,6 +245,8 @@ class EasyConfig(object):
         parser.set_specifications(arg_specs)
         local_vars = parser.get_config_dict()
         self.log.debug("Parsed easyconfig as a dictionary: %s" % local_vars)
+
+        self.comments = parser.get_comments()
 
         # make sure all mandatory parameters are defined
         # this includes both generic mandatory parameters and software-specific parameters defined via extra_options
@@ -475,7 +477,6 @@ class EasyConfig(object):
         """
         Dump this easyconfig to file, with the given filename.
         """
-        eb_file = file(fp, 'w')
 
         # ordered groups of keys to obtain a nice looking easyconfig file
         grouped_keys = [
@@ -537,29 +538,43 @@ class EasyConfig(object):
                         else:
                             val = newval
 
-                        ebtxt.append("%s = %s" % (key, val))
+                        add_key_and_comments(key, val)
+
                         printed_keys.append(key)
                         printed = True
                 if printed:
                     ebtxt.append('')
 
+        def add_key_and_comments(key, val):
+            """ Adds key, value pair and comments (if there are any) to the dump file """
+            if key in self.comments['inline']:
+                ebtxt.append("%s = %s  %s" % (key, val, self.comments['inline'][key]))
+            else:
+                if key in self.comments['above']:
+                    ebtxt.extend(self.comments['above'][key])
+
+                ebtxt.append("%s = %s" % (key, val))
+
         # print easyconfig parameters ordered and in groups specified above
         ebtxt = []
         printed_keys = []
+
+        # add header comments
+        ebtxt.extend(self.comments['header'])
+
         include_defined_parameters(grouped_keys)
 
         # print other easyconfig parameters at the end
         keys_to_ignore = printed_keys + last_keys
         for key in default_values:
             if key not in keys_to_ignore and self[key] != default_values[key]:
-                ebtxt.append("%s = %s" % (key, quote_py_str(self[key])))
+                add_key_and_comments(key, quote_py_str(self[key]))
         ebtxt.append('')
 
         # print last two parameters
         include_defined_parameters([[k] for k in last_keys])
 
-        eb_file.write(('\n'.join(ebtxt)).strip()) # strip for newlines at the end
-        eb_file.close()
+        write_file(fp, ('\n'.join(ebtxt)).strip()) # strip for newlines at the end
 
         self.enable_templating = orig_enable_templating
 

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -174,7 +174,7 @@ class EasyConfigParser(object):
 
                     # check if hash actually indicated a comment; or is part of the value
                     if key in self.get_config_dict():
-                        if comment.replace("'", "").replace('"', '') not in self.get_config_dict()[key]:
+                        if comment.replace("'", "").replace('"', '') not in str(self.get_config_dict()[key]):
                             self.comments['inline'][key] = '# ' + comment
             i += 1
 

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -172,8 +172,9 @@ class EasyConfigParser(object):
                     key = raw[i].split('=', 1)[0].strip()
 
                     # check if hash actually indicated a comment; or is part of the value
-                    if comment.replace("'", "").replace('"', '') not in self.get_config_dict()[key]:
-                        self.comments['inline'][key] = '# ' + comment
+                    if key in self.get_config_dict():
+                        if comment.replace("'", "").replace('"', '') not in self.get_config_dict()[key]:
+                            self.comments['inline'][key] = '# ' + comment
             i += 1
 
     def _det_format_version(self):

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -163,13 +163,16 @@ class EasyConfigParser(object):
                     while raw[i].startswith('#') or not raw[i]:
                         comment.append(raw[i])
                         i += 1
-                    key = raw[i].partition('=')[0].strip()
+                    key = raw[i].split('=', 1)[0].strip()
                     self.comments['above'][key] = comment
 
                 elif '#' in raw[i]:  # inline comment
-                    comment = '# ' + raw[i].partition('#')[2].strip()
-                    key = raw[i].partition('=')[0].strip()
-                    self.comments['inline'][key] = comment
+                    comment = raw[i].rsplit('#', 1)[1].strip()
+                    key = raw[i].split('=', 1)[0].strip()
+
+                    # check if hash actually indicated a comment; or is part of the value
+                    if comment.replace("'", "").replace('"', '') not in self.get_config_dict()[key]:
+                        self.comments['inline'][key] = '# ' + comment
             i += 1
 
     def _det_format_version(self):

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -141,6 +141,7 @@ class EasyConfigParser(object):
         """Extract comments from raw content."""
         # Keep track of comments and their location (top of easyconfig, key they are intended for, line they are on
         # discriminate between header comments (top of easyconfig file), single-line comments (at end of line) and other
+        # At the moment there is no support for inline comments on lines that don't contain the key value
 
         self.comments = {
             'header' : [],

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -153,7 +153,8 @@ class EasyConfigParser(object):
         header = True
 
         i = 0
-        while i<len(raw):
+        num_lines = len(raw)
+        while i<num_lines:
             if raw[i].startswith('#') and header:
                 self.comments['header'].append(raw[i])
             else:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1343,7 +1343,6 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(templ_dict, "{'a': '%(name)s', 'b': 'notemplate'}")
         self.assertEqual(to_template_str(('foo', '0.0.1'), templ_const, templ_val), "('%(name)s', '%(version)s')")
 
->>>>>>> develop
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1272,6 +1272,51 @@ class EasyConfigTest(EnhancedTestCase):
         # reparsing the dumped easyconfig file should work
         ecbis = EasyConfig(testec)
 
+    def test_dump_comments(self):
+        """ Test dump() method for files containing comments """
+        rawtxt = '\n'.join([
+            "# #",
+            "# some header comment",
+            "# #",
+            "easyblock = 'EB_foo'",
+            '',
+            "name = 'Foo'  # name comment",
+            "version = '0.0.1'",
+            "versionsuffix = '-test'",
+            '',
+            "# comment on the homepage",
+            "homepage = 'http://foo.com/'",
+            'description = "foo description"',
+            '',
+            "# toolchain comment with newline",
+            '',
+            "toolchain = {'version': 'dummy', 'name': 'dummy'}",
+            '',
+            "sanity_check_paths = {'files': ['files/foo/foobar'], 'dirs':[] }",
+            '',
+            "foo_extra1 = 'foobar'",
+        ])
+
+        handle, testec = tempfile.mkstemp(prefix=self.test_prefix, suffix='.eb')
+        os.close(handle)
+
+        ec = EasyConfig(None, rawtxt=rawtxt)
+        ec.dump(testec)
+        ectxt = read_file(testec)
+
+        patterns = [
+            r"# #\n# some header comment\n# #",
+            r"name = 'Foo'  # name comment",
+            r"# comment on the homepage\nhomepage = 'http://foo.com/'",
+            r"# toolchain comment with newline\n\ntoolchain = {'version': 'dummy', 'name': 'dummy'}"
+        ]
+
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertTrue(regex.search(ectxt), "Pattern '%s' found in: %s" % (regex.pattern, ectxt))
+
+        # reparsing the dumped easyconfig file should work
+        ecbis = EasyConfig(testec)
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
At the moment, there's no support for comments on lines that do not contain keys because for that to work, dump's indentation needs to be fixed first

for example, right now, the comment in

    dependencies = [
        ('JasPer', '1.900.1'),
        ('grib_api', '1.9.18'),
        ('netCDF', '4.1.3'),  # can't use 4.2, because Fortran stuff is in seperate netCDF-Fortran install
    ]

will be ignored. This will have to be fixed when I take care of the indentation.