### PR TITLE
Patch new files

### DIFF
--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -51,6 +51,14 @@ import sys
 import tempfile
 from distutils.version import LooseVersion
 
+# argparse preferrred, optparse deprecated >=2.7
+HAVE_ARGPARSE=False
+try: 
+    import argparse
+    HAVE_ARGPARSE = True
+except ImportError:
+    import optparse
+
 PYPI_SOURCE_URL = 'https://pypi.python.org/packages/source'
 
 VSC_BASE = 'vsc-base'
@@ -437,10 +445,30 @@ def main():
         error("Don't run the EasyBuild bootstrap script as root, "
               "since stage 2 (installing EasyBuild with EasyBuild) will fail.")
 
-    # see if an install dir was specified
-    if not len(sys.argv) == 2:
-        error("Usage: %s <install path>" % sys.argv[0])
-    install_path = os.path.abspath(sys.argv[1])
+    # general option/argument parser
+    if HAVE_ARGPARSE:
+        bs_argparser = argparse.ArgumentParser()
+        bs_argparser.add_argument(
+          "prefix", help="Installation prefix directory",
+          type=str)
+        bs_args = bs_argparser.parse_args()
+
+        # prefix specification
+        install_path = os.path.abspath(bs_args.prefix)
+    else:
+        bs_argparser = optparse.OptionParser(usage="usage: %prog [options] prefix")
+        (bs_opts,bs_args) = bs_argparser.parse_args()
+
+        # poor method, but should prefer argparse module for better pos arg support.
+        if len(bs_args) < 1:
+            error("Too few arguments\n" + bs_argparser.get_usage())
+        elif len(bs_args) > 1:
+            error("Too many arguments\n" + bs_argparser.get_usage())
+        
+        # prefix specification	
+	install_path = os.path.abspath(str(bs_args[0]))
+
+    info("Installation prefix %s" % install_path)
 
     sourcepath = EASYBUILD_BOOTSTRAP_SOURCEPATH
     if sourcepath is not None:

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -540,7 +540,7 @@ preinstallopts = '%(preinstallopts)s'
 pyshortver = '.'.join(SYS_PYTHON_VERSION.split('.')[:2])
 sanity_check_paths = {
     'files': ['bin/eb'],
-    'dirs': ['lib/python%%s/site-packages' %% pyshortver],
+    'dirs': [('lib/python%%s/site-packages' %% pyshortver, 'lib64/python%%s/site-packages' %% pyshortver)],
 }
 
 moduleclass = 'tools'

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -46,7 +46,7 @@ from easybuild.tools.filetools import which
 from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
-from easybuild.tools.utilities import import_available_modules
+from easybuild.tools.utilities import import_available_modules, quote_str
 
 
 _log = fancylogger.getLogger('tools.package')
@@ -119,6 +119,8 @@ def package_with_fpm(easyblock):
         '-s', 'dir',  # source
         '--version', pkgver,
         '--iteration', pkgrel,
+        '--description', quote_str(easyblock.cfg["description"]),
+        '--url', easyblock.cfg["homepage"],
         depstring,
         easyblock.installdir,
         easyblock.module_generator.get_module_filepath(),

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -336,7 +336,16 @@ def get_os_version():
                 "11": [
                     ('2.6.27', ''),
                     ('2.6.32', '_SP1'),
+                    ('3.0.101-63', '_SP4'),
+                    # not 100% correct, since early SP3 had 3.0.76 - 3.0.93, but close enough?
+                    ('3.0.101', '_SP3'),
+                    # SP2 kernel versions range from 3.0.13 - 3.0.101
                     ('3.0', '_SP2'),
+                ],
+
+                # Once SLES 12 SP1 comes out we'll need to make this stricter
+                "12": [
+                    ('3.12', ''),
                 ],
             }
 

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -43,7 +43,7 @@ from socket import gethostname
 # recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
 #   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
 # This causes problems further up the dependency chain...
-VERSION = LooseVersion('2.4.0')
+VERSION = LooseVersion('2.5.0.dev0')
 UNKNOWN = 'UNKNOWN'
 
 def get_git_revision():


### PR DESCRIPTION
Allow patches which have '/dev/null' in the first line:

--- /dev/null   2015-07-10 16:14:12.096153473 +0200
+++ conifer_v0.2.2/setup.py    2015-11-24 17:59:09.000000000 +0100

Reasons:

- It's a valid patch naming
- There are tons of patches like this in the FreeBSD ports repo, this makes migrating easier
- If this is not working, one has to write much more easyblocks, just to touch or create a file. IMHO this helps to avoid 1/3 of all existing custom easyblocks.