### PR TITLE
use class name (string) rather than License instances as values for software license constants

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -214,6 +214,7 @@ class EasyConfig(object):
         self.short_mod_name = mns.det_short_module_name(self)
         self.mod_subdir = mns.det_module_subdir(self)
 
+        self.software_license = None
 
     def copy(self):
         """
@@ -335,16 +336,17 @@ class EasyConfig(object):
 
     def validate_license(self):
         """Validate the license"""
-        lic = self._config['software_license'][0]
+        lic = self['software_license']
         if lic is None:
             # when mandatory, remove this possibility
             if 'software_license' in self.mandatory:
-                raise EasyBuildError("License is mandatory, but 'software_license' is undefined")
-        elif not isinstance(lic, License):
-            raise EasyBuildError('License %s has to be a License subclass instance, found classname %s.',
-                                 lic, lic.__class__.__name__)
-        elif not lic.name in EASYCONFIG_LICENSES_DICT:
-            raise EasyBuildError('Invalid license %s (classname: %s).', lic.name, lic.__class__.__name__)
+                raise EasyBuildError("Software license is mandatory, but 'software_license' is undefined")
+        elif lic in EASYCONFIG_LICENSES_DICT:
+            # create License instance
+            self.software_license = EASYCONFIG_LICENSES_DICT[lic]()
+        else:
+            known_licenses = ', '.join(EASYCONFIG_LICENSES_DICT.keys())
+            raise EasyBuildError("Invalid license %s (known licenses: )", lic, known_licenses)
 
         # TODO, when GROUP_SOURCE and/or GROUP_BINARY is True
         #  check the owner of source / binary (must match 'group' parameter from easyconfig)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -345,8 +345,8 @@ class EasyConfig(object):
             # create License instance
             self.software_license = EASYCONFIG_LICENSES_DICT[lic]()
         else:
-            known_licenses = ', '.join(EASYCONFIG_LICENSES_DICT.keys())
-            raise EasyBuildError("Invalid license %s (known licenses: )", lic, known_licenses)
+            known_licenses = ', '.join(sorted(EASYCONFIG_LICENSES_DICT.keys()))
+            raise EasyBuildError("Invalid license %s (known licenses: %s)", lic, known_licenses)
 
         # TODO, when GROUP_SOURCE and/or GROUP_BINARY is True
         #  check the owner of source / binary (must match 'group' parameter from easyconfig)

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -50,7 +50,7 @@ def build_easyconfig_constants_dict():
     all_consts = [
         ('TEMPLATE_CONSTANTS', dict([(x[0], x[1]) for x in TEMPLATE_CONSTANTS])),
         ('EASYCONFIG_CONSTANTS', dict([(key, val[0]) for key, val in EASYCONFIG_CONSTANTS.items()])),
-        ('EASYCONFIG_LICENSES', EASYCONFIG_LICENSES_DICT),
+        ('EASYCONFIG_LICENSES', dict([(x, x) for x in EASYCONFIG_LICENSES_DICT.keys()])),
     ]
     err = []
     const_dict = {}

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -46,11 +46,10 @@ _log = fancylogger.getLogger('easyconfig.format.pyheaderconfigobj', fname=False)
 
 def build_easyconfig_constants_dict():
     """Make a dictionary with all constants that can be used"""
-    # sanity check
     all_consts = [
         ('TEMPLATE_CONSTANTS', dict([(x[0], x[1]) for x in TEMPLATE_CONSTANTS])),
         ('EASYCONFIG_CONSTANTS', dict([(key, val[0]) for key, val in EASYCONFIG_CONSTANTS.items()])),
-        ('EASYCONFIG_LICENSES', dict([(x, x) for x in EASYCONFIG_LICENSES_DICT.keys()])),
+        ('EASYCONFIG_LICENSES', dict([(klass().name, name) for name, klass in EASYCONFIG_LICENSES_DICT.items()])),
     ]
     err = []
     const_dict = {}

--- a/easybuild/framework/easyconfig/licenses.py
+++ b/easybuild/framework/easyconfig/licenses.py
@@ -28,10 +28,12 @@ Easyconfig licenses module that provides all licenses that can
 be used within an Easyconfig file.
 
 @author: Stijn De Weirdt (Ghent University)
+@author: Kenneth Hoste (Ghent University)
 """
 
 from vsc.utils import fancylogger
 from vsc.utils.missing import get_subclasses
