### PR TITLE
add and use only_if_module_is_available decorator function to guard functionality that uses optional dependencies

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -64,7 +64,7 @@ from easybuild.tools.utilities import only_if_module_is_available, quote_str
 try:
     # PyGraph (used for generating dependency graphs)
     # https://pypi.python.org/pypi/python-graph-core
-    import pygraph.classes.digraph as digraph
+    from pygraph.classes.digraph import digraph
     # https://pypi.python.org/pypi/python-graph-dot
     import pygraph.readwrite.dot as dot
     # graphviz (used for creating dependency graph images)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -36,6 +36,7 @@ Set of file tools.
 @author: Sotiris Fragkiskos (NTUA, CERN)
 """
 import glob
+import hashlib
 import os
 import re
 import shutil
@@ -93,23 +94,14 @@ STRING_ENCODING_CHARMAP = {
     r'~': "_tilde_",
 }
 
-try:
-    # preferred over md5/sha modules, but only available in Python 2.5 and more recent
-    import hashlib
-    md5_class = hashlib.md5
-    sha1_class = hashlib.sha1
-except ImportError:
-    import md5, sha
-    md5_class = md5.md5
-    sha1_class = sha.sha
 
 # default checksum for source and patch files
 DEFAULT_CHECKSUM = 'md5'
 
 # map of checksum types to checksum functions
 CHECKSUM_FUNCTIONS = {
-    'md5': lambda p: calc_block_checksum(p, md5_class()),
-    'sha1': lambda p: calc_block_checksum(p, sha1_class()),
+    'md5': lambda p: calc_block_checksum(p, hashlib.md5()),
+    'sha1': lambda p: calc_block_checksum(p, hashlib.sha1()),
     'adler32': lambda p: calc_block_checksum(p, ZlibChecksum(zlib.adler32)),
     'crc32': lambda p: calc_block_checksum(p, ZlibChecksum(zlib.crc32)),
     'size': lambda p: os.path.getsize(p),

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -87,6 +87,8 @@ class GC3Pie(JobBackend):
         """GC3Pie constructor."""
         super(GC3Pie, self).__init__(*args, **kwargs)
 
+    # _check_version is called by __init__, so guard it (too) with the decorator
+    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def _check_version(self):
         """Check whether GC3Pie version complies with required version."""
         # location of __version__ to use may change, depending on the minimal required SVN revision for development versions

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -39,6 +39,7 @@ from vsc.utils import fancylogger
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
 from easybuild.tools.job.backend import JobBackend
+from easybuild.tools.utilities import only_if_module_is_available
 
 
 _log = fancylogger.getLogger('gc3pie', fname=False)
@@ -60,24 +61,9 @@ try:
     # instruct GC3Pie to not ignore errors, but raise exceptions instead
     gc3libs.UNIGNORE_ALL_ERRORS = True
 
-    # GC3Pie is available, no need guard against import errors
-    def gc3pie_imported(fn):
-        """No-op decorator."""
-        return fn
-
 except ImportError as err:
     _log.debug("Failed to import gc3libs from GC3Pie."
                " Silently ignoring, this is a real issue only when GC3Pie is used as backend for --job")
-
-    # GC3Pie not available, turn method in a raised EasyBuildError
-    def gc3pie_imported(_):
-        """Decorator which raises an EasyBuildError because GC3Pie is not available."""
-        def fail(*args, **kwargs):
-            """Raise EasyBuildError since GC3Pie is not available."""
-            errmsg = "Python modules 'gc3libs' is not available. Please make sure GC3Pie is installed and usable: %s"
-            raise EasyBuildError(errmsg, err)
-
-        return fail
 
 
 # eb --job --job-backend=GC3Pie
@@ -96,7 +82,7 @@ class GC3Pie(JobBackend):
     DEVELOPMENT_VERSION = 'development'  # 'magic' version string indicated non-released version
     REQ_SVN_REVISION = 4287  # use integer value, not a string!
 
-    @gc3pie_imported
+    @only_if_module_is_available('gc3libs.core', pkgname='gc3pie')
     def _check_version(self):
         """Check whether GC3Pie version complies with required version."""
         # location of __version__ to use may change, depending on the minimal required SVN revision for development versions
@@ -122,7 +108,7 @@ class GC3Pie(JobBackend):
             raise EasyBuildError("Failed to parse GC3Pie version string '%s' using pattern %s",
                                  version_str, version_regex.pattern)
 
-    @gc3pie_imported
+    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def init(self):
         """
         Initialise the GC3Pie job backend.
