### PR TITLE
enable auto-converting type of easyconfig parameter values

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -109,7 +109,8 @@ class EasyConfig(object):
     Class which handles loading, reading, validation of easyconfigs
     """
 
-    def __init__(self, path, extra_options=None, build_specs=None, validate=True, hidden=None, rawtxt=None):
+    def __init__(self, path, extra_options=None, build_specs=None, validate=True, hidden=None, rawtxt=None,
+                 auto_convert_value_types=True):
         """
         initialize an easyconfig.
         @param path: path to easyconfig file to be parsed (ignored if rawtxt is specified)
@@ -118,6 +119,8 @@ class EasyConfig(object):
         @param validate: indicates whether validation should be performed (note: combined with 'validate' build option)
         @param hidden: indicate whether corresponding module file should be installed hidden ('.'-prefixed)
         @param rawtxt: raw contents of easyconfig file
+        @param auto_convert_value_types: indicates wether types of easyconfig values should be automatically converted
+                                         in case they are wrong
         """
         self.template_values = None
         self.enable_templating = True  # a boolean to control templating
@@ -184,7 +187,8 @@ class EasyConfig(object):
 
         # parse easyconfig file
         self.build_specs = build_specs
-        self.parser = EasyConfigParser(filename=self.path, rawcontent=self.rawtxt)
+        self.parser = EasyConfigParser(filename=self.path, rawcontent=self.rawtxt,
+                                       auto_convert_value_types=auto_convert_value_types)
         self.parse()
 
         # handle allowed system dependencies

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -79,18 +79,27 @@ class EasyConfigParser(object):
         Can contain references to multiple version and toolchain/toolchain versions
     """
 
-    def __init__(self, filename=None, format_version=None, rawcontent=None):
-        """Initialise the EasyConfigParser class"""
+    def __init__(self, filename=None, format_version=None, rawcontent=None,
+                 auto_convert_value_types=True):
+        """
+        Initialise the EasyConfigParser class
+        @param filename: path to easyconfig file to parse (superseded by rawcontent, if specified)
+        @param format_version: version of easyconfig file format, used to determine how to parse supplied easyconfig
+        @param rawcontent: raw content of easyconfig file to parse (preferred over easyconfig file supplied via filename)
+        @param auto_convert_value_types: indicates whether types of easyconfig values should be automatically converted
+                                         in case they are wrong
+        """
         self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
 
         self.rawcontent = None  # the actual unparsed content
+
+        self.auto_convert = auto_convert_value_types
 
         self.get_fn = None  # read method and args
         self.set_fn = None  # write method and args
 
         self.format_version = format_version
         self._formatter = None
-
         if rawcontent is not None:
             self.rawcontent = rawcontent
             self._set_formatter()
@@ -115,9 +124,13 @@ class EasyConfigParser(object):
         """
         wrong_type_msgs = []
         for key in cfg:
-            type_ok, _ = check_type_of_param_value(key, cfg[key])
+            type_ok, newval = check_type_of_param_value(key, cfg[key], self.auto_convert)
             if not type_ok:
                 wrong_type_msgs.append("value for '%s' should be of type '%s'" % (key, TYPES[key].__name__))
+            elif newval != cfg[key]:
+                self.log.warning("Value for '%s' easyconfig parameter was converted from %s (type: %s) to %s (type: %s)",
+                                 key, cfg[key], type(cfg[key]), newval, type(newval))
+                cfg[key] = newval
 
         if wrong_type_msgs:
             raise EasyBuildError("Type checking of easyconfig parameter values failed: %s", ', '.join(wrong_type_msgs))

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1532,8 +1532,12 @@ class EasyConfigTest(EnhancedTestCase):
         """Test value tupe checking of easyconfig parameters."""
         ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'gzip-1.4-broken.eb')
         # name/version parameters have values of wrong type in this broken easyconfig
-        error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
+        error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'version'.*"
         self.assertErrorRegex(EasyBuildError, error_msg_pattern, EasyConfig, ec_file, auto_convert_value_types=False)
+
+        # test default behaviour: auto-converting of mismatching value types
+        ec = EasyConfig(ec_file)
+        self.assertEqual(ec['version'], '1.4')
 
 
 def suite():

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1533,7 +1533,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'gzip-1.4-broken.eb')
         # name/version parameters have values of wrong type in this broken easyconfig
         error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
-        self.assertErrorRegex(EasyBuildError, error_msg_pattern, EasyConfig, ec_file)
+        self.assertErrorRegex(EasyBuildError, error_msg_pattern, EasyConfig, ec_file, auto_convert_value_types=False)
 
 
 def suite():

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -190,7 +190,7 @@ class EasyConfigParserTest(EnhancedTestCase):
         """Test checking of easyconfig parameter value types."""
         test_ec = os.path.join(TESTDIRBASE, 'gzip-1.4-broken.eb')
         error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
-        ecp = EasyConfigParser(test_ec)
+        ecp = EasyConfigParser(test_ec, auto_convert_value_types=False)
         self.assertErrorRegex(EasyBuildError, error_msg_pattern, ecp.get_config_dict)
 
 

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -189,9 +189,14 @@ class EasyConfigParserTest(EnhancedTestCase):
     def test_check_value_types(self):
         """Test checking of easyconfig parameter value types."""
         test_ec = os.path.join(TESTDIRBASE, 'gzip-1.4-broken.eb')
-        error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'name'.*'version'.*"
+        error_msg_pattern = "Type checking of easyconfig parameter values failed: .*'version'.*"
         ecp = EasyConfigParser(test_ec, auto_convert_value_types=False)
         self.assertErrorRegex(EasyBuildError, error_msg_pattern, ecp.get_config_dict)
+
+        # test default behaviour: auto-converting of mismatched value types
+        ecp = EasyConfigParser(test_ec)
+        ecdict = ecp.get_config_dict()
+        self.assertEqual(ecdict['version'], '1.4')
 
 
 def suite():

--- a/test/framework/easyconfigs/gzip-1.4-broken.eb
+++ b/test/framework/easyconfigs/gzip-1.4-broken.eb
@@ -11,8 +11,8 @@
 ##
 easyblock = 'ConfigureMake'
 
-# wrong type of values, on purpose
-name = ['gzip']  # 'gzip'
+name = 'gzip'
+# wrong type of value (on purpose, for testing), should be a string
 version = 1.4  # '1.4'
 
 homepage = "http://www.gzip.org/"


### PR DESCRIPTION
fleshed out the relevant bits from #1430 

This shouldn't make a difference with `.eb` files, especially since only the type of `name` and `version` is being checked and converted if needed.