### PR TITLE
fix checking of sanity check paths w.r.t. discriminating between files and directories

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1563,7 +1563,7 @@ class EasyBlock(object):
         """
         # supported/required keys in for sanity check paths, along with function used to check the paths
         path_keys_and_check = {
-            'files': lambda fp: os.path.exists(fp),  # files must exist
+            'files': lambda fp: os.path.exists(fp) and not os.path.isdir(fp),  # files must exist and not be a directory
             'dirs': lambda dp: os.path.isdir(dp) and os.listdir(dp),  # directories must exist and be non-empty
         }
         # prepare sanity check paths

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1600,7 +1600,7 @@ class EasyBlock(object):
                 found = False
                 for name in xs:
                     path = os.path.join(self.installdir, name)
-                    if os.path.exists(path):
+                    if check_fn(path):
                         self.log.debug("Sanity check: found %s %s in %s" % (key[:-1], name, self.installdir))
                         found = True
                         break


### PR DESCRIPTION
This fixes the way in which sanity check paths are checked.

The `check_fn` variable contains the function that should be used for checking files/directories specifically.

In particular, this fixes:

* making sure that directories are *non-empty*
* making sure that directories are really directories, not files
* making sure that files are really files, not directories