### PR TITLE
implement basic support for type checking of easyconfig parameters

### DIFF
--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -100,8 +100,6 @@ class EasyConfigParser(object):
         else:
             raise EasyBuildError("Neither filename nor rawcontent provided to EasyConfigParser")
 
-        self.check_values_types()
-
         self._formatter.extract_comments(self.rawcontent)
 
     def process(self, filename=None):
@@ -109,12 +107,11 @@ class EasyConfigParser(object):
         self._read(filename=filename)
         self._set_formatter()
 
-    def check_values_types(self):
+    def check_values_types(self, cfg):
         """Check types of easyconfig parameter values."""
-        params = self.get_config_dict()
         wrong_type_msgs = []
-        for key in params:
-            if not check_type_of_param_value(key, params[key]):
+        for key in cfg:
+            if not check_type_of_param_value(key, cfg[key]):
                 wrong_type_msgs.append("value for '%s' should be of type '%s'" % (key, TYPES[key].__name__))
 
         if wrong_type_msgs:
@@ -201,7 +198,11 @@ class EasyConfigParser(object):
         # allows to bypass the validation step, typically for testing
         if validate:
             self._formatter.validate()
-        return self._formatter.get_config_dict()
+
+        cfg = self._formatter.get_config_dict()
+        self.check_values_types(cfg)
+
+        return cfg
 
     def dump(self, ecfg, default_values, templ_const, templ_val):
         """Dump easyconfig in format it was parsed from."""

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -35,6 +35,7 @@ from vsc.utils import fancylogger
 
 from easybuild.framework.easyconfig.format.format import FORMAT_DEFAULT_VERSION
 from easybuild.framework.easyconfig.format.format import get_format_version, get_format_version_classes
+from easybuild.framework.easyconfig.types import TYPES, check_type_of_param_value
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, write_file
 
@@ -99,12 +100,27 @@ class EasyConfigParser(object):
         else:
             raise EasyBuildError("Neither filename nor rawcontent provided to EasyConfigParser")
 
+        self.check_types()
+
         self._formatter.extract_comments(self.rawcontent)
 
     def process(self, filename=None):
         """Create an instance"""
         self._read(filename=filename)
         self._set_formatter()
+
+    def check_types(self):
+        """Check types of easyconfig parameter values."""
+        params = self.get_config_dict()
+        wrong_type_msgs = []
+        for key in params:
+            if not check_type_of_param_value(key, params[key]):
+                wrong_type_msgs.append("value for '%s' should be of type '%s'" % (key, TYPES[key].__name__))
+
+        if wrong_type_msgs:
+            raise EasyBuildError("Type checking of easyconfig parameter values failed: %s", ' '.join(wrong_type_msgs))
+        else:
+            self.log.info("Type checking of easyconfig parameter values passed!")
 
     def _check_filename(self, fn):
         """Perform sanity check on the filename, and set mechanism to set the content of the file"""

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -108,7 +108,11 @@ class EasyConfigParser(object):
         self._set_formatter()
 
     def check_values_types(self, cfg):
-        """Check types of easyconfig parameter values."""
+        """
+        Check types of easyconfig parameter values.
+
+        @param cfg: dictionary with easyconfig parameter values (result of get_config_dict())
+        """
         wrong_type_msgs = []
         for key in cfg:
             if not check_type_of_param_value(key, cfg[key]):

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -100,7 +100,7 @@ class EasyConfigParser(object):
         else:
             raise EasyBuildError("Neither filename nor rawcontent provided to EasyConfigParser")
 
-        self.check_types()
+        self.check_values_types()
 
         self._formatter.extract_comments(self.rawcontent)
 
@@ -109,7 +109,7 @@ class EasyConfigParser(object):
         self._read(filename=filename)
         self._set_formatter()
 
-    def check_types(self):
+    def check_values_types(self):
         """Check types of easyconfig parameter values."""
         params = self.get_config_dict()
         wrong_type_msgs = []

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -115,7 +115,7 @@ class EasyConfigParser(object):
                 wrong_type_msgs.append("value for '%s' should be of type '%s'" % (key, TYPES[key].__name__))
 
         if wrong_type_msgs:
-            raise EasyBuildError("Type checking of easyconfig parameter values failed: %s", ' '.join(wrong_type_msgs))
+            raise EasyBuildError("Type checking of easyconfig parameter values failed: %s", ', '.join(wrong_type_msgs))
         else:
             self.log.info("Type checking of easyconfig parameter values passed!")
 

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -43,7 +43,12 @@ _log = fancylogger.getLogger('easyconfig.types', fname=False)
 
 
 def check_type_of_param_value(key, value):
