### PR TITLE
Skip symlinked files when fixing permissions

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -701,15 +701,16 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
             paths = []
             if not onlydirs:
                 if not skip_symlinks:
-                    paths += files
+                    paths.extend(files)
                 else:
                     for path in files:
-                        fname = os.path.join(root, path)
-                        if not os.path.islink(fname):
+                        if not os.path.islink(os.path.join(root, path)):
                             paths.append(path)
+                        else:
+                            _log.debug("Not adjusting permissions for symlink %s", path)
             if not onlyfiles:
                 # os.walk skips symlinked dirs by default, i.e., no special handling needed here
-                paths += dirs
+                paths.extend(dirs)
 
             for path in paths:
                 allpaths.append(os.path.join(root, path))

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -700,14 +700,14 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
         for root, dirs, files in os.walk(name):
             paths = []
             if not onlydirs:
-                if not skip_symlinks:
-                    paths.extend(files)
-                else:
+                if skip_symlinks:
                     for path in files:
-                        if not os.path.islink(os.path.join(root, path)):
-                            paths.append(path)
-                        else:
+                        if os.path.islink(os.path.join(root, path)):
                             _log.debug("Not adjusting permissions for symlink %s", path)
+                        else:
+                            paths.append(path)
+                else:
+                    paths.extend(files)
             if not onlyfiles:
                 # os.walk skips symlinked dirs by default, i.e., no special handling needed here
                 paths.extend(dirs)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -686,7 +686,7 @@ def convert_name(name, upper=False):
 
 
 def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs=False, recursive=True,