@@ -145,7 +131,7 @@ class GC3Pie(JobBackend):
         # before polling again (in seconds)
         self.poll_interval = build_option('job_polling_interval')
 
-    @gc3pie_imported
+    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def make_job(self, script, name, env_vars=None, hours=None, cores=None):
         """
         Create and return a job object with the given parameters.
@@ -209,7 +195,7 @@ class GC3Pie(JobBackend):
 
         return Application(['/bin/sh', '-c', script], **named_args)
 
-    @gc3pie_imported
+    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def queue(self, job, dependencies=frozenset()):
         """
         Add a job to the queue, optionally specifying dependencies.
@@ -220,7 +206,7 @@ class GC3Pie(JobBackend):
         # since it's not trivial to determine the correct job count from self.jobs, we keep track of a count ourselves
         self.job_cnt += 1
 
-    @gc3pie_imported
+    @only_if_module_is_available('gc3libs.exceptions', pkgname='gc3pie')
     def complete(self):
         """
         Complete a bulk job submission.
@@ -267,7 +253,7 @@ class GC3Pie(JobBackend):
         print_msg("Done processing jobs", log=self.log, silent=build_option('silent'))
         self._print_status_report()
 
-    @gc3pie_imported
+    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def _print_status_report(self):
         """
         Print a job status report to STDOUT and the log file.

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -82,7 +82,11 @@ class GC3Pie(JobBackend):
     DEVELOPMENT_VERSION = 'development'  # 'magic' version string indicated non-released version
     REQ_SVN_REVISION = 4287  # use integer value, not a string!
 
-    @only_if_module_is_available('gc3libs.core', pkgname='gc3pie')
+    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
+    def __init__(self, *args, **kwargs):
+        """GC3Pie constructor."""
+        super(GC3Pie, self).__init__(*args, **kwargs)
+
     def _check_version(self):
         """Check whether GC3Pie version complies with required version."""
         # location of __version__ to use may change, depending on the minimal required SVN revision for development versions
@@ -108,7 +112,6 @@ class GC3Pie(JobBackend):
             raise EasyBuildError("Failed to parse GC3Pie version string '%s' using pattern %s",
                                  version_str, version_regex.pattern)
 
-    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def init(self):
         """
         Initialise the GC3Pie job backend.
@@ -131,7 +134,6 @@ class GC3Pie(JobBackend):
         # before polling again (in seconds)
         self.poll_interval = build_option('job_polling_interval')
 
-    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def make_job(self, script, name, env_vars=None, hours=None, cores=None):
         """
         Create and return a job object with the given parameters.
@@ -195,7 +197,6 @@ class GC3Pie(JobBackend):
 
         return Application(['/bin/sh', '-c', script], **named_args)
 
-    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def queue(self, job, dependencies=frozenset()):
         """
         Add a job to the queue, optionally specifying dependencies.
@@ -206,7 +207,6 @@ class GC3Pie(JobBackend):
         # since it's not trivial to determine the correct job count from self.jobs, we keep track of a count ourselves
         self.job_cnt += 1
 
-    @only_if_module_is_available('gc3libs.exceptions', pkgname='gc3pie')
     def complete(self):
         """
         Complete a bulk job submission.
@@ -253,7 +253,6 @@ class GC3Pie(JobBackend):
         print_msg("Done processing jobs", log=self.log, silent=build_option('silent'))
         self._print_status_report()
 
