### PR TITLE
fix extracting of comments from an easyconfig file that includes 'tail' comments

### DIFF
--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -272,6 +272,8 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         params, _ = self._find_defined_params(ecfg, [[k] for k in LAST_PARAMS], default_values, templ_const, templ_val)
         dump.extend(params)
 
+        dump.extend(self.comments['tail'])
+
         return '\n'.join(dump)
 
     def extract_comments(self, rawtxt):
@@ -286,6 +288,7 @@ class FormatOneZero(EasyConfigFormatConfigObj):
             'header' : [],  # header comment lines
             'inline' : {},  # inline comments
             'iter': {},  # (inline) comments on elements of iterable values
+            'tail': [],
          }
 
         rawlines = rawtxt.split('\n')
@@ -301,13 +304,21 @@ class FormatOneZero(EasyConfigFormatConfigObj):
             if rawline.startswith('#'):
                 comment = []
                 # comment could be multi-line
-                while rawline.startswith('#') or not rawline:
+                while rawline is not None and (rawline.startswith('#') or not rawline):
                     # drop empty lines (that don't even include a #)
                     if rawline:
                         comment.append(rawline)
-                    rawline = rawlines.pop(0)
-                key = rawline.split('=', 1)[0].strip()
-                self.comments['above'][key] = comment
+                    # grab next line (if more lines are left)
+                    if rawlines:
+                        rawline = rawlines.pop(0)
+                    else:
+                        rawline = None
+
+                if rawline is None:
+                    self.comments['tail'] = comment
+                else:
+                    key = rawline.split('=', 1)[0].strip()
+                    self.comments['above'][key] = comment
 
             elif '#' in rawline:  # inline comment
                 comment_key, comment_val = None, None

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1343,6 +1343,7 @@ class EasyConfigTest(EnhancedTestCase):
             '}',
             '',
             "foo_extra1 = 'foobar'",
+            "# trailing comment",
         ])
 
         handle, testec = tempfile.mkstemp(prefix=self.test_prefix, suffix='.eb')
@@ -1365,6 +1366,8 @@ class EasyConfigTest(EnhancedTestCase):
         for pattern in patterns:
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(ectxt), "Pattern '%s' found in: %s" % (regex.pattern, ectxt))
+
+        self.assertTrue(ectxt.endswith("# trailing comment"))
 
         # reparsing the dumped easyconfig file should work
         ecbis = EasyConfig(testec)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -303,7 +303,7 @@ class EasyConfigTest(EnhancedTestCase):
             '       "patches": ["toy-0.0.eb"],',  # dummy patch to avoid downloading fail
             '       "checksums": [',
             '           "787393bfc465c85607a5b24486e861c5",',  # MD5 checksum for source (gzip-1.4.eb)
-            '           "ddd5161154f5db67701525123129ff09",',  # MD5 checksum for patch (toy-0.0.eb)
+            '           "44893c3ed46a7c7ab2e72fea7d19925d",',  # MD5 checksum for patch (toy-0.0.eb)
             '       ],',
             '   }),',
             ']',

--- a/test/framework/easyconfigs/toy-0.0.eb
+++ b/test/framework/easyconfigs/toy-0.0.eb
@@ -25,3 +25,4 @@ sanity_check_paths = {
 postinstallcmds = ["echo TOY > %(installdir)s/README"]
 
 moduleclass = 'tools'
+# trailing comment, leave this here, it may trigger bugs with extract_comments()


### PR DESCRIPTION
fix for #1380