### PR TITLE
Support for SLES 12 and kernel 3.12.x

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -338,6 +338,9 @@ def get_os_version():
                     ('2.6.32', '_SP1'),
                     ('3.0', '_SP2'),
                 ],
+                "12": [
+                    ('3.12', ''),
+                ],
             }
 
             # append suitable suffix to system version

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -336,8 +336,14 @@ def get_os_version():
                 "11": [
                     ('2.6.27', ''),
                     ('2.6.32', '_SP1'),
+                    ('3.0.101-63', '_SP4'),
+                    # not 100% correct, since early SP3 had 3.0.76 - 3.0.93, but close enough?
+                    ('3.0.101', '_SP3'),
+                    # SP2 kernel versions range from 3.0.13 - 3.0.101
                     ('3.0', '_SP2'),
                 ],
+
+                # Once SLES 12 SP1 comes out we'll need to make this stricter
                 "12": [
                     ('3.12', ''),
                 ],


### PR DESCRIPTION
Adding support for SLES 12.

Based on this document (and what I see on the VMs) I've added support for SLES 12 and kernel versions 3.12.x.  SLES 12 kernel versions range from 3.12.28 - .43 for the initial release.

https://www.novell.com/support/kb/doc.php?id=3594951