-    """Check value type of specified easyconfig parameter."""
+    """
+    Check value type of specified easyconfig parameter.
+
+    @param key: name of easyconfig parameter
+    @param value: easyconfig parameter value, of which type should be checked
+    """
     type_ok = True
 
     if key in TYPES:

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -30,6 +30,7 @@ Support for checking types of easyconfig parameter values.
 """
 from vsc.utils import fancylogger
 
+# easy types, that can be verified with isinstance
 EASY_TYPES = [basestring, int]
 # type checking is skipped for easyconfig parameters names not listed in TYPES
 TYPES = {
@@ -44,6 +45,7 @@ _log = fancylogger.getLogger('easyconfig.types', fname=False)
 def check_type_of_param_value(key, value):
     """Check value type of specified easyconfig parameter."""
     type_ok = True
+
     if key in TYPES:
         expected_type = TYPES[key]
         if expected_type in EASY_TYPES:
@@ -54,7 +56,6 @@ def check_type_of_param_value(key, value):
                 type_ok = False
                 _log.warning("Value type checking of easyconfig parameter '%s' FAILED: expected '%s', got '%s'",
                              key, expected_type.__name__, type(value).__name__)
-
     else:
         _log.debug("No type specified for easyconfig parameter '%s', so skipping type check.", key)
 

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -1,0 +1,61 @@
+# #
+# Copyright 2015-2015 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+
+"""
+Support for checking types of easyconfig parameter values.
+
+@author: Kenneth Hoste (Ghent University)
+"""
+from vsc.utils import fancylogger
+
+EASY_TYPES = [basestring, int]
+# type checking is skipped for easyconfig parameters names not listed in TYPES
+TYPES = {
+    'name': basestring,
+    'version': basestring,
+}
+
+
+_log = fancylogger.getLogger('easyconfig.types', fname=False)
+
+
+def check_type_of_param_value(key, value):
+    """Check value type of specified easyconfig parameter."""
+    type_ok = True
+    if key in TYPES:
+        expected_type = TYPES[key]
+        if expected_type in EASY_TYPES:
+            if isinstance(value, expected_type):
+                _log.debug("Value type checking of easyconfig parameter '%s' passed: expected '%s', got '%s'",
+                           key, expected_type.__name__, type(value).__name__)
+            else:
+                type_ok = False
+                _log.warning("Value type checking of easyconfig parameter '%s' FAILED: expected '%s', got '%s'",
+                             key, expected_type.__name__, type(value).__name__)
+
+    else:
+        _log.debug("No type specified for easyconfig parameter '%s', so skipping type check.", key)
+
+    return type_ok

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1528,6 +1528,13 @@ class EasyConfigTest(EnhancedTestCase):
         err_pat = r"Invalid license LicenseThatDoesNotExist \(known licenses:"
         self.assertErrorRegex(EasyBuildError, err_pat, ec.validate_license)
 
+    def test_param_value_type_checking(self):
+        """Test value tupe checking of easyconfig parameters."""
+        ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'gzip-1.4-broken.eb')
+        # name/version parameters have values of wrong type in this broken easyconfig
+        error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
+        self.assertErrorRegex(EasyBuildError, error_msg_pattern, EasyConfig, ec_file)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -186,6 +186,13 @@ class EasyConfigParserTest(EnhancedTestCase):
         self.assertEqual(constants['GPLv2'], 'LicenseGPLv2')
         self.assertEqual(constants['EXTERNAL_MODULE'], 'EXTERNAL_MODULE')
 
+    def test_check_value_types(self):
+        """Test checking of easyconfig parameter value types."""
+        test_ec = os.path.join(TESTDIRBASE, 'gzip-1.4-broken.eb')
+        error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
+        ecp = EasyConfigParser(test_ec)
+        self.assertErrorRegex(EasyBuildError, error_msg_pattern, ecp.get_config_dict)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfigs/gzip-1.4-broken.eb
+++ b/test/framework/easyconfigs/gzip-1.4-broken.eb
@@ -1,0 +1,41 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
+# Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_06-19.html
+##
+easyblock = 'ConfigureMake'
+
+# wrong type of values, on purpose
+name = ['gzip']  # 'gzip'
+version = 1.4  # '1.4'
+
+homepage = "http://www.gzip.org/"
+description = "gzip (GNU zip) is a popular data compression program as a replacement for compress"
+
+# test toolchain specification
+toolchain = {'name':'dummy','version':'dummy'}
+
+# source tarball filename
+sources = [SOURCE_TAR_GZ]
+
+# download location for source files
+source_urls = ['http://ftpmirror.gnu.org/gzip']
+
+# make sure the gzip and gunzip binaries are available after installation
+sanity_check_paths = {
+    'files': ["bin/gunzip", "bin/gzip"],
+    'dirs': [],
+}
+
+# run 'gzip -h' and 'gzip --version' after installation
+sanity_check_commands = [True, ('gzip', '--version')]
+
+software_license = GPLv3
+
+moduleclass = 'tools'

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -291,7 +291,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         def test_mns():
             """Test default module naming scheme."""
             # test default naming scheme
-            for ec_file in ec_files:
+            for ec_file in [f for f in ec_files if not 'broken' in os.path.basename(f)]:
                 ec_path = os.path.abspath(ec_file)
                 ecs = process_easyconfig(ec_path, validate=False)
                 # derive module name directly from easyconfig file name

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -75,7 +75,7 @@ class ScriptsTest(EnhancedTestCase):
         for root, subfolders, files in os.walk(easyconfigs_dir):
             if 'v2.0' in subfolders:
                 subfolders.remove('v2.0')
-            for ec_file in files:
+            for ec_file in [f for f in files if 'broken' not in os.path.basename(f)]:
                 shutil.copy2(os.path.join(root, ec_file), tmpdir)
 
         cmd = "%s %s --local --quiet --path %s" % (sys.executable, script, tmpdir)

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -83,6 +83,7 @@ import test.framework.systemtools as s
 import test.framework.toolchain as tc
 import test.framework.toolchainvariables as tcv
 import test.framework.toy_build as t
+import test.framework.type_checking as et
 import test.framework.tweak as tw
 import test.framework.variables as v
 
@@ -104,7 +105,7 @@ log = fancylogger.getLogger()
 # call suite() for each module and then run them all
 # note: make sure the options unit tests run first, to avoid running some of them with a readily initialized config
 tests = [gen, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, l, f_c, sc, tw,
-         p, i, pkg, d]
+         p, i, pkg, d, et]
 
 SUITE = unittest.TestSuite([x.suite() for x in tests])
 

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -1,0 +1,61 @@
+# #
+# Copyright 2015-2015 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Unit tests for easyconfig/types.py
+
+@author: Kenneth Hoste (Ghent University)
+"""
+from test.framework.utilities import EnhancedTestCase
+from unittest import TestLoader, main
+
+from easybuild.framework.easyconfig.types import check_type_of_param_value
+
+
+class TypeCheckingTest(EnhancedTestCase):
+    """Tests for value type checking of easyconfig parameters."""
+
+    def test_check_type_of_param_value(self):
+        """Test check_type_of_param_value function."""
+        # check selected values that should be strings
+        for key in ['name', 'version']:
+            self.assertTrue(check_type_of_param_value(key, 'foo'))
+            for not_a_string in [100, 1.5, ('bar',), ['baz'], None]:
+                self.assertFalse(check_type_of_param_value(key, not_a_string))
+            # value doesn't matter, only type does
+            self.assertTrue(check_type_of_param_value(key, ''))
+
+        # parameters with no type specification always pass the check
+        key = 'nosucheasyconfigparametereverhopefully'
+        for val in ['foo', 100, 1.5, ('bar',), ['baz'], '', None]:
+            self.assertTrue(check_type_of_param_value(key, val))
+
+
+def suite():
+    """ returns all the testcases in this module """
+    return TestLoader().loadTestsFromTestCase(TypeCheckingTest)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Without type checking, you can run into nasty errors, for example the one below when using a non-string value for the `version` easyconfig parameter:

