### PR TITLE
fix dev version to follow PEP-440, which setuptools basically jams down our throat

### DIFF
--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -37,7 +37,13 @@ from socket import gethostname
 
 # note: release candidates should be versioned as a pre-release, e.g. "1.1rc1"
 # 1.1-rc1 would indicate a post-release, i.e., and update of 1.1, so beware!
-VERSION = LooseVersion('2.4.0dev')
+#
+# important note: dev versions should follow the 'X.Y.Z.dev0' format
+# see https://www.python.org/dev/peps/pep-0440/#developmental-releases
+# recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
+#   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
+# This causes problems further up the dependency chain...
+VERSION = LooseVersion('2.4.0.dev0')
 UNKNOWN = 'UNKNOWN'
 
 def get_git_revision():


### PR DESCRIPTION
see also https://bitbucket.org/pypa/setuptools/pull-requests/118/remove-warning-on-normalization