-    @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def _print_status_report(self):
         """
         Print a job status report to STDOUT and the log file.

--- a/easybuild/tools/job/pbs_python.py
+++ b/easybuild/tools/job/pbs_python.py
@@ -68,6 +68,10 @@ class PbsPython(JobBackend):
     REQ_VERSION = '4.1.0'
 
     @only_if_module_is_available('pbs', pkgname='pbs_python')
+    def __init__(self, *args, **kwargs):
+        """PbsPython constructor."""
+        super(GC3Pie, self).__init__(*args, **kwargs)
+
     def _check_version(self):
         """Check whether pbs_python version complies with required version."""
         version_regex = re.compile('pbs_python version (?P<version>.*)')
@@ -81,7 +85,6 @@ class PbsPython(JobBackend):
             raise EasyBuildError("Failed to parse pbs_python version string '%s' using pattern %s",
                                  pbs.version, version_regex.pattern)
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def __init__(self, *args, **kwargs):
         """Constructor."""
         pbs_server = kwargs.pop('pbs_server', None)
@@ -101,7 +104,6 @@ class PbsPython(JobBackend):
         self.connect_to_server()
         self._submitted = []
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def connect_to_server(self):
         """Connect to PBS server, set and return connection."""
         if not self.conn:
@@ -148,13 +150,11 @@ class PbsPython(JobBackend):
 
         self.log.info("Job ids of leaf nodes in dep. graph: %s" % ','.join(leaf_nodes))
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def disconnect_from_server(self):
         """Disconnect current connection."""
         pbs.pbs_disconnect(self.conn)
         self.conn = None
 
-    @only_if_module_is_available('PBSQuery', pkgname='pbs_python')
     def _get_ppn(self):
         """Guess PBS' `ppn` value for a full node."""
         # cache this value as it's not likely going to change over the
@@ -256,7 +256,6 @@ class PbsJob(object):
         """
         self.deps.extend(jobs)
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def _submit(self):
         """Submit the jobscript txt, set self.jobid"""
         txt = self.script
@@ -341,7 +340,6 @@ class PbsJob(object):
             self.jobid = jobid
             os.remove(scriptfn)
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def set_hold(self, hold_type=None):
         """Set hold on job of specified type."""
         # we can't set this default for hold_type in function signature,
@@ -363,7 +361,6 @@ class PbsJob(object):
         else:
             self.log.warning("Hold type %s was already set for %s" % (hold_type, self.jobid))
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def release_hold(self, hold_type=None):
         """Release hold on job of specified type."""
         # we can't set this default for hold_type in function signature,
@@ -430,7 +427,6 @@ class PbsJob(object):
         else:
             return 'running'
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def info(self, types=None):
         """
         Return jobinfo
@@ -473,7 +469,6 @@ class PbsJob(object):
         self.log.debug("Found jobinfo %s" % job_details)
         return job_details
 
-    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def remove(self):
         """Remove the job with id jobid"""
         result = pbs.pbs_deljob(self.pbsconn, self.jobid, '')  # use empty string, not NULL

--- a/easybuild/tools/job/pbs_python.py
+++ b/easybuild/tools/job/pbs_python.py
@@ -72,6 +72,8 @@ class PbsPython(JobBackend):
         """PbsPython constructor."""
         super(PbsPython, self).__init__(*args, **kwargs)
 
+    # _check_version is called by __init__, so guard it (too) with the decorator
+    @only_if_module_is_available('pbs', pkgname='pbs_python')
     def _check_version(self):
         """Check whether pbs_python version complies with required version."""
         version_regex = re.compile('pbs_python version (?P<version>.*)')

--- a/easybuild/tools/job/pbs_python.py
+++ b/easybuild/tools/job/pbs_python.py
@@ -70,7 +70,7 @@ class PbsPython(JobBackend):
     @only_if_module_is_available('pbs', pkgname='pbs_python')
     def __init__(self, *args, **kwargs):
         """PbsPython constructor."""
