### PR TITLE
Use diff --git lines to determine the files in PR

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -543,9 +543,9 @@ def extract_cmd(filepath, overwrite=False):
 
 def det_patched_files(path=None, txt=None, omit_ab_prefix=False):
     """Determine list of patched files from a patch."""
-    # expected format: "+++ path/to/patched/file"
+    # searches for the diff --git lines to determine the filenames
     # also take into account the 'a/' or 'b/' prefix that may be used
-    patched_regex = re.compile(r"^\s*\+{3}\s+(?P<ab_prefix>[ab]/)?(?P<file>\S+)", re.M)
+    patched_regex = re.compile(r"^diff --git (?P<ab_prefix>[ab]/)?(?P<file>\S+)", re.M)
     if path is not None:
         try:
             f = open(path, 'r')

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -541,11 +541,21 @@ def extract_cmd(filepath, overwrite=False):
     return cmd_tmpl % {'filepath': filepath, 'target': target}
 
 
-def det_patched_files(path=None, txt=None, omit_ab_prefix=False):
-    """Determine list of patched files from a patch."""
-    # searches for the diff --git lines to determine the filenames
-    # also take into account the 'a/' or 'b/' prefix that may be used
-    patched_regex = re.compile(r"^diff --git (?P<ab_prefix>[ab]/)?(?P<file>\S+)", re.M)
+def det_patched_files(path=None, txt=None, omit_ab_prefix=False, github=False):
+    """
+    Determine list of patched files from a patch.
+    It search for "+++ path/to/patched/file" lines to determine
+    the patched files.
+    @param path the path to the diff
+    @param txt the contents of the diff (either path or txt should be give)
+    @param omit_ab_prefix ignore the a/ or b/ prefix of the files
+    @param github use diff --git as search criteria
+    """
+    if github:
+        patched_regex = re.compile(r"^diff --git (?P<ab_prefix>[ab]/)?(?P<file>\S+)", re.M)
+    else:
+        patched_regex = re.compile(r"^\s*\+{3}\s+(?P<ab_prefix>[ab]/)?(?P<file>\S+)", re.M)
+
     if path is not None:
         try:
             f = open(path, 'r')

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -172,7 +172,7 @@ def remove_file(path):
         if os.path.exists(path):
             os.remove(path)
     except OSError, err:
-          raise EasyBuildError("Failed to remove %s: %s", path, err)
+        raise EasyBuildError("Failed to remove %s: %s", path, err)
 
 
 def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
@@ -321,7 +321,7 @@ def find_easyconfigs(path, ignore_dirs=None):
             files.append(spec)
 
         # ignore subdirs specified to be ignored by replacing items in dirnames list used by os.walk
-        dirnames[:] = [d for d in dirnames if not d in ignore_dirs]
+        dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
 
     return files
 
@@ -361,7 +361,7 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False):
             # note: we still need to consider e.g., .local !
             # replace list elements using [:], so os.walk doesn't process deleted directories
             # see http://stackoverflow.com/questions/13454164/os-walk-without-hidden-folders
-            dirnames[:] = [d for d in dirnames if not d in ignore_dirs]
+            dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
 
         hits = sorted(hits)
 
@@ -384,7 +384,7 @@ def compute_checksum(path, checksum_type=DEFAULT_CHECKSUM):
     @param path: Path of file to compute checksum for
     @param checksum_type: Type of checksum ('adler32', 'crc32', 'md5' (default), 'sha1', 'size')
     """
-    if not checksum_type in CHECKSUM_FUNCTIONS:
+    if checksum_type not in CHECKSUM_FUNCTIONS:
         raise EasyBuildError("Unknown checksum type (%s), supported types are: %s",
                              checksum_type, CHECKSUM_FUNCTIONS.keys())
 
@@ -976,7 +976,7 @@ def move_logs(src_logfile, target_logfile):
             _log.info("Moved log file %s to %s" % (src_logfile, new_log_path))
 
     except (IOError, OSError), err:
-        raise EasyBuildError("Failed to move log file(s) %s* to new log file %s*: %s" ,
+        raise EasyBuildError("Failed to move log file(s) %s* to new log file %s*: %s",
                              src_logfile, target_logfile, err)
 
 
@@ -1077,7 +1077,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
         else:
             errors.extend((src, dst, str(why)))
     if errors:
-        raise Error, errors
+        raise Error(errors)
 
 
 def encode_string(name):
@@ -1135,6 +1135,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
 def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, regexp=True, std_qa=None, path=None):
     """NO LONGER SUPPORTED: use run_cmd_qa from easybuild.tools.run instead"""
     _log.nosupport("run_cmd_qa was moved from easybuild.tools.filetools to easybuild.tools.run", '2.0')
+
 
 def parse_log_for_error(txt, regExp=None, stdout=True, msg=None):
     """NO LONGER SUPPORTED: use parse_log_for_error from easybuild.tools.run instead"""

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -116,7 +116,7 @@ class Githubfs(object):
     @staticmethod
     def isdir(githubobj):
         """Check if this path points to a directory"""
-        if isinstance(githubobj,(list, tuple)):
+        if isinstance(githubobj, (list, tuple)):
             return True
         else:
             try:
@@ -147,7 +147,7 @@ class Githubfs(object):
         """
         Walk the github repo in an os.walk like fashion.
         """
-        isdir, listdir =  self.isdir, self.listdir
+        isdir, listdir = self.isdir, self.listdir
 
         # If this fails we blow up, since permissions on a github repo are recursive anyway.j
         githubobjs = listdir(top)
@@ -183,7 +183,7 @@ class Githubfs(object):
             obj = self.get_path(path).get(ref=self.branchname)[1]
             if not self.isfile(obj):
                 raise GithubError("Error: not a valid file: %s" % str(obj))
-            return  base64.b64decode(obj['content'])
+            return base64.b64decode(obj['content'])
 
 
 class GithubError(Exception):
@@ -349,7 +349,7 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     if not sorted(tmp_files) == sorted(all_files):
         raise EasyBuildError("Not all patched files were downloaded to %s: %s vs %s", path, tmp_files, all_files)
 
-    ec_files = [os.path.join(path, fn) for fn in tmp_files]
+    ec_files = [os.path.join(path, filename) for filename in tmp_files]
 
     return ec_files
 
@@ -426,6 +426,7 @@ class GithubToken(object):
         else:
             # success
             _log.info("Successfully obtained GitHub token for user %s from keyring." % user)
+
 
 def fetch_github_token(user):
     """Fetch GitHub token for specified user from keyring."""

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -324,7 +324,7 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     diff_txt = read_file(diff_filepath)
     os.remove(diff_filepath)
 
-    patched_files = det_patched_files(txt=diff_txt, omit_ab_prefix=True)
+    patched_files = det_patched_files(txt=diff_txt, omit_ab_prefix=True, github=True)
     _log.debug("List of patched files: %s" % patched_files)
 
     # obtain last commit


### PR DESCRIPTION
Instead of searching for +++ lines, search for diff --git. This should
be more foolproof and lead to less false positives.

hpcugent/easybuild-easyconfigs#2126 is an example where the previous regex failed.