### PR TITLE
fix 'exist' for hidden Lua module files

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -857,7 +857,7 @@ class Lmod(ModulesTool):
         # module file may be either in Tcl syntax (no file extension) or Lua sytax (.lua extension);
         # the current configuration for matters little, since the module may have been installed with a different cfg;
         # Lmod may pick up both Tcl and Lua module files, regardless of the EasyBuild configuration
-        return super(Lmod, self)._exist(mod_names, r'^\s*\S*/%s(.lua)?:\s*$')
+        return super(Lmod, self).exist(mod_names, r'^\s*\S*/%s(.lua)?:\s*$')
 
 
 def get_software_root_env_var_name(name):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -355,7 +355,7 @@ class ModulesTool(object):
         self.log.debug("'module available %s' gave %d answers: %s" % (mod_name, len(ans), ans))
         return ans
 
-    def _exist(self, mod_names, mod_exists_regex_template):
+    def exist(self, mod_names, mod_exists_regex_template=r'^\s*\S*/%s:\s*$'):
         """
         Check if modules with specified names exists.
         """
@@ -702,10 +702,6 @@ class EnvironmentModulesC(ModulesTool):
     def update(self):
         """Update after new modules were added."""
         pass
-
-    def exist(self, mod_names):
-        """Check if modules with specified names exists."""
-        return super(EnvironmentModulesC, self)._exist(mod_names, r'^\s*\S*/%s:\s*$')
 
 
 class EnvironmentModulesTcl(EnvironmentModulesC):

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -118,8 +118,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.testmods.exist(['toy/.0.0-deps']), [True])
 
         # exists works on hidden modules in Lua syntax (only with Lmod)
-        modtool = modules_tool()
-        if isinstance(modtool, Lmod):
+        if isinstance(self.testmods, Lmod):
             test_modules_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'modules'))
             # make sure only the .lua module file is there, otherwise this test doesn't work as intended
             self.assertTrue(os.path.exists(os.path.join(test_modules_path, 'bzip2', '.1.0.6.lua')))

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -117,6 +117,15 @@ class ModulesTest(EnhancedTestCase):
         # exists works on hidden modules
         self.assertEqual(self.testmods.exist(['toy/.0.0-deps']), [True])
 
+        # exists works on hidden modules in Lua syntax (only with Lmod)
+        modtool = modules_tool()
+        if isinstance(modtool, Lmod):
+            test_modules_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'modules'))
+            # make sure only the .lua module file is there, otherwise this test doesn't work as intended
+            self.assertTrue(os.path.exists(os.path.join(test_modules_path, 'bzip2', '.1.0.6.lua')))
+            self.assertFalse(os.path.exists(os.path.join(test_modules_path, 'bzip2', '.1.0.6')))
+            self.assertEqual(self.testmods.exist(['bzip2/.1.0.6']), [True])
+
         # exists also works on lists of module names
         # list should be sufficiently long, since for short lists 'show' is always used
         mod_names = ['OpenMPI/1.6.4-GCC-4.6.4', 'foo/1.2.3', 'GCC',

--- a/test/framework/modules/bzip2/.1.0.6.lua
+++ b/test/framework/modules/bzip2/.1.0.6.lua
@@ -1,0 +1,24 @@
+help([[bzip2 is a freely available, patent free, high-quality data compressor. It typically
+compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
+compressors), whilst being around twice as fast at compression and six times faster at decompression. - Homepage: http://www.bzip.org/]])
+whatis([[Name: bzip2]])
+whatis([[Version: 1.0.6]])
+whatis([[Description: bzip2 is a freely available, patent free, high-quality data compressor. It typically
+compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
+compressors), whilst being around twice as fast at compression and six times faster at decompression. - Homepage: http://www.bzip.org/]])
+whatis([[Homepage: http://www.bzip.org/]])
+
+local root = "/Users/example/.local/easybuild/software/bzip2/1.0.6"
+
+conflict("bzip2")
+
+prepend_path("CPATH", pathJoin(root, "include"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(root, "lib"))
+prepend_path("LIBRARY_PATH", pathJoin(root, "lib"))
+prepend_path("MANPATH", pathJoin(root, "man"))
+prepend_path("PATH", pathJoin(root, "bin"))
+setenv("EBROOTBZIP2", root)
+setenv("EBVERSIONBZIP2", "1.0.6")
+setenv("EBDEVELBZIP2", pathJoin(root, "easybuild/bzip2-1.0.6-easybuild-devel"))
+
+-- Built with EasyBuild version 2.1.1


### PR DESCRIPTION
fix for #1340

Existence of hidden modules is checked via `module show`, and then checking whether the module file path matches with the module name.

The regex wasn't taking into account that the module file path may have a `.lua` extension for hidden Lua module files.