-        super(GC3Pie, self).__init__(*args, **kwargs)
+        super(PbsPython, self).__init__(*args, **kwargs)
 
     def _check_version(self):
         """Check whether pbs_python version complies with required version."""

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -75,6 +75,7 @@ class GitRepository(FileRepository):
 
     USABLE = HAVE_GIT
 
+    @only_if_module_is_available('git', pkgname='GitPython')
     def __init__(self, *args):
         """
         Initialize git client to None (will be set later)
@@ -83,14 +84,12 @@ class GitRepository(FileRepository):
         self.client = None
         FileRepository.__init__(self, *args)
 
-    @only_if_module_is_available('git', pkgname='GitPython')
     def setup_repo(self):
         """
         Set up git repository.
         """
         self.wc = tempfile.mkdtemp(prefix='git-wc-')
 
-    @only_if_module_is_available('git', pkgname='GitPython')
     def create_working_copy(self):
         """
         Create git working copy.

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -46,6 +46,7 @@ from vsc.utils import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.repository.filerepo import FileRepository
+from easybuild.tools.utilities import only_if_module_is_available
 from easybuild.tools.version import VERSION
 
 _log = fancylogger.getLogger('gitrepo', fname=False)
@@ -54,7 +55,7 @@ _log = fancylogger.getLogger('gitrepo', fname=False)
 # failing imports are just ignored
 # a NameError should be catched where these are used
 
-# GitPython
+# GitPython (http://gitorious.org/git-python)
 try:
     import git
     from git import GitCommandError
@@ -82,17 +83,14 @@ class GitRepository(FileRepository):
         self.client = None
         FileRepository.__init__(self, *args)
 
+    @only_if_module_is_available('git', pkgname='GitPython')
     def setup_repo(self):
         """
         Set up git repository.
         """
-        try:
-            git.GitCommandError
-        except NameError, err:
-            raise EasyBuildError("It seems like GitPython is not available: %s", err)
-
         self.wc = tempfile.mkdtemp(prefix='git-wc-')
 
+    @only_if_module_is_available('git', pkgname='GitPython')
     def create_working_copy(self):
         """
         Create git working copy.

--- a/easybuild/tools/repository/svnrepo.py
+++ b/easybuild/tools/repository/svnrepo.py
@@ -46,12 +46,14 @@ from vsc.utils import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.repository.filerepo import FileRepository
+from easybuild.tools.utilities import only_if_module_is_available
+
 
 _log = fancylogger.getLogger('svnrepo', fname=False)
 
+
 # optional Python packages, these might be missing
 # failing imports are just ignored
-# a NameError should be catched where these are used
 
 # PySVN
 try:
@@ -59,7 +61,7 @@ try:
     from pysvn import ClientError  # IGNORE:E0611 pysvn fails to recognize ClientError is available
     HAVE_PYSVN = True
 except ImportError:
-    _log.debug('Failed to import pysvn module')
+    _log.debug("Failed to import pysvn module")
     HAVE_PYSVN = False
 
 
@@ -81,16 +83,12 @@ class SvnRepository(FileRepository):
         self.client = None
         FileRepository.__init__(self, *args)
 
+    @only_if_module_is_available('pysvn', url='http://pysvn.tigris.org/')
     def setup_repo(self):
         """
         Set up SVN repository.
         """
         self.repo = os.path.join(self.repo, self.subdir)
-        try:
-            pysvn.ClientError  # IGNORE:E0611 pysvn fails to recognize ClientError is available
-        except NameError, err:
-            raise EasyBuildError("pysvn not available (%s). Make sure it is installed properly. "
-                                 "Run 'python -c \"import pysvn\"' to test.", err)
 
         # try to connect to the repository
         self.log.debug("Try to connect to repository %s" % self.repo)

--- a/easybuild/tools/repository/svnrepo.py
+++ b/easybuild/tools/repository/svnrepo.py
@@ -76,6 +76,7 @@ class SvnRepository(FileRepository):
 
     USABLE = HAVE_PYSVN
 
+    @only_if_module_is_available('pysvn', url='http://pysvn.tigris.org/')
     def __init__(self, *args):
         """
         Set self.client to None. Real logic is in setupRepo and createWorkingCopy
