### PR TITLE
add support for specifying builds by providing module name (WIP)

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1115,6 +1115,12 @@ class ActiveMNS(object):
             self.log.debug("Obtained valid full module name %s", mod_name)
         return mod_name
 
+    def parse_full_module_name(self, mod_name):
+        """
+        Parse specified full module name into list of possible matching name/version/versionsuffix/toolchain specs.
+        """
+        return self.mns.parse_full_module_name(mod_name)
+
     def det_install_subdir(self, ec):
         """Determine name of software installation subdirectory."""
         self.log.debug("Determining software installation subdir for %s", ec)

--- a/easybuild/tools/module_naming_scheme/easybuild_mns.py
+++ b/easybuild/tools/module_naming_scheme/easybuild_mns.py
@@ -30,6 +30,7 @@ Implementation of (default) EasyBuild module naming scheme.
 import copy
 import os
 
+from easybuild.framework.easyconfig.easyconfig import robot_find_easyconfig
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.module_naming_scheme import ModuleNamingScheme
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
@@ -59,12 +60,14 @@ class EasyBuildMNS(ModuleNamingScheme):
         @param mod_name: full module name to parse
         @return: list of dictionaries with possible matching specs
         """
+        res = []
         specs = {
             'name': None,
             'toolchain': {'name': None, 'version': None},
             'version': None,
             'versionsuffix': None,
         }
+
         # expected format is <name>/<version>-[<toolchain_name>-<toolchain_version>][-<versionsuffix>]
         mod_name_parts = mod_name.split('/')
 
@@ -76,8 +79,12 @@ class EasyBuildMNS(ModuleNamingScheme):
 
         specs['name'] = name
 
+        # <name>/<version> is the bare minumum
+        if len(mod_name_parts) < 2:
+            self.log.debug("Specified module name '%s' has fewer parts than expected: %s", mod_name, mod_name_parts)
+
         # ASSUMPTION: versionsuffix starts with '-'
-        if len(installver_parts) <= 2:
+        elif len(installver_parts) <= 2:
             # no toolchain => dummy toolchain
             specs['version'] = installver_parts[0]
             specs['toolchain']['name'] = DUMMY_TOOLCHAIN_NAME
@@ -90,7 +97,9 @@ class EasyBuildMNS(ModuleNamingScheme):
                 specs['versionsuffix'] = '-' + installver_parts[1]
 
             derived_mod_name = self.det_full_module_name(specs)
-            if mod_name != derived_mod_name:
+            if mod_name == derived_mod_name:
+                res.append(specs)
+            else:
                 raise EasyBuildError("Parsing full module naming unexpectedly failed: '%s' vs '%s'",
                                      mod_name, derived_mod_name)
 
@@ -104,6 +113,7 @@ class EasyBuildMNS(ModuleNamingScheme):
             for i, pot_tcname in enumerate(installver_parts):
                 if pot_tcname in all_tcs_names:
                     tcname_index = i
+                    break
 
             # derive information we can from obtained index for toolchain name
             if tcname_index is None:
@@ -125,32 +135,32 @@ class EasyBuildMNS(ModuleNamingScheme):
             orig_specs = copy.deepcopy(specs)
             derived_mod_name = self.det_full_module_name(specs)
             split_indices = (1, 2)
-            while split_indices[0] <= len(installver_parts) and mod_name != derived_mod_name:
+            while split_indices[0] <= len(installver_parts):
                 # restore correctly derived specs until now
                 specs = copy.deepcopy(orig_specs)
 
-                start_index = 0
+                start_index, end_index = 0, split_indices[0]
                 if specs['version'] is None:
-                    specs['version'] = '-'.join(installver_parts[:split_indices[0]])
-                    start_index = split_indices[0]
+                    specs['version'] = '-'.join(installver_parts[:end_index])
+                    start_index, end_index = end_index, split_indices[1]
                 if specs['toolchain']['version'] is None:
-                    specs['toolchain']['version'] = '-'.join(installver_parts[start_index:split_indices[1]])
-                    start_index = split_indices[1]
+                    specs['toolchain']['version'] = '-'.join(installver_parts[start_index:end_index])
+                    start_index = end_index
                 if installver_parts[start_index:]:
                     # ASSUMPTION: versionsuffix starts with '-'
                     specs['versionsuffix'] = '-' + '-'.join(installver_parts[start_index:])
+                    end_index = len(installver_parts)
                 else:
                     specs['versionsuffix'] = ''
 
                 derived_mod_name = self.det_full_module_name(specs)
+                if mod_name == derived_mod_name:
+                    res.append(specs)
 
-                if split_indices[1] < len(installver_parts):
+                # move along to try new version/toolchain version/versionsuffix split
+                if end_index < len(installver_parts):
                     split_indices = (split_indices[0], split_indices[1] + 1)
                 else:
                     split_indices = (split_indices[0] + 1, split_indices[0] + 2)
 
-            if mod_name != derived_mod_name:
-                raise EasyBuildError("Failed to successfully parse specified module name '%s'", mod_name)
-
-        # just return a single possible spec: either we found a match, or we failed to parse the module name correctly
-        return [specs]
+        return res

--- a/easybuild/tools/module_naming_scheme/easybuild_mns.py
+++ b/easybuild/tools/module_naming_scheme/easybuild_mns.py
@@ -27,11 +27,14 @@ Implementation of (default) EasyBuild module naming scheme.
 
 @author: Kenneth Hoste (Ghent University)
 """
