### PR TITLE
Fix HMNS to always use full version number

### DIFF
--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -93,7 +93,7 @@ class HierarchicalMNS(ModuleNamingScheme):
             # no compiler in toolchain, dummy toolchain
             res = None
         elif len(tc_comps) == 1:
-            res = (tc_comps[0]['name'], tc_comps[0]['version'])
+            res = (tc_comps[0]['name'], self.det_full_version(tc_comps[0]))
         else:
             comp_versions = dict([(comp['name'], self.det_full_version(comp)) for comp in tc_comps])
             comp_names = comp_versions.keys()


### PR DESCRIPTION
Fixes an issue encountered when building `GNU-4.9.3-2.25` using `GCC-4.9.3-binutils-2.25`.  The `GCC/4.9.3-binutils-2.25` module file extended the modulepath by `<installdir>/Compiler/GCC/4.9.3-binutils-2.25`, but software was (incorrectly) installed to `<installdir>/Compiler/GCC/4.9.3`.