```
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 361, in <module>
    main()
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 276, in main
    easyconfigs, generated_ecs = parse_easyconfigs(paths)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/tools.py", line 345, in parse_easyconfigs
    ecs = process_easyconfig(ec_file, **kwargs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 943, in process_easyconfig
    ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 188, in __init__
    self.parse()
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 296, in parse
    self.generate_template_values()
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 661, in generate_template_values
    self._generate_template_values(skip_lower=True)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 675, in _generate_template_values
    ignore=ignore, skip_lower=skip_lower)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/templates.py", line 161, in template_constant_dict
    version = LooseVersion(version).version
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/version.py", line 265, in __init__
    self.parse(vstring)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/version.py", line 274, in parse
    self.component_re.split(vstring))
TypeError: expected string or buffer
```

With these changes in place, you'll get this instead:

```
EasyBuildError: "Failed to process easyconfig example.eb: Type checking of easyconfig parameter values failed: value for 'version' should be of type 'basestring'"
```

This implementation is intended as a starting point, since only the values for `name`/`version` will be type-checked for now.
Complex values like `sanity_check_paths` will need additional logic/functionality, and support for automatically trying to convert values is probably worthwhile too. For example, with easyconfig files in YAML syntax (see #1407), a value for `version` like `1.6` would be parsed as `float` by default, although it should be a string value...