### PR TITLE
allow get_cpu_speed to return None if CPU freq could not be determined

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -229,7 +229,7 @@ def get_cpu_speed():
                 cpu_freq = float(res.group('cpu_freq'))
                 _log.debug("Found CPU frequency using regex '%s': %s" % (cpu_freq_regex.pattern, cpu_freq))
             else:
-                raise SystemToolsException("Failed to determine CPU frequency from %s" % PROC_CPUINFO_FP)
+                _log.debug("Failed to determine CPU frequency from %s", PROC_CPUINFO_FP)
         else:
             _log.debug("%s not found to determine max. CPU clock frequency without CPU scaling: %s" % PROC_CPUINFO_FP)
 

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -240,8 +240,8 @@ class SystemToolsTest(EnhancedTestCase):
     def test_cpu_speed_native(self):
         """Test getting CPU speed."""
         cpu_speed = get_cpu_speed()
-        self.assertTrue(isinstance(cpu_speed, float))
-        self.assertTrue(cpu_speed > 0.0)
+        self.assertTrue(isinstance(cpu_speed, float) or cpu_speed is None)
+        self.assertTrue(cpu_speed > 0.0 or cpu_speed is None)
 
     def test_cpu_speed_linux(self):
         """Test getting CPU speed (mocked for Linux)."""


### PR DESCRIPTION
fix for #1419