### PR TITLE
include --hidden in job script when needed

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -978,9 +978,6 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
                 _log.debug("Adding toolchain %s as dependency for app %s." % (dep, name))
                 easyconfig['dependencies'].append(dep)
 
-            # this is used by the parallel builder
-            easyconfig['unresolved_deps'] = copy.deepcopy(easyconfig['dependencies'])
-
     if cache_key is not None:
         _easyconfigs_cache[cache_key] = [e.copy() for e in easyconfigs]
 

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -169,14 +169,14 @@ def _dep_graph(fn, specs, silent=False):
     for spec in specs:
         spec['module'] = mk_node_name(spec['ec'])
         all_nodes.add(spec['module'])
-        spec['unresolved_deps'] = [mk_node_name(s) for s in spec['unresolved_deps']]
-        all_nodes.update(spec['unresolved_deps'])
+        spec['dependencies'] = [mk_node_name(s) for s in spec['dependencies']]
+        all_nodes.update(spec['dependencies'])
 
     # build directed graph
     dgr = digraph()
     dgr.add_nodes(all_nodes)
     for spec in specs:
-        for dep in spec['unresolved_deps']:
+        for dep in spec['dependencies']:
             dgr.add_edge((spec['module'], dep))
 
     # write to file

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -121,6 +121,7 @@ def submit_jobs(ordered_ecs, cmd_line_opts, testing=False, prepare_first=True):
     @param ordered_ecs: list of easyconfigs, in the order they should be processed
     @param cmd_line_opts: list of command line options (in 'longopt=value' form)
     @param testing: If `True`, skip actual job submission
+    @param prepare_first: prepare by runnning fetch step first for each easyconfig
     """
     curdir = os.getcwd()
 
@@ -133,7 +134,7 @@ def submit_jobs(ordered_ecs, cmd_line_opts, testing=False, prepare_first=True):
     # compose string with command line options, properly quoted and with '%' characters escaped
     opts_str = subprocess.list2cmdline(opts).replace('%', '%%')
 
-    command = "unset TMPDIR && cd %s && eb %%(spec)s %s %%(add_opts)s--testoutput=%%(output_dir)s" % (curdir, opts_str)
+    command = "unset TMPDIR && cd %s && eb %%(spec)s %s %%(add_opts)s --testoutput=%%(output_dir)s" % (curdir, opts_str)
     _log.info("Command template for jobs: %s" % command)
     job_info_lines = []
     if testing:

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -96,8 +96,10 @@ def build_easyconfigs_in_parallel(build_command, easyconfigs, output_dir='easybu
         _log.info("creating job for ec: %s" % str(ec))
         new_job = create_job(active_job_backend, build_command, ec, output_dir=output_dir)
 
-        # sometimes unresolved_deps will contain things, not needed to be build
-        dep_mod_names = map(ActiveMNS().det_full_module_name, ec['unresolved_deps'])
+        # filter out dependencies marked as external modules
+        deps = [d for d in ec['dependencies'] if not d['external_module']]
+
+        dep_mod_names = map(ActiveMNS().det_full_module_name, deps)
         job_deps = [module_to_job[dep] for dep in dep_mod_names if dep in module_to_job]
 
         # actually (try to) submit job
@@ -113,7 +115,7 @@ def build_easyconfigs_in_parallel(build_command, easyconfigs, output_dir='easybu
     return jobs
 
 
-def submit_jobs(ordered_ecs, cmd_line_opts, testing=False):
+def submit_jobs(ordered_ecs, cmd_line_opts, testing=False, prepare_first=True):
     """
     Submit jobs.
     @param ordered_ecs: list of easyconfigs, in the order they should be processed
@@ -131,13 +133,13 @@ def submit_jobs(ordered_ecs, cmd_line_opts, testing=False):
     # compose string with command line options, properly quoted and with '%' characters escaped
     opts_str = subprocess.list2cmdline(opts).replace('%', '%%')
 
-    command = "unset TMPDIR && cd %s && eb %%(spec)s %s --testoutput=%%(output_dir)s" % (curdir, opts_str)
+    command = "unset TMPDIR && cd %s && eb %%(spec)s %s %%(add_opts)s--testoutput=%%(output_dir)s" % (curdir, opts_str)
     _log.info("Command template for jobs: %s" % command)
     job_info_lines = []
     if testing:
         _log.debug("Skipping actual submission of jobs since testing mode is enabled")
     else:
-        build_easyconfigs_in_parallel(command, ordered_ecs)
+        return build_easyconfigs_in_parallel(command, ordered_ecs, prepare_first=prepare_first)
 
 
 def create_job(job_backend, build_command, easyconfig, output_dir='easybuild-build'):
