### PR TITLE
[.yeb] alternate toolchain format

### DIFF
--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -95,9 +95,6 @@ class FormatYeb(EasyConfigFormat):
         """
         txt = self._inject_constants_dict(txt)
         self.parsed_yeb = yaml.load(txt)
-        # toolchain param value check, convert to dict if alt format is used
-        check_type_of_param_value('toolchain', self.parsed_yeb['toolchain'], auto_convert=True)
-
 
     def _inject_constants_dict(self, txt):
         """Inject constants so they are resolved when actually parsing the YAML text."""

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -35,6 +35,7 @@ from vsc.utils import fancylogger
 from easybuild.framework.easyconfig.format.format import INDENT_4SPACES, EasyConfigFormat
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_constants_dict
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_variables_dict
+from easybuild.framework.easyconfig.types import check_type_of_param_value
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file
 from easybuild.tools.utilities import only_if_module_is_available, quote_str
@@ -94,12 +95,9 @@ class FormatYeb(EasyConfigFormat):
         """
         txt = self._inject_constants_dict(txt)
         self.parsed_yeb = yaml.load(txt)
-        # make dict out of toolchain
-        if not isinstance(self.parsed_yeb['toolchain'], dict):
-            self.parsed_yeb['toolchain'] = {
-                'name': self.parsed_yeb['toolchain'].split(',')[0].strip(),
-                'version': self.parsed_yeb['toolchain'].split(',')[1].strip(),
-            }
+        # toolchain param value check, convert to dict if alt format is used
+        check_type_of_param_value('toolchain', self.parsed_yeb['toolchain'], auto_convert=True)
+
 
     def _inject_constants_dict(self, txt):
         """Inject constants so they are resolved when actually parsing the YAML text."""

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -35,7 +35,6 @@ from vsc.utils import fancylogger
 from easybuild.framework.easyconfig.format.format import INDENT_4SPACES, EasyConfigFormat
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_constants_dict
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_variables_dict
-from easybuild.framework.easyconfig.types import check_type_of_param_value
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file
 from easybuild.tools.utilities import only_if_module_is_available, quote_str

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -94,6 +94,12 @@ class FormatYeb(EasyConfigFormat):
         """
         txt = self._inject_constants_dict(txt)
         self.parsed_yeb = yaml.load(txt)
+        # make dict out of toolchain
+        if not isinstance(self.parsed_yeb['toolchain'], dict):
+            self.parsed_yeb['toolchain'] = {
+                'name': self.parsed_yeb['toolchain'].split(',')[0].strip(),
+                'version': self.parsed_yeb['toolchain'].split(',')[1].strip(),
+            }
 
     def _inject_constants_dict(self, txt):
         """Inject constants so they are resolved when actually parsing the YAML text."""

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -111,33 +111,28 @@ def convert_value_type(val, typ):
 
     return res
 
-def to_dict(tc):
+def to_toolchain(tcspec):
     """
     Convert a toolchain string "foo, v0" to a dictionary {'name':'foo', 'version':'v0'}
 
-    @param toolchain_str: a toolchain string
+    @param tcspec: a toolchain in the form of a string or a list
     """
     # check if tc is a string or a list of two values; else, it can not be converted
-    if isinstance(tc, basestring):
-        if tc.count(',') != 1:
-            raise EasyBuildError("Can not convert string %s to toolchain dict. Expected format: name,version" % tc)
-        else:
-            tc_split = tc.split(',')
-            return {'name':tc_split[0].strip(), 'version':tc_split[1].strip()}
+    if isinstance(tcspec, basestring):
+        tcspec = tcspec.split(',')
 
-    elif isinstance(tc, list):
-        if len(tc) != 2:
+    if isinstance(tcspec, list):
+        if len(tcspec) == 2:
+            return {'name':tcspec[0].strip(), 'version':tcspec[1].strip()}
+        else:
             raise EasyBuildError("Can not convert list %s to toolchain dict. Expected 2 elements")
-        else:
-            return {'name':tc[0], 'version':tc[1]}
-
     else:
-        raise EasyBuildError("Conversion of type %s to toolchain dict is not supported" % type(tc))
+        raise EasyBuildError("Conversion of type %s to toolchain dict is not supported" % type(tcspec))
 
 TYPE_CONVERSION_FUNCTIONS = {
     basestring: str,
     float: float,
     int: int,
     str: str,
-    dict: to_dict,
+    dict: to_toolchain,
 }

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -34,19 +34,13 @@ from easybuild.tools.build_log import EasyBuildError
 
 
 # easy types, that can be verified with isinstance
-EASY_TYPES = [basestring, int]
+EASY_TYPES = [basestring, int, dict]
 # type checking is skipped for easyconfig parameters names not listed in TYPES
 TYPES = {
     'name': basestring,
     'version': basestring,
+    'toolchain': dict,
 }
-TYPE_CONVERSION_FUNCTIONS = {
-    basestring: str,
-    float: float,
-    int: int,
-    str: str,
-}
-
 
 _log = fancylogger.getLogger('easyconfig.types', fname=False)
 
@@ -116,3 +110,34 @@ def convert_value_type(val, typ):
         raise EasyBuildError("No conversion function available (yet) for target type %s", typ)
 
     return res
+
+def to_dict(tc):
+    """
+    Convert a toolchain string "foo, v0" to a dictionary {'name':'foo', 'version':'v0'}
+
+    @param toolchain_str: a toolchain string
+    """
+    # check if tc is a string or a list of two values; else, it can not be converted
+    if isinstance(tc, basestring):
+        if tc.count(',') != 1:
+            raise EasyBuildError("Can not convert string %s to toolchain dict. Expected format: name,version" % tc)
+        else:
+            tc_split = tc.split(',')
+            return {'name':tc_split[0].strip(), 'version':tc_split[1].strip()}
+
+    elif isinstance(tc, list):
+        if len(tc) != 2:
+            raise EasyBuildError("Can not convert list %s to toolchain dict. Expected 2 elements")
+        else:
+            return {'name':tc[0], 'version':tc[1]}
+
+    else:
+        raise EasyBuildError("Conversion of type %s to toolchain dict is not supported" % type(tc))
+
+TYPE_CONVERSION_FUNCTIONS = {
+    basestring: str,
+    float: float,
+    int: int,
+    str: str,
+    dict: to_dict,
+}

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -111,9 +111,10 @@ def convert_value_type(val, typ):
 
     return res
 
+
 def to_toolchain(tcspec):
     """