+
 
 _log = fancylogger.getLogger('easyconfig.licenses', fname=False)
 
@@ -51,14 +53,20 @@ class License(object):
 
     CLASSNAME_PREFIX = 'License'
 
-    def __init__(self):
+    @property
+    def name(self):
+        """Return license name."""
         if self.NAME is None:
             name = self.__class__.__name__
             if name.startswith(self.CLASSNAME_PREFIX):
                 name = name[len(self.CLASSNAME_PREFIX):]
         else:
             name = self.NAME
-        self.name = name
+
+        return name
+
+    def __init__(self):
+        """License constructor."""
         self.version = self.VERSION
         self.description = self.DESCRIPTION
         self.distribute_source = self.DISTRIBUTE_SOURCE
@@ -153,14 +161,12 @@ def what_licenses():
     for lic in get_subclasses(License):
         if lic.HIDDEN:
             continue
-        lic_instance = lic()
-        res[lic_instance.name] = lic_instance
+        res[lic().name] = lic
 
     return res
 
 
 EASYCONFIG_LICENSES_DICT = what_licenses()
-EASYCONFIG_LICENSES = EASYCONFIG_LICENSES_DICT.keys()
 
 
 def license_documentation():

--- a/easybuild/framework/easyconfig/licenses.py
+++ b/easybuild/framework/easyconfig/licenses.py
@@ -74,12 +74,12 @@ class License(object):
         self.group_binary = self.GROUP_BINARY
 
 
-class VeryRestrictive(License):
+class LicenseVeryRestrictive(License):
     """Default license should be very restrictive, so nothing to do here, just a placeholder"""
     pass
 
 
-class LicenseUnknown(VeryRestrictive):
+class LicenseUnknown(LicenseVeryRestrictive):
     """A (temporary) license, could be used as default in case nothing was specified"""
     pass
 
@@ -161,7 +161,7 @@ def what_licenses():
     for lic in get_subclasses(License):
         if lic.HIDDEN:
             continue
-        res[lic().name] = lic
+        res[lic.__name__] = lic
 
     return res
 
@@ -171,12 +171,16 @@ EASYCONFIG_LICENSES_DICT = what_licenses()
 
 def license_documentation():
     """Generate the easyconfig licenses documentation"""
-    indent_l0 = " " * 2
-    indent_l1 = indent_l0 + " " * 2
+    indent_l0 = ' ' * 2
+    indent_l1 = indent_l0 + ' ' * 2
     doc = []
 
     doc.append("Constants that can be used in easyconfigs")
     for lic_name, lic in EASYCONFIG_LICENSES_DICT.items():
-        doc.append('%s%s: %s (version %s)' % (indent_l1, lic_name, lic.description, lic.version))
+        lic_inst = lic()
+        strver = ''
+        if lic_inst.version:
+            strver = " (version: %s)" % '.'.join([str(d) for d in lic_inst.version])
+        doc.append("%s%s: %s%s" % (indent_l1, lic_inst.name, lic_inst.description, strver))
 
-    return "\n".join(doc)
+    return '\n'.join(doc)

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -25,16 +25,16 @@
 """
 Unit tests for docs.py.
 """
-
+import inspect
 import os
 import re
 import sys
-import inspect
+from unittest import TestLoader, main
 
+from easybuild.framework.easyconfig.licenses import license_documentation
 from easybuild.tools.docs import gen_easyblocks_overview_rst
 from easybuild.tools.utilities import import_available_modules
 from test.framework.utilities import EnhancedTestCase, init_config
-from unittest import TestLoader, main
 
 class DocsTest(EnhancedTestCase):
 
@@ -88,6 +88,12 @@ class DocsTest(EnhancedTestCase):
 
         regex = re.compile(pattern)
         self.assertTrue(re.search(regex, ebdoc), "Pattern %s found in %s" % (regex.pattern, ebdoc))
