### PR TITLE
Change polling loops so they keep going only if error code is None

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -122,7 +122,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
 
     ec = p.poll()
     stdouterr = ''
-    while ec < 0:
+    while ec is None:
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
         output = p.stdout.read(readSize)
@@ -269,7 +269,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     oldLenOut = -1
     hitCount = 0
 
-    while ec < 0:
+    while ec is None:
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
         try:


### PR DESCRIPTION
This small but important fix deals with the situation where the UNIX command generates an exit code less than zero, as happens if the UNIX command dies by reason of receiving a signal. While I would expect that receiving such an exit code causes the loop to exit, previous behaviour had it looping endlessly until the Python process was interrupted by a user or killed via some other means. Now, the loop should only keep running if, in fact, the UNIX command has not yet exited (by means of a signal or otherwise).