-
+import copy
 import os
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.module_naming_scheme import ModuleNamingScheme
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
+from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME, DUMMY_TOOLCHAIN_VERSION
+from easybuild.tools.toolchain.utilities import search_toolchain
 
 
 class EasyBuildMNS(ModuleNamingScheme):
@@ -48,3 +51,106 @@ class EasyBuildMNS(ModuleNamingScheme):
         @return: string with full module name <name>/<installversion>, e.g.: 'gzip/1.5-goolf-1.4.10'
         """
         return os.path.join(ec['name'], det_full_ec_version(ec))
+
+    def parse_full_module_name(self, mod_name):
+        """
+        Parse specified full module name into list of possible matching name/version/versionsuffix/toolchain specs.
+
+        @param mod_name: full module name to parse
+        @return: list of dictionaries with possible matching specs
+        """
+        specs = {
+            'name': None,
+            'toolchain': {'name': None, 'version': None},
+            'version': None,
+            'versionsuffix': None,
+        }
+        # expected format is <name>/<version>-[<toolchain_name>-<toolchain_version>][-<versionsuffix>]
+        mod_name_parts = mod_name.split('/')
+
+        # split name and install version
+        # ASSUMPTION: no '/' in software name
+        name = mod_name_parts[0]
+        installver = '/'.join(mod_name_parts[1:])
+        installver_parts = installver.split('-')
+
+        specs['name'] = name
+
+        # ASSUMPTION: versionsuffix starts with '-'
+        if len(installver_parts) <= 2:
+            # no toolchain => dummy toolchain
+            specs['version'] = installver_parts[0]
+            specs['toolchain']['name'] = DUMMY_TOOLCHAIN_NAME
+            specs['toolchain']['version'] = DUMMY_TOOLCHAIN_VERSION
+            if len(installver_parts) == 1:
+                # version only, no versionsuffix
+                specs['versionsuffix'] = ''
+            else:
+                # version + versionsuffix
+                specs['versionsuffix'] = '-' + installver_parts[1]
+
+            derived_mod_name = self.det_full_module_name(specs)
+            if mod_name != derived_mod_name:
+                raise EasyBuildError("Parsing full module naming unexpectedly failed: '%s' vs '%s'",
+                                     mod_name, derived_mod_name)
+
+        else:
+            # try and find toolchain name first, can be used as an anchor point
+            # ASSUMPTION: no '-' in toolchain name
+            _, all_tcs = search_toolchain('')
+            all_tcs_names = [x.NAME for x in all_tcs]
+
+            tcname_index = None
+            for i, pot_tcname in enumerate(installver_parts):
+                if pot_tcname in all_tcs_names:
+                    tcname_index = i
+
+            # derive information we can from obtained index for toolchain name
+            if tcname_index is None:
+                # no toolchain name found => dummy toolchain
+                specs['toolchain']['name'] = DUMMY_TOOLCHAIN_NAME
+                specs['toolchain']['version'] = DUMMY_TOOLCHAIN_VERSION
+
+            elif tcname_index > 0:
+                # toolchain name found => software version (and toolchain name) known
+                specs['version'] = '-'.join(installver_parts[:tcname_index])
+                specs['toolchain']['name'] = installver_parts[tcname_index]
+                installver_parts = installver_parts[tcname_index+1:]
+
+            else:
+                # no software version?!
+                raise EasyBuildError("Toolchain name found as first part of install version, software version missing?")
+
+            # potentially still unknown: software version, toolchain version, versionsuffix
+            orig_specs = copy.deepcopy(specs)
+            derived_mod_name = self.det_full_module_name(specs)
+            split_indices = (1, 2)
+            while split_indices[0] <= len(installver_parts) and mod_name != derived_mod_name:
+                # restore correctly derived specs until now
+                specs = copy.deepcopy(orig_specs)
+
+                start_index = 0
+                if specs['version'] is None:
+                    specs['version'] = '-'.join(installver_parts[:split_indices[0]])
+                    start_index = split_indices[0]
+                if specs['toolchain']['version'] is None:
+                    specs['toolchain']['version'] = '-'.join(installver_parts[start_index:split_indices[1]])
+                    start_index = split_indices[1]
+                if installver_parts[start_index:]:
+                    # ASSUMPTION: versionsuffix starts with '-'
+                    specs['versionsuffix'] = '-' + '-'.join(installver_parts[start_index:])
+                else:
+                    specs['versionsuffix'] = ''
+
+                derived_mod_name = self.det_full_module_name(specs)
+
+                if split_indices[1] < len(installver_parts):
+                    split_indices = (split_indices[0], split_indices[1] + 1)
+                else:
+                    split_indices = (split_indices[0] + 1, split_indices[0] + 2)
+
+            if mod_name != derived_mod_name:
+                raise EasyBuildError("Failed to successfully parse specified module name '%s'", mod_name)
+
+        # just return a single possible spec: either we found a match, or we failed to parse the module name correctly
+        return [specs]

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -84,6 +84,15 @@ class ModuleNamingScheme(object):
         # by default: full module name doesn't include a $MODULEPATH subdir
         return self.det_full_module_name(ec)
 
+    def parse_full_module_name(self, mod_name):
+        """
+        Parse specified full module name into list of possible matching name/version/versionsuffix/toolchain specs.
+
+        @param mod_name: full module name to parse
+        @return: list of dictionaries with possible matching specs
+        """
+        raise EasyBuildError("Parsing of module names not implemented for '%s'", self.__class__.__name__)
+
     def det_install_subdir(self, ec):
         """
         Determine name of software installation subdirectory of install path.

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -554,47 +554,71 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
     def test_parse_full_module_name(self):
         """Test parse_full_module_name method of module naming scheme."""