@@ -83,7 +84,6 @@ class SvnRepository(FileRepository):
         self.client = None
         FileRepository.__init__(self, *args)
 
-    @only_if_module_is_available('pysvn', url='http://pysvn.tigris.org/')
     def setup_repo(self):
         """
         Set up SVN repository.

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -122,3 +122,27 @@ def import_available_modules(namespace):
                     raise EasyBuildError("import_available_modules: Failed to import %s: %s", modpath, err)
                 modules.append(mod)
     return modules
+
+
+def only_if_module_is_available(modname, pkgname=None, url=None):
+    """Decorator to guard functions/methods against missing required module with specified name."""
+    if pkgname and url is None:
+        url = 'https://pypi.python.org/pypi/%s' % pkgname
+
+    def wrap(orig):
+        """Decorated function, raises ImportError if specified module is not available."""
+        try:
+            __import__(modname)
+            return orig
+
+        except ImportError as err:
+            def error(*args):
+                msg = "%s; required module '%s' is not available" % (err, modname)
+                if pkgname:
+                    msg += " (provided by Python package %s, available from %s)" % (pkgname, url)
+                elif url:
+                    msg += " (available from %s)" % url
+                raise ImportError(msg)
+            return error
+
+    return wrap

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -105,7 +105,7 @@ class FileToolsTest(EnhancedTestCase):
         os.mkdir(os.path.join(tmpdir, 'easybuild'))
 
         os.chdir(tmpdir)
-        self.assertEqual(foodir, ft.find_base_dir())
+        self.assertTrue(os.path.samefile(foodir, ft.find_base_dir()))
 
     def test_encode_class_name(self):
         """Test encoding of class names."""

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -30,6 +30,7 @@ Unit tests for scripts
 import os
 import re
 import shutil
+import sys
 import tempfile
 from test.framework.utilities import EnhancedTestCase
 from unittest import TestLoader, main
@@ -77,7 +78,7 @@ class ScriptsTest(EnhancedTestCase):
             for ec_file in files:
                 shutil.copy2(os.path.join(root, ec_file), tmpdir)
 
-        cmd = "python %s --local --quiet --path %s" % (script, tmpdir)
+        cmd = "%s %s --local --quiet --path %s" % (sys.executable, script, tmpdir)
         out, ec = run_cmd(cmd, simple=False)
 
         # make sure output is kind of what we expect it to be

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -88,6 +88,8 @@ class EnhancedTestCase(_EnhancedTestCase):
         log = fancylogger.getLogger(fname=False)
         self.orig_log_handlers = log.handlers[:]
 
+        log.info("setting up test %s" % self._testMethodName)
+
         self.orig_tmpdir = tempfile.gettempdir()
         # use a subdirectory for this test (which we can clean up easily after the test completes)
         self.test_prefix = set_tmpdir()

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -149,6 +149,8 @@ class EnhancedTestCase(_EnhancedTestCase):
         """Clean up after running testcase."""
         super(EnhancedTestCase, self).tearDown()
 
+        self.log.info("Cleaning up for test %s", self.id())
+
         # go back to where we were before
         os.chdir(self.cwd)
 

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -88,7 +88,7 @@ class EnhancedTestCase(_EnhancedTestCase):
         log = fancylogger.getLogger(fname=False)
         self.orig_log_handlers = log.handlers[:]
 
-        log.info("setting up test %s" % self._testMethodName)
+        log.info("setting up test %s" % self.id())
 
         self.orig_tmpdir = tempfile.gettempdir()
         # use a subdirectory for this test (which we can clean up easily after the test completes)


### PR DESCRIPTION
This results in removal of some duplicate code, and clean/uniform error messages on missing Python modules, like:

```
ImportError: No module named gc3libs.core; required module 'gc3libs.core' is not available (provided by Python package gc3pie, available from https://pypi.python.org/pypi/gc3pie)
```