@@ -167,10 +169,16 @@ def create_job(job_backend, build_command, easyconfig, output_dir='easybuild-bui
     ec_tuple = (easyconfig['ec']['name'], det_full_ec_version(easyconfig['ec']))
     name = '-'.join(ec_tuple)
 
+    # determine whether additional options need to be passed to the 'eb' command
+    add_opts = ''
+    if easyconfig['hidden']:
+        add_opts += ' --hidden'
+
     # create command based on build_command template
     command = build_command % {
-        'spec': easyconfig['spec'],
+        'add_opts': add_opts,
         'output_dir': os.path.join(os.path.abspath(output_dir), name),
+        'spec': easyconfig['spec'],
     }
 
     # just use latest build stats

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -28,6 +28,7 @@ Unit tests for parallelbuild.py
 @author: Kenneth Hoste (Ghent University)
 """
 import os
+import re
 import stat
 from test.framework.utilities import EnhancedTestCase, init_config
 from unittest import TestLoader, main
@@ -38,7 +39,7 @@ from easybuild.tools import config
 from easybuild.tools.filetools import adjust_permissions, mkdir, which, write_file
 from easybuild.tools.job import pbs_python
 from easybuild.tools.job.pbs_python import PbsPython
-from easybuild.tools.parallelbuild import build_easyconfigs_in_parallel
+from easybuild.tools.parallelbuild import build_easyconfigs_in_parallel, submit_jobs
 from easybuild.tools.robot import resolve_dependencies
 
 
@@ -71,6 +72,7 @@ class MockPbsJob(object):
         self.deps = []
         self.jobid = None
         self.clean_conn = None
+        self.script = args[1]
 
     def add_dependencies(self, *args, **kwargs):
         pass
@@ -106,6 +108,7 @@ class ParallelBuildTest(EnhancedTestCase):
         pbs_python.PbsJob = MockPbsJob
 
         build_options = {
+            'external_modules_metadata': {},
             'robot_path': os.path.join(os.path.dirname(__file__), 'easyconfigs'),
             'valid_module_classes': config.module_classes(),
             'validate': False,
@@ -115,8 +118,22 @@ class ParallelBuildTest(EnhancedTestCase):
         ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'gzip-1.5-goolf-1.4.10.eb')
         easyconfigs = process_easyconfig(ec_file)
         ordered_ecs = resolve_dependencies(easyconfigs)
-        jobs = build_easyconfigs_in_parallel("echo %(spec)s", ordered_ecs, prepare_first=False)
+        jobs = build_easyconfigs_in_parallel("echo '%(spec)s'", ordered_ecs, prepare_first=False)
         self.assertEqual(len(jobs), 8)
+        regex = re.compile("echo '.*/gzip-1.5-goolf-1.4.10.eb'")
+        self.assertTrue(regex.search(jobs[-1].script), "Pattern '%s' found in: %s" % (regex.pattern, jobs[-1].script))
+
+        ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'gzip-1.4-GCC-4.6.3.eb')
+        ordered_ecs = resolve_dependencies(process_easyconfig(ec_file), retain_all_deps=True)
+        jobs = submit_jobs(ordered_ecs, '', testing=False, prepare_first=False)
+
+        # make sure command is correct, and that --hidden is there when it needs to be
+        for i, ec in enumerate(ordered_ecs):
+            if ec['hidden']:
+                regex = re.compile("eb %s.* --hidden" % ec['spec'])
+            else:
+                regex = re.compile("eb %s" % ec['spec'])
+            self.assertTrue(regex.search(jobs[i].script), "Pattern '%s' found in: %s" % (regex.pattern, jobs[i].script))
 
         # restore mocked stuff
         PbsPython.__init__ = PbsPython__init__


### PR DESCRIPTION
fix for #1328 

This also fixes an other issue I ran into, i.e. dependencies marked as external modules were not being filtered when determining job dependencies, which manifested itself as:

```
======================================================================
ERROR: test_build_easyconfigs_in_parallel_pbs_python (__main__.ParallelBuildTest)
Test build_easyconfigs_in_parallel(), using (mocked) pbs_python as backend for --job.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/framework/parallelbuild.py", line 121, in test_build_easyconfigs_in_parallel_pbs_python
    jobs = build_easyconfigs_in_parallel("echo '%(spec)s'", ordered_ecs, prepare_first=False)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/parallelbuild.py", line 97, in build_easyconfigs_in_parallel
    new_job = create_job(active_job_backend, build_command, ec, output_dir=output_dir)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/parallelbuild.py", line 174, in create_job
    if easyconfig['ec']['hidden']:
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 102, in new_ec_method
    return ec_method(self, key, *args, **kwargs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 694, in __getitem__
    raise EasyBuildError("Use of unknown easyconfig parameter '%s' when getting parameter value", key)
EasyBuildError: "Use of unknown easyconfig parameter 'hidden' when getting parameter value"

----------------------------------------------------------------------
Ran 2 tests in 3.140s
```

cc @ocaisa