+        test_easyconfigs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs')
+        init_config(build_options={'robot_path': test_easyconfigs_path})
+
         # test using default mns (EasyBuildMNS)
         specs = ActiveMNS().parse_full_module_name('GCC/4.7.2')
-        self.assertEqual(specs, [{
+        expected_specs = {
             'name': 'GCC',
             'toolchain': {'name': 'dummy', 'version': 'dummy'},
             'version': '4.7.2',
             'versionsuffix': '',
-        }])
+        }
+        self.assertEqual(specs, expected_specs)
 
-        specs = ActiveMNS().parse_full_module_name('GCC/4.7.2-CLooG')
-        self.assertEqual(specs, [{
-            'name': 'GCC',
+        specs = ActiveMNS().parse_full_module_name('toy/0.0-deps')
+        expected_specs = {
+            'name': 'toy',
             'toolchain': {'name': 'dummy', 'version': 'dummy'},
-            'version': '4.7.2',
-            'versionsuffix': '-CLooG',
-        }])
+            'version': '0.0',
+            'versionsuffix': '-deps',
+        }
+        self.assertEqual(specs, expected_specs)
 
         specs = ActiveMNS().parse_full_module_name('gzip/1.5-goolf-1.4.10')
-        self.assertEqual(specs, [{
+        expected_specs = {
             'name': 'gzip',
             'toolchain': {'name': 'goolf', 'version': '1.4.10'},
             'version': '1.5',
             'versionsuffix': '',
-        }])
+        }
+        self.assertEqual(specs, expected_specs)
 
