### PR TITLE
relax sanity_check_paths in EasyBuild bootstrap script to deal with possible zipped .egg

### DIFF
--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -540,7 +540,7 @@ preinstallopts = '%(preinstallopts)s'
 pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 sanity_check_paths = {
     'files': ['bin/eb'],
-    'dirs': ['lib/python%s/site-packages' % pyshortver],
+    'dirs': ['lib/python%%s/site-packages' %% pyshortver],
 }
 
 moduleclass = 'tools'

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -536,6 +536,14 @@ sources = [%(sources)s]
 allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
 
 preinstallopts = '%(preinstallopts)s'
+
+pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
+sanity_check_paths = {
+    'files': ['bin/eb'],
+    'dirs': ['lib/python%s/site-packages' % pyshortver],
+}
+
+moduleclass = 'tools'
 """
 
 # distribute_setup.py script (https://pypi.python.org/pypi/distribute)


### PR DESCRIPTION
If the vsc-base dependency gets installed as a zipped `.egg`, the sanity check will fail because the EasyBuild easyblock checks for files *in* the vsc-base .egg directory.

This is a hotfix, the problem has to be resolved in the EasyBuildMeta easyblock (see https://github.com/hpcugent/easybuild-easyblocks/issues/710), but this change is required right now to ensure the bootstrap keeps working until the next EasyBuild release is out that includes the fixes EasyBuildMeta easyblock.