### PR TITLE
fix MPI compiler wrapper env vars for toolchains using psmpi

### DIFF
--- a/easybuild/toolchains/gpsmpi.py
+++ b/easybuild/toolchains/gpsmpi.py
@@ -27,11 +27,10 @@ EasyBuild support for gpsmpi compiler toolchain (includes GCC and Parastation MP
 
 """
 
-from easybuild.toolchains.gmpich import Gmpich
+from easybuild.toolchains.compiler.gcc import Gcc
+from easybuild.toolchains.mpi.psmpi import Psmpi
 
 
-class Gpsmpi(Gmpich):
+class Gpsmpi(Gcc, Psmpi):
     """Compiler toolchain with GCC and Parastation MPICH."""
     NAME = 'gpsmpi'
-    # Use Parastation naming
-    MPI_MODULE_NAME = ["psmpi"]

--- a/easybuild/toolchains/mpi/psmpi.py
+++ b/easybuild/toolchains/mpi/psmpi.py
@@ -1,4 +1,4 @@
-##
+# #
 # Copyright 2012-2015 Ghent University
 #
 # This file is part of EasyBuild,
@@ -21,18 +21,28 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
-##
+# #
 """
-EasyBuild support for intel compiler toolchain (includes Intel compilers (icc, ifort), Parastation MPICH).
+Support for MPICH2 as toolchain MPI library.
 
+@author: Stijn De Weirdt (Ghent University)
+@author: Kenneth Hoste (Ghent University)
+@author: Jens Timmerman (Ghent University)
 """
 
-from easybuild.toolchains.compiler.inteliccifort import IntelIccIfort
-from easybuild.toolchains.mpi.psmpi import Psmpi
+from easybuild.toolchains.mpi.mpich import Mpich
 
 
-class Ipsmpi(IntelIccIfort, Psmpi):
-    """
-    Compiler toolchain with Intel compilers (icc/ifort), Parastation MPICH.
-    """
-    NAME = 'ipsmpi'
+class Psmpi(Mpich):
+    """MPICH2 MPI class"""
+    MPI_MODULE_NAME = ['psmpi']
+
+    def _set_mpi_compiler_variables(self):
+        """Set the MPICH_{CC, CXX, F77, F90, FC} variables."""
+
+        # hardwire MPI wrapper commands (otherwise Mpich parent class sets them based on MPICH version)
+        self.MPI_COMPILER_MPIF77 = 'mpif77'
+        self.MPI_COMPILER_MPIF90 = 'mpif90'
+        self.MPI_COMPILER_MPIFC = 'mpif90'
+
+        super(Psmpi, self)._set_mpi_compiler_variables()

--- a/easybuild/toolchains/mpi/psmpi.py
+++ b/easybuild/toolchains/mpi/psmpi.py
@@ -23,18 +23,16 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 # #
 """
-Support for MPICH2 as toolchain MPI library.
+Support for Parastation MPI as toolchain MPI library.
 
-@author: Stijn De Weirdt (Ghent University)
 @author: Kenneth Hoste (Ghent University)
-@author: Jens Timmerman (Ghent University)
 """
 
 from easybuild.toolchains.mpi.mpich import Mpich
 
 
 class Psmpi(Mpich):
-    """MPICH2 MPI class"""
+    """Parastation MPI class"""
     MPI_MODULE_NAME = ['psmpi']
 
     def _set_mpi_compiler_variables(self):


### PR DESCRIPTION
bug introduced via #1394, manifests itself with error below, for example when building ScaLAPACK with gpsmpi/2014.12:

```
mpifort -c -fPIC -O2 -march=native icopy.f
make[2]: mpifort: Command not found
```