-        specs = ActiveMNS().parse_full_module_name('OpenMPI/1.6.4-GCC-4.7.2-no-OFED')
-        self.assertEqual(specs, [{
-            'name': 'OpenMPI',
-            'toolchain': {'name': 'GCC', 'version': '4.7.2'},
-            'version': '1.6.4',
-            'versionsuffix': '-no-OFED',
-        }])
+        # check whether discriminating between toolchain version and versionsuffix works
+        specs = ActiveMNS().parse_full_module_name('OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2')
+        expected_specs = {
+            'name': 'OpenBLAS',
+            'toolchain': {'name': 'gompi', 'version': '1.4.10'},
+            'version': '0.2.6',
+            'versionsuffix': '-LAPACK-3.4.2',
+        }
+        self.assertEqual(specs, expected_specs)
 
-        mod_name = 'ScaLAPACK/1.8.0-gompi-1.1.0-no-OFED-ATLAS-3.8.4-LAPACK-3.4.0-BLACS-1.1'
+        mod_name = 'ScaLAPACK/2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2'
         specs = ActiveMNS().parse_full_module_name(mod_name)
-        self.assertEqual(specs, [{
+        expected_specs = {
             'name': 'ScaLAPACK',
-            'toolchain': {'name': 'gompi', 'version': '1.1.0-no-OFED'},
-            'version': '1.8.0',
-            'versionsuffix': '-ATLAS-3.8.4-LAPACK-3.4.0-BLACS-1.1',
-        }])
+            'toolchain': {'name': 'gompi', 'version': '1.4.10'},
+            'version': '2.0.2',
+            'versionsuffix': '-OpenBLAS-0.2.6-LAPACK-3.4.2',
+        }
+        self.assertEqual(specs, expected_specs)
+
+        # long toolchain version (actually version+versionsuffix), no software versionsuffix
+        specs = ActiveMNS().parse_full_module_name('imkl/11.1.2.144-iimpi-5.5.3-GCC-4.8.3')
+        expected_specs = {
+            'name': 'imkl',
+            'toolchain': {'name': 'iimpi', 'version': '5.5.3-GCC-4.8.3'},
+            'version': '11.1.2.144',
+            'versionsuffix': '',
+        }
+        self.assertEqual(specs, expected_specs)
+
+        # matching easyconfig is required
+        self.assertEqual(ActiveMNS().parse_full_module_name('unknown/1.2.3'), None)
+        # module names with not enough 'parts' just result in 'None'
+        self.assertEqual(ActiveMNS().parse_full_module_name('foobar'), None)
 
         # test using broken MNS, where parsing of module naming is not supported
         os.environ['EASYBUILD_MODULE_NAMING_SCHEME'] = 'BrokenModuleNamingScheme'

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -552,6 +552,57 @@ class ModuleGeneratorTest(EnhancedTestCase):
         for ecfile, mns_vals in test_ecs.items():
             test_ec(ecfile, *mns_vals)
 