-    Convert a toolchain string "foo, v0" to a dictionary {'name':'foo', 'version':'v0'}
+    Convert a toolchain string "intel, 2015a" to a dictionary {'name':'intel', 'version':'2015a'}
 
     @param tcspec: a toolchain in the form of a string or a list
     """
@@ -123,12 +124,16 @@ def to_toolchain(tcspec):
 
     if isinstance(tcspec, list):
         if len(tcspec) == 2:
-            return {'name':tcspec[0].strip(), 'version':tcspec[1].strip()}
+            res = {'name': tcspec[0].strip(), 'version': tcspec[1].strip()}
         else:
-            raise EasyBuildError("Can not convert list %s to toolchain dict. Expected 2 elements")
+            raise EasyBuildError("Can not convert list %s to toolchain dict. Expected 2 elements", tcspec)
     else:
-        raise EasyBuildError("Conversion of type %s to toolchain dict is not supported" % type(tcspec))
+        raise EasyBuildError("Conversion of %s (type %s) to toolchain dict is not supported", tcspec, type(tcspec))
 
+    return res
+
+
+# this uses to_toolchain, so it needs to be at the bottom of the module
 TYPE_CONVERSION_FUNCTIONS = {
     basestring: str,
     float: float,

--- a/test/framework/easyconfigs/yeb/SQLite-3.8.10.2-goolf-1.4.10.yeb
+++ b/test/framework/easyconfigs/yeb/SQLite-3.8.10.2-goolf-1.4.10.yeb
@@ -10,7 +10,7 @@ homepage: http://www.sqlite.org/
 # quotes on description to escape special character :
 description: "SQLite: SQL Database Engine in a C Library"
 
-toolchain: {name: goolf, version: 1.4.10}
+toolchain: goolf, 1.4.10
 
 # eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
 source_urls: ["http://www.sqlite.org/2015/"]

--- a/test/framework/easyconfigs/yeb/bzip-bad-toolchain.yeb
+++ b/test/framework/easyconfigs/yeb/bzip-bad-toolchain.yeb
@@ -13,7 +13,7 @@ description: |
     compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
     compressors), whilst being around twice as fast at compression and six times faster at decompression.
 
-toolchain: [GCC, 4.9.2]
+toolchain: GCC,4.9,2
 toolchainopts: {pic: True}
 
 sources:

--- a/test/framework/easyconfigs/yeb/bzip-bad-toolchain.yeb
+++ b/test/framework/easyconfigs/yeb/bzip-bad-toolchain.yeb
@@ -13,7 +13,7 @@ description: |
     compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
     compressors), whilst being around twice as fast at compression and six times faster at decompression.
 
-toolchain: GCC,4.9,2
+toolchain: GCC, 4.9, 2
 toolchainopts: {pic: True}
 
 sources:

--- a/test/framework/easyconfigs/yeb/bzip-bad-toolchain.yeb
+++ b/test/framework/easyconfigs/yeb/bzip-bad-toolchain.yeb
@@ -13,6 +13,7 @@ description: |
     compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
     compressors), whilst being around twice as fast at compression and six times faster at decompression.
 
+# bad toolchain with three parameters
 toolchain: GCC, 4.9, 2
 toolchainopts: {pic: True}
 

--- a/test/framework/easyconfigs/yeb/bzip2-1.0.6-GCC-4.9.2.yeb
+++ b/test/framework/easyconfigs/yeb/bzip2-1.0.6-GCC-4.9.2.yeb
@@ -13,7 +13,7 @@ description: |
     compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical
     compressors), whilst being around twice as fast at compression and six times faster at decompression.
 
-toolchain: {name: GCC, version: 4.9.2}
+toolchain: GCC, 4.9.2
 toolchainopts: {pic: True}
 
 sources:

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -100,6 +100,8 @@ class TypeCheckingTest(EnhancedTestCase):
             to_toolchain, "intel, 2015, a")
         self.assertErrorRegex(EasyBuildError, "Can not convert list .* to toolchain dict. Expected 2 elements",
             to_toolchain, "intel")
+        self.assertErrorRegex(EasyBuildError, "Can not convert list .* to toolchain dict. Expected 2 elements",
+            to_toolchain, ['gcc', '4', '7'])
 
 
 def suite():

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -31,7 +31,7 @@ from test.framework.utilities import EnhancedTestCase
 from unittest import TestLoader, main
 
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.framework.easyconfig.types import check_type_of_param_value, convert_value_type
+from easybuild.framework.easyconfig.types import check_type_of_param_value, convert_value_type, to_toolchain
 
 
 class TypeCheckingTest(EnhancedTestCase):
@@ -84,6 +84,22 @@ class TypeCheckingTest(EnhancedTestCase):
         class Foo():
             pass
         self.assertErrorRegex(EasyBuildError, "No conversion function available", convert_value_type, None, Foo)
+
+    def test_to_toolchain(self):
+        """ Test toolchain string to dict conversion """
+        # normal cases
+        self.assertEqual(to_toolchain("intel, 2015a"), {'name': 'intel', 'version': '2015a'})
+        self.assertEqual(to_toolchain(['gcc', '4.7']), {'name': 'gcc', 'version': '4.7'})
+
+        # wrong type
+        self.assertErrorRegex(EasyBuildError, r"Conversion of .* \(type .*\) to toolchain dict is not supported",
+            to_toolchain, ('intel', '2015a'))
+
+        # wrong number of elements
+        self.assertErrorRegex(EasyBuildError, "Can not convert list .* to toolchain dict. Expected 2 elements",
+            to_toolchain, "intel, 2015, a")
+        self.assertErrorRegex(EasyBuildError, "Can not convert list .* to toolchain dict. Expected 2 elements",
+            to_toolchain, "intel")
 
 
 def suite():

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -120,12 +120,12 @@ class YebTest(EnhancedTestCase):
             self.assertEqual(loaded.get(key), 'foobar')
 
 
-    def test_toolchain_alt_format(self):
+    def test_bad_toolchain_format(self):
         """ Test alternate toolchain format name,version """
         # only test bad cases - the right ones are tested with the test files in test_parse_yeb
         testdir = os.path.dirname(os.path.abspath(__file__))
         test_easyconfigs = os.path.join(testdir, 'easyconfigs', 'yeb')
-        expected = 'Can not convert string GCC,4.9,2 to toolchain dict. Expected format: name,version'
+        expected = r'Can not convert list .* to toolchain dict. Expected 2 elements'
         self.assertErrorRegex(EasyBuildError, expected, EasyConfig, os.path.join(test_easyconfigs, 'bzip-bad-toolchain.yeb'))
 
 

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -36,6 +36,7 @@ from unittest import TestLoader, main
 import easybuild.tools.build_log
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig
 from easybuild.framework.easyconfig.format.yeb import is_yeb_format
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file
 
 class YebTest(EnhancedTestCase):
@@ -117,6 +118,15 @@ class YebTest(EnhancedTestCase):
         loaded = yaml.load('\n'.join(stream))
         for key in ['fb1', 'fb2', 'fb3']:
             self.assertEqual(loaded.get(key), 'foobar')
+
+
+    def test_toolchain_alt_format(self):
+        """ Test alternate toolchain format name,version """
+        # only test bad cases - the right ones are tested with the test files in test_parse_yeb
+        testdir = os.path.dirname(os.path.abspath(__file__))
+        test_easyconfigs = os.path.join(testdir, 'easyconfigs', 'yeb')
+        expected = 'Can not convert string GCC,4.9,2 to toolchain dict. Expected format: name,version'
+        self.assertErrorRegex(EasyBuildError, expected, EasyConfig, os.path.join(test_easyconfigs, 'bzip-bad-toolchain.yeb'))
 
 
 def suite():


### PR DESCRIPTION
yeb files now work with `toolchain: name,version` or `toolchain: [name,version]`; there's also still support for the old syntax.

docs: https://github.com/hpcugent/easybuild/pull/165