-                       group_id=None, relative=True, ignore_errors=False):
+                       group_id=None, relative=True, ignore_errors=False, skip_symlinks=True):
     """
     Add or remove (if add is False) permissionBits from all files (if onlydirs is False)
     and directories (if onlyfiles is False) in path
@@ -700,8 +700,15 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
         for root, dirs, files in os.walk(name):
             paths = []
             if not onlydirs:
-                paths += files
+                if not skip_symlinks:
+                    paths += files
+                else:
+                    for path in files:
+                        fname = os.path.join(root, path)
+                        if not os.path.islink(fname):
+                            paths.append(path)
             if not onlyfiles:
+                # os.walk skips symlinked dirs by default, i.e., no special handling needed here
                 paths += dirs
 
             for path in paths:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -453,6 +453,82 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(ft.weld_paths('/foo', '/foo/bar/baz'), '/foo/bar/baz/')
 
 
+    def test_adjust_permissions(self):
+        """Test adjust_permissions"""
+        # set umask hard to run test reliably
+        orig_umask = os.umask(0022)
+
+        # prep files/dirs/(broken) symlinks is test dir
+
+        # file: rw-r--r--
+        ft.write_file(os.path.join(self.test_prefix, 'foo'), 'foo')
+        foo_perms = os.stat(os.path.join(self.test_prefix, 'foo'))[stat.ST_MODE]
+        for bit in [stat.S_IRUSR, stat.S_IWUSR, stat.S_IRGRP, stat.S_IROTH]:
+            self.assertTrue(foo_perms & bit)
+        for bit in [stat.S_IXUSR, stat.S_IWGRP, stat.S_IXGRP, stat.S_IWOTH, stat.S_IXOTH]:
+            self.assertFalse(foo_perms & bit)
+
+        # dir: rwxr-xr-x
+        ft.mkdir(os.path.join(self.test_prefix, 'bar'))
+        bar_perms = os.stat(os.path.join(self.test_prefix, 'bar'))[stat.ST_MODE]
+        for bit in [stat.S_IRUSR, stat.S_IWUSR, stat.S_IXUSR, stat.S_IRGRP, stat.S_IXGRP, stat.S_IROTH, stat.S_IXOTH]:
+            self.assertTrue(bar_perms & bit)
+        for bit in [stat.S_IWGRP, stat.S_IWOTH]:
+            self.assertFalse(bar_perms & bit)
+
+        # file in dir: rw-r--r--
+        foobar_path = os.path.join(self.test_prefix, 'bar', 'foobar')
+        ft.write_file(foobar_path, 'foobar')
+        foobar_perms = os.stat(foobar_path)[stat.ST_MODE]
+        for bit in [stat.S_IRUSR, stat.S_IWUSR, stat.S_IRGRP, stat.S_IROTH]:
+            self.assertTrue(foobar_perms & bit)
+        for bit in [stat.S_IXUSR, stat.S_IWGRP, stat.S_IXGRP, stat.S_IWOTH, stat.S_IXOTH]:
+            self.assertFalse(foobar_perms & bit)
+
+        # include symlink
+        os.symlink(foobar_path, os.path.join(self.test_prefix, 'foobar_symlink'))
+
+        # include broken symlink (symlinks are skipped, so this shouldn't cause problems)
+        tmpfile = os.path.join(self.test_prefix, 'thiswontbetherelong')
+        ft.write_file(tmpfile, 'poof!')
+        os.symlink(tmpfile, os.path.join(self.test_prefix, 'broken_symlink'))
+        os.remove(tmpfile)
+
+        # test default behaviour:
+        # recursive, add permissions, relative to existing permissions, both files and dirs, skip symlinks
+        # add user execution, group write permissions
+        ft.adjust_permissions(self.test_prefix, stat.S_IXUSR|stat.S_IWGRP)
+
+        # foo file: rwxrw-r--
+        foo_perms = os.stat(os.path.join(self.test_prefix, 'foo'))[stat.ST_MODE]
+        for bit in [stat.S_IRUSR, stat.S_IWUSR, stat.S_IXUSR, stat.S_IRGRP, stat.S_IWGRP, stat.S_IROTH]:
+            self.assertTrue(foo_perms & bit)
+        for bit in [stat.S_IXGRP, stat.S_IWOTH, stat.S_IXOTH]:
+            self.assertFalse(foo_perms & bit)
+
+        # bar dir: rwxrwxr-x
+        bar_perms = os.stat(os.path.join(self.test_prefix, 'bar'))[stat.ST_MODE]
+        for bit in [stat.S_IRUSR, stat.S_IWUSR, stat.S_IXUSR, stat.S_IRGRP, stat.S_IWGRP, stat.S_IXGRP,
+                    stat.S_IROTH, stat.S_IXOTH]:
+            self.assertTrue(bar_perms & bit)
+        self.assertFalse(bar_perms & stat.S_IWOTH)
+
+        # foo/foobar file: rwxrw-r--
+        for path in [os.path.join(self.test_prefix, 'bar', 'foobar'), os.path.join(self.test_prefix, 'foobar_symlink')]:
+            perms = os.stat(path)[stat.ST_MODE]
+            for bit in [stat.S_IRUSR, stat.S_IWUSR, stat.S_IXUSR, stat.S_IRGRP, stat.S_IWGRP, stat.S_IROTH]:
+                self.assertTrue(perms & bit)
+            for bit in [stat.S_IXGRP, stat.S_IWOTH, stat.S_IXOTH]:
+                self.assertFalse(perms & bit)
+
+        # broken symlinks are trouble if symlinks are not skipped
+        self.assertErrorRegex(EasyBuildError, "No such file or directory", ft.adjust_permissions, self.test_prefix,
+                              stat.S_IXUSR, skip_symlinks=False)
+
+        # restore original umask
+        os.umask(orig_umask)
+
+
 def suite():
     """ returns all the testcases in this module """
     return TestLoader().loadTestsFromTestCase(FileToolsTest)


### PR DESCRIPTION
Either the symlinks will point to other files in the installation prefix, so permissions for those files are being handled twice in that case, or the symlinks point to somewhere else (like for PDT), in which case we shouldn't touch the files they point to at all (not only to avoid errors, it's just plain wrong to do so)...

The old behavior is still available via `skip_symlinks=False`.