+
+    def test_license_docs(self):
+        """Test license_documentation function."""
+        lic_docs = license_documentation()
+        gplv3 = "GPLv3: The GNU General Public License"
+        self.assertTrue(gplv3 in lic_docs, "%s found in: %s" % (gplv3, lic_docs))
 
 
 def suite():

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -46,6 +46,7 @@ from easybuild.framework.easyconfig.constants import EXTERNAL_MODULE_MARKER
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig
 from easybuild.framework.easyconfig.easyconfig import create_paths
 from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
+from easybuild.framework.easyconfig.licenses import License, LicenseGPLv3
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.templates import to_template_str
 from easybuild.framework.easyconfig.tools import dep_graph, find_related_easyconfigs, parse_easyconfigs
@@ -1490,6 +1491,25 @@ class EasyConfigTest(EnhancedTestCase):
         # no matches for unknown software name
         ec['name'] = 'nosuchsoftware'
         self.assertEqual(find_related_easyconfigs(test_easyconfigs, ec), [])
+
+    def test_software_license(self):
+        """Tests related to software_license easyconfig parameter."""
+        # default: None
+        ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'toy-0.0.eb')
+        ec = EasyConfig(ec_file)
+        ec.validate_license()
+        self.assertEqual(ec['software_license'], None)
+        self.assertEqual(ec.software_license, None)
+
+        # specified software license gets handled correctly
+        ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'gzip-1.4.eb')
+        ec = EasyConfig(ec_file)
+        ec.validate_license()
+        # constant GPLv3 is resolved as string
+        self.assertEqual(ec['software_license'], 'GPLv3')
+        # software_license is defined as License subclass
+        self.assertTrue(isinstance(ec.software_license, LicenseGPLv3))
+        self.assertTrue(issubclass(ec.software_license.__class__, License))
 
 
 def suite():

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -303,7 +303,7 @@ class EasyConfigTest(EnhancedTestCase):
             '       "source_urls": [("http://example.com", "suffix")],'
             '       "patches": ["toy-0.0.eb"],',  # dummy patch to avoid downloading fail
             '       "checksums": [',
-            '           "787393bfc465c85607a5b24486e861c5",',  # MD5 checksum for source (gzip-1.4.eb)
+            '           "a5464d79c2c8d4935e383ebd070b305e",',  # MD5 checksum for source (gzip-1.4.eb)
             '           "44893c3ed46a7c7ab2e72fea7d19925d",',  # MD5 checksum for patch (toy-0.0.eb)
             '       ],',
             '   }),',
@@ -1506,7 +1506,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(ec_file)
         ec.validate_license()
         # constant GPLv3 is resolved as string
-        self.assertEqual(ec['software_license'], 'GPLv3')
+        self.assertEqual(ec['software_license'], 'LicenseGPLv3')
         # software_license is defined as License subclass
         self.assertTrue(isinstance(ec.software_license, LicenseGPLv3))
         self.assertTrue(issubclass(ec.software_license.__class__, License))

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1511,6 +1511,10 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertTrue(isinstance(ec.software_license, LicenseGPLv3))
         self.assertTrue(issubclass(ec.software_license.__class__, License))
 
+        ec['software_license'] = 'LicenseThatDoesNotExist'
+        err_pat = r"Invalid license LicenseThatDoesNotExist \(known licenses:"
+        self.assertErrorRegex(EasyBuildError, err_pat, ec.validate_license)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -873,18 +873,20 @@ class EasyConfigTest(EnhancedTestCase):
             ('gzip-1.4.eb', 'gzip.eb', {'version': '1.4'}),
             ('gzip-1.4.eb', 'gzip.eb', {'version': '1.4', 'toolchain': {'name': 'dummy', 'version': 'dummy'}}),
             ('gzip-1.4-GCC-4.6.3.eb', 'gzip.eb', {'version': '1.4', 'toolchain': {'name': 'GCC', 'version': '4.6.3'}}),
-            ('gzip-1.5-goolf-1.4.10.eb', 'gzip.eb', {'version': '1.5', 'toolchain': {'name': 'goolf', 'version': '1.4.10'}}),
-            ('gzip-1.5-ictce-4.1.13.eb', 'gzip.eb', {'version': '1.5', 'toolchain': {'name': 'ictce', 'version': '4.1.13'}}),
+            ('gzip-1.5-goolf-1.4.10.eb', 'gzip.eb',
+             {'version': '1.5', 'toolchain': {'name': 'goolf', 'version': '1.4.10'}}),
+            ('gzip-1.5-ictce-4.1.13.eb', 'gzip.eb',
+             {'version': '1.5', 'toolchain': {'name': 'ictce', 'version': '4.1.13'}}),
         ]:
             ec1 = EasyConfig(os.path.join(easyconfigs_path, 'v1.0', eb_file1), validate=False)
             ec2 = EasyConfig(os.path.join(easyconfigs_path, 'v2.0', eb_file2), validate=False, build_specs=specs)
 
             ec2_dict = ec2.asdict()
