### PR TITLE
[.yeb] no (more) need for quotes in version definition in gzip.yeb (WIP)

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -109,7 +109,8 @@ class EasyConfig(object):
     Class which handles loading, reading, validation of easyconfigs
     """
 
-    def __init__(self, path, extra_options=None, build_specs=None, validate=True, hidden=None, rawtxt=None):
+    def __init__(self, path, extra_options=None, build_specs=None, validate=True, hidden=None, rawtxt=None,
+                 auto_convert_value_types=True):
         """
         initialize an easyconfig.
         @param path: path to easyconfig file to be parsed (ignored if rawtxt is specified)
@@ -118,6 +119,8 @@ class EasyConfig(object):
         @param validate: indicates whether validation should be performed (note: combined with 'validate' build option)
         @param hidden: indicate whether corresponding module file should be installed hidden ('.'-prefixed)
         @param rawtxt: raw contents of easyconfig file
+        @param auto_convert_value_types: indicates wether types of easyconfig values should be automatically converted
+                                         in case they are wrong
         """
         self.template_values = None
         self.enable_templating = True  # a boolean to control templating
@@ -184,7 +187,8 @@ class EasyConfig(object):
 
         # parse easyconfig file
         self.build_specs = build_specs
-        self.parser = EasyConfigParser(filename=self.path, rawcontent=self.rawtxt)
+        self.parser = EasyConfigParser(filename=self.path, rawcontent=self.rawtxt,
+                                       auto_convert_value_types=auto_convert_value_types)
         self.parse()
 
         # handle allowed system dependencies

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -114,9 +114,11 @@ class EasyConfigParser(object):
         """
         wrong_type_msgs = []
         for key in cfg:
-            type_ok, _ = check_type_of_param_value(key, cfg[key])
+            type_ok, newval = check_type_of_param_value(key, cfg[key], auto_convert=True)
             if not type_ok:
                 wrong_type_msgs.append("value for '%s' should be of type '%s'" % (key, TYPES[key].__name__))
+            else:
+                cfg[key] = newval
 
         if wrong_type_msgs:
             raise EasyBuildError("Type checking of easyconfig parameter values failed: %s", ', '.join(wrong_type_msgs))

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1533,7 +1533,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'gzip-1.4-broken.eb')
         # name/version parameters have values of wrong type in this broken easyconfig
         error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
-        self.assertErrorRegex(EasyBuildError, error_msg_pattern, EasyConfig, ec_file)
+        self.assertErrorRegex(EasyBuildError, error_msg_pattern, EasyConfig, ec_file, auto_convert_value_types=False)
 
 
 def suite():

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -190,7 +190,7 @@ class EasyConfigParserTest(EnhancedTestCase):
         """Test checking of easyconfig parameter value types."""
         test_ec = os.path.join(TESTDIRBASE, 'gzip-1.4-broken.eb')
         error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
-        ecp = EasyConfigParser(test_ec)
+        ecp = EasyConfigParser(test_ec, auto_convert_value_types=False)
         self.assertErrorRegex(EasyBuildError, error_msg_pattern, ecp.get_config_dict)
 
 

--- a/test/framework/easyconfigs/yeb/gzip.yeb
+++ b/test/framework/easyconfigs/yeb/gzip.yeb
@@ -3,7 +3,7 @@
 easyblock: ConfigureMake
 
 name: gzip
-version: '1.6'
+version: 1.6
 
 homepage: 'http://www.gnu.org/software/gzip/'
 description:


### PR DESCRIPTION
We have support now to automatically convert wrongly parsed values, so use it to fix the `version` issue in `gzip.yeb`.