+    def test_parse_full_module_name(self):
+        """Test parse_full_module_name method of module naming scheme."""
+        # test using default mns (EasyBuildMNS)
+        specs = ActiveMNS().parse_full_module_name('GCC/4.7.2')
+        self.assertEqual(specs, [{
+            'name': 'GCC',
+            'toolchain': {'name': 'dummy', 'version': 'dummy'},
+            'version': '4.7.2',
+            'versionsuffix': '',
+        }])
+
+        specs = ActiveMNS().parse_full_module_name('GCC/4.7.2-CLooG')
+        self.assertEqual(specs, [{
+            'name': 'GCC',
+            'toolchain': {'name': 'dummy', 'version': 'dummy'},
+            'version': '4.7.2',
+            'versionsuffix': '-CLooG',
+        }])
+
+        specs = ActiveMNS().parse_full_module_name('gzip/1.5-goolf-1.4.10')
+        self.assertEqual(specs, [{
+            'name': 'gzip',
+            'toolchain': {'name': 'goolf', 'version': '1.4.10'},
+            'version': '1.5',
+            'versionsuffix': '',
+        }])
+
+        specs = ActiveMNS().parse_full_module_name('OpenMPI/1.6.4-GCC-4.7.2-no-OFED')
+        self.assertEqual(specs, [{
+            'name': 'OpenMPI',
+            'toolchain': {'name': 'GCC', 'version': '4.7.2'},
+            'version': '1.6.4',
+            'versionsuffix': '-no-OFED',
+        }])
+
+        mod_name = 'ScaLAPACK/1.8.0-gompi-1.1.0-no-OFED-ATLAS-3.8.4-LAPACK-3.4.0-BLACS-1.1'
+        specs = ActiveMNS().parse_full_module_name(mod_name)
+        self.assertEqual(specs, [{
+            'name': 'ScaLAPACK',
+            'toolchain': {'name': 'gompi', 'version': '1.1.0-no-OFED'},
+            'version': '1.8.0',
+            'versionsuffix': '-ATLAS-3.8.4-LAPACK-3.4.0-BLACS-1.1',
+        }])
+
+        # test using broken MNS, where parsing of module naming is not supported
+        os.environ['EASYBUILD_MODULE_NAMING_SCHEME'] = 'BrokenModuleNamingScheme'
+        init_config()
+        error_regex = "Parsing of module names not implemented for 'BrokenModuleNamingScheme'"
+        self.assertErrorRegex(EasyBuildError, error_regex, ActiveMNS().parse_full_module_name, 'foo/bar')
+
+
 class TclModuleGeneratorTest(ModuleGeneratorTest):
     """Test for module_generator module for Tcl syntax."""
     MODULE_GENERATOR_CLASS = ModuleGeneratorTcl


### PR DESCRIPTION
The idea here is to support installing software using `eb` by providing module names, rather than specifying easyconfigs, like:

```shell
$ eb OpenFOAM/2.3.1-intel-2015a
# corresponds to 'eb OpenFOAM-2.3.1-intel-2015a' when using default module naming scheme

```

or:

```shell
$ eb MPI/GCC/4.9.2/OpenMPI/1.8.4/FFTW/3.3.4
# corresponds to 'eb FFTW-3.3.4-gompi-2015a.eb' when HierarchicalMNS is used a module naming scheme
```

This would be one way of specifying what to install when 'fat' easyconfigs (e.g. `GCC.eb` or `GCC.yaml`) are installed, other ways may be added later (e.g., `eb OpenFOAM 2.3.1 intel/2015`, or `eb <software name> <software version> [<versionsuffix>] <toolchain>`) 

TODO list:

* [x] extend API for module naming schemes to support parsing of provided module name
* [x] implement parsing of module names for EasyBuildMNS
* [ ] implement parsing of module names for HierarchicalMNS
* [ ] implement parsing of module names for other included module naming schemes
* [ ] add support to `eb` to also accept module names, and go find corresponding easyconfig file