-            # reset mandatory attributes from format2 that are not in format 1
-            for attr in ['docurls', 'software_license', 'software_license_urls']:
+            # reset mandatory attributes from format2 that are not defined in format 1 easyconfigs
+            for attr in ['docurls', 'software_license_urls']:
                 ec2_dict[attr] = None
 
-            self.assertEqual(ec1.asdict(), ec2_dict)
+            self.assertEqual(ec1.asdict(), ec2_dict, "Parsed %s is equivalent with %s" % (eb_file1, eb_file2))
 
         # restore
         easybuild.tools.build_log.EXPERIMENTAL = orig_experimental

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -34,6 +34,7 @@ from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 import easybuild.tools.build_log
 from easybuild.framework.easyconfig.format.format import Dependency
+from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_constants_dict
 from easybuild.framework.easyconfig.format.version import EasyVersion
 from easybuild.framework.easyconfig.parser import EasyConfigParser
 from easybuild.tools.build_log import EasyBuildError
@@ -169,6 +170,22 @@ class EasyConfigParserTest(EnhancedTestCase):
         self.assertEqual(ec['toolchain']['name'], 'goolf')
 
         self.assertErrorRegex(EasyBuildError, "Neither filename nor rawcontent provided", EasyConfigParser)
+
+    def test_easyconfig_constants(self):
+        """Test available easyconfig constants."""
+        constants = build_easyconfig_constants_dict()
+        # make sure both keys and values are only strings
+        for constant_name in constants:
+            self.assertTrue(isinstance(constant_name, basestring), "Constant name %s is a string" % constant_name)
+            val = constants[constant_name]
+            self.assertTrue(isinstance(val, basestring), "Constant value %s is a string" % val)
+
+        # check a couple of randomly picked constant values
+        self.assertEqual(constants['SOURCE_TAR_GZ'], '%(name)s-%(version)s.tar.gz')
+        self.assertEqual(constants['PYPI_SOURCE'], 'https://pypi.python.org/packages/source/%(nameletter)s/%(name)s')
+        self.assertEqual(constants['GPLv2'], 'LicenseGPLv2')
+        self.assertEqual(constants['EXTERNAL_MODULE'], 'EXTERNAL_MODULE')
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfigs/gzip-1.4-GCC-4.6.3.eb
+++ b/test/framework/easyconfigs/gzip-1.4-GCC-4.6.3.eb
@@ -38,3 +38,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/gzip-1.4.eb
+++ b/test/framework/easyconfigs/gzip-1.4.eb
@@ -35,3 +35,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/gzip-1.5-goolf-1.4.10.eb
+++ b/test/framework/easyconfigs/gzip-1.5-goolf-1.4.10.eb
@@ -32,3 +32,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/gzip-1.5-ictce-4.1.13.eb
+++ b/test/framework/easyconfigs/gzip-1.5-ictce-4.1.13.eb
@@ -32,3 +32,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/v1.0/gzip-1.4-GCC-4.6.3.eb
+++ b/test/framework/easyconfigs/v1.0/gzip-1.4-GCC-4.6.3.eb
@@ -35,3 +35,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/v1.0/gzip-1.4.eb
+++ b/test/framework/easyconfigs/v1.0/gzip-1.4.eb
@@ -35,3 +35,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/v1.0/gzip-1.5-goolf-1.4.10.eb
+++ b/test/framework/easyconfigs/v1.0/gzip-1.5-goolf-1.4.10.eb
@@ -32,3 +32,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/v1.0/gzip-1.5-ictce-4.1.13.eb
+++ b/test/framework/easyconfigs/v1.0/gzip-1.5-ictce-4.1.13.eb
@@ -32,3 +32,6 @@ sanity_check_paths = {
 # run 'gzip -h' and 'gzip --version' after installation
 sanity_check_commands = [True, ('gzip', '--version')]
 
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/easyconfigs/v2.0/gzip.eb
+++ b/test/framework/easyconfigs/v2.0/gzip.eb
@@ -42,4 +42,4 @@ toolchains = dummy == dummy, goolf, GCC == 4.6.3, goolf == 1.4.10, ictce == 4.1.
 
 [DEFAULT]
 easyblock = ConfigureMake
-moduleclass = base
+moduleclass = tools

--- a/test/framework/license.py
+++ b/test/framework/license.py
@@ -60,6 +60,7 @@ class LicenseTest(EnhancedTestCase):
         lics = what_licenses()
         for lic in lics:
             self.assertTrue(isinstance(lic, basestring))
+            self.assertTrue(lic.startswith('License'))
             self.assertTrue(issubclass(lics[lic], License))
 
 

--- a/test/framework/license.py
+++ b/test/framework/license.py
@@ -55,6 +55,13 @@ class LicenseTest(EnhancedTestCase):
         self.assertTrue(VeryRestrictive.GROUP_SOURCE)
         self.assertTrue(VeryRestrictive.GROUP_BINARY)
 
+    def test_licenses(self):
+        """Test format of available licenses."""
+        lics = what_licenses()
+        for lic in lics:
+            self.assertTrue(isinstance(lic, basestring))
+            self.assertTrue(issubclass(lics[lic], License))
+
 def suite():
     """ returns all the testcases in this module """
     return TestLoader().loadTestsFromTestCase(LicenseTest)

--- a/test/framework/license.py
+++ b/test/framework/license.py
@@ -30,7 +30,7 @@ Unit tests for easyconfig/licenses.py
 from test.framework.utilities import EnhancedTestCase
 from unittest import TestLoader, main
 
-from easybuild.framework.easyconfig.licenses import License, VeryRestrictive, what_licenses
+from easybuild.framework.easyconfig.licenses import License, LicenseVeryRestrictive, what_licenses
 
 
 class LicenseTest(EnhancedTestCase):
@@ -39,9 +39,9 @@ class LicenseTest(EnhancedTestCase):
     def test_common_ones(self):
         """Check if a number of common licenses can be found"""
         lics = what_licenses()
-        commonlicenses = ['VeryRestrictive', 'GPLv2', 'GPLv3']
+        commonlicenses = ['LicenseVeryRestrictive', 'LicenseGPLv2', 'LicenseGPLv3']
         for lic in commonlicenses:
-            self.assertTrue(lic in lics)
+            self.assertTrue(lic in lics, "%s found in %s" % (lic, lics.keys()))
 
     def test_default_license(self):
         """Verify that the default License class is very restrictive"""
@@ -51,9 +51,9 @@ class LicenseTest(EnhancedTestCase):
 
     def test_veryrestrictive_license(self):
         """Verify that the very restrictive class is very restrictive"""
-        self.assertFalse(VeryRestrictive.DISTRIBUTE_SOURCE)
-        self.assertTrue(VeryRestrictive.GROUP_SOURCE)
-        self.assertTrue(VeryRestrictive.GROUP_BINARY)
+        self.assertFalse(LicenseVeryRestrictive.DISTRIBUTE_SOURCE)
+        self.assertTrue(LicenseVeryRestrictive.GROUP_SOURCE)
+        self.assertTrue(LicenseVeryRestrictive.GROUP_BINARY)
 
     def test_licenses(self):
         """Test format of available licenses."""
@@ -61,6 +61,7 @@ class LicenseTest(EnhancedTestCase):
         for lic in lics:
             self.assertTrue(isinstance(lic, basestring))
             self.assertTrue(issubclass(lics[lic], License))
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -370,9 +370,9 @@ class ModuleGeneratorTest(EnhancedTestCase):
         ec2mod_map = {
             'GCC-4.6.3.eb': 'GCC/9e9ab5a1e978f0843b5aedb63ac4f14c51efb859',
             'gzip-1.4.eb': 'gzip/53d5c13e85cb6945bd43a58d1c8d4a4c02f3462d',
-            'gzip-1.4-GCC-4.6.3.eb': 'gzip/863557cc81811f8c3f4426a4b45aa269fa54130b',
-            'gzip-1.5-goolf-1.4.10.eb': 'gzip/b63c2b8cc518905473ccda023100b2d3cff52d55',
-            'gzip-1.5-ictce-4.1.13.eb': 'gzip/3d49f0e112708a95f79ed38b91b506366c0299ab',
+            'gzip-1.4-GCC-4.6.3.eb': 'gzip/585eba598f33c64ef01c6fa47af0fc37f3751311',
+            'gzip-1.5-goolf-1.4.10.eb': 'gzip/fceb41e04c26b540b7276c4246d1ecdd1e8251c9',
+            'gzip-1.5-ictce-4.1.13.eb': 'gzip/ae16b3a0a330d4323987b360c0d024f244ac4498',
             'toy-0.0.eb': 'toy/44a206d9e8c14130cc9f79e061468303c6e91b53',
             'toy-0.0-multiple.eb': 'toy/44a206d9e8c14130cc9f79e061468303c6e91b53',
         }
@@ -380,7 +380,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
         # test determining module name for dependencies (i.e. non-parsed easyconfigs)
         # using a module naming scheme that requires all easyconfig parameters
-        ec2mod_map['gzip-1.5-goolf-1.4.10.eb'] = 'gzip/.b63c2b8cc518905473ccda023100b2d3cff52d55'
+        ec2mod_map['gzip-1.5-goolf-1.4.10.eb'] = 'gzip/.fceb41e04c26b540b7276c4246d1ecdd1e8251c9'
         for dep_ec, dep_spec in [
             ('GCC-4.6.3.eb', {
                 'name': 'GCC',
@@ -517,7 +517,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
                              ['Compiler/GCC/4.7.2/%s' % c for c in moduleclasses]),
             'OpenMPI-1.6.4-GCC-4.7.2.eb': ('OpenMPI/1.6.4', 'Compiler/GCC/4.7.2/mpi',
                              ['MPI/GCC/4.7.2/OpenMPI/1.6.4/%s' % c for c in moduleclasses]),
-            'gzip-1.5-goolf-1.4.10.eb': ('gzip/1.5', 'MPI/GCC/4.7.2/OpenMPI/1.6.4/base',
+            'gzip-1.5-goolf-1.4.10.eb': ('gzip/1.5', 'MPI/GCC/4.7.2/OpenMPI/1.6.4/tools',
                              []),
             'goolf-1.4.10.eb': ('goolf/1.4.10', 'Core/toolchain',
                              []),

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -369,7 +369,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         # note: these checksums will change if another easyconfig parameter is added
         ec2mod_map = {
             'GCC-4.6.3.eb': 'GCC/9e9ab5a1e978f0843b5aedb63ac4f14c51efb859',
-            'gzip-1.4.eb': 'gzip/8805ec3152d2a4a08b6c06d740c23abe1a4d059f',
+            'gzip-1.4.eb': 'gzip/53d5c13e85cb6945bd43a58d1c8d4a4c02f3462d',
             'gzip-1.4-GCC-4.6.3.eb': 'gzip/863557cc81811f8c3f4426a4b45aa269fa54130b',
             'gzip-1.5-goolf-1.4.10.eb': 'gzip/b63c2b8cc518905473ccda023100b2d3cff52d55',
             'gzip-1.5-ictce-4.1.13.eb': 'gzip/3d49f0e112708a95f79ed38b91b506366c0299ab',

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -802,7 +802,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ("ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/numlib",
              "ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2", 'x'),
             ("goolf-1.4.10.eb", "Core/toolchain", "goolf/1.4.10", 'x'),
-            ("gzip-1.5-goolf-1.4.10.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/base", "gzip/1.5", ' '),  # listed but not there: ' '
+            ("gzip-1.5-goolf-1.4.10.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/tools", "gzip/1.5", ' '),  # listed but not there: ' '
         ]
         for ec, mod_subdir, mod_name, mark in ecs_mods:
             regex = re.compile("^ \* \[%s\] \S+%s \(module: %s \| %s\)$" % (mark, ec, mod_subdir, mod_name), re.M)


### PR DESCRIPTION
@Caylo ran into this when working on support for easyconfigs files in YAML syntax (.yeb), see #1408, where constants have to be injected into the easyconfig file being parsed; injecting `License` instances into YAML doesn't work