### PR TITLE
fix using included module naming scheme

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -268,8 +268,7 @@ class EasyBuildOptions(GeneralOption):
             # purposely take a copy for the default logfile format
             'logfile-format': ("Directory name and format of the log file",
                                'strtuple', 'store', DEFAULT_LOGFILE_FORMAT[:], {'metavar': 'DIR,FORMAT'}),
-            'module-naming-scheme': ("Module naming scheme",
-                                     'choice', 'store', DEFAULT_MNS, sorted(avail_module_naming_schemes().keys())),
+            'module-naming-scheme': ("Module naming scheme to use", None, 'store', DEFAULT_MNS),
             'module-syntax': ("Syntax to be used for module files", 'choice', 'store', DEFAULT_MODULE_SYNTAX,
                               sorted(avail_module_generators().keys())),
             'moduleclasses': (("Extend supported module classes "
@@ -450,6 +449,12 @@ class EasyBuildOptions(GeneralOption):
                 msg = "Configuration option '%s' must specify a *relative* path (use 'installpath-%s' instead?): '%s'"
                 msg = msg % (subdir_opt, typ, val)
                 error_msgs.append(msg)
+
+        # specified module naming scheme must be a known one
+        avail_mnss = avail_module_naming_schemes()
+        if self.options.module_naming_scheme and self.options.module_naming_scheme not in avail_mnss:
+            msg = "Selected module naming scheme '%s' is unknown: %s" % (self.options.module_naming_scheme, avail_mnss)
+            error_msgs.append(msg)
 
         if error_msgs:
             raise EasyBuildError("Found problems validating the options: %s", '\n'.join(error_msgs))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1803,6 +1803,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args.append('--include-module-naming-schemes=%s/*.py' % self.test_prefix)
         self.eb_main(args, logfile=dummylogfn, do_build=True, raise_error=True, raise_systemexit=True, verbose=True)
         toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
+        if get_module_syntax() == 'Lua':
+            toy_mod += '.lua'
         self.assertTrue(os.path.exists(toy_mod), "Found %s" % toy_mod)
 
     def test_include_toolchains(self):

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -189,7 +189,7 @@ class EnhancedTestCase(_EnhancedTestCase):
             modtool.add_module_path(modpath)
 
     def eb_main(self, args, do_build=False, return_error=False, logfile=None, verbose=False, raise_error=False,
-                reset_env=True):
+                reset_env=True, raise_systemexit=False):
         """Helper method to call EasyBuild main function."""
         cleanup()
 
@@ -206,9 +206,10 @@ class EnhancedTestCase(_EnhancedTestCase):
 
         try:
             main((args, logfile, do_build))
-        except SystemExit:
-            pass
-        except Exception, err:
+        except SystemExit as err:
+            if raise_systemexit:
+                raise err
+        except Exception as err:
             myerr = err
             if verbose:
                 print "err: %s" % err


### PR DESCRIPTION
fix for #1367

`--include-module-naming-schemes` has to be processed before checking whether the specified naming scheme `--module-naming-scheme` is available or not, i.e. don't let the option parser check it by making `--module-naming-scheme` a choice option