### PR TITLE
hoist string value into a list in make_module_req

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1039,7 +1039,11 @@ class EasyBlock(object):
 
             lines.append('\n')
             for key in sorted(requirements):
-                for path in requirements[key]:
+                reqs = requirements[key]
+                if isinstance(reqs, basestring):
+                    reqs = [reqs]
+
+                for path in reqs:
                     paths = sorted(glob.glob(path))
                     if paths:
                         lines.append(self.module_generator.prepend_paths(key, paths))

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1041,6 +1041,7 @@ class EasyBlock(object):
             for key in sorted(requirements):
                 reqs = requirements[key]
                 if isinstance(reqs, basestring):
+                    self.log.warning("Hoisting string value %s into a list before iterating over it", reqs)
                     reqs = [reqs]
 
                 for path in reqs:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -207,6 +207,16 @@ class EasyBlockTest(EnhancedTestCase):
         else:
             self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
 
+        # check for behavior when a string value is used as dict value by make_module_req_guesses
+        eb.make_module_req_guess = lambda: {'PATH': 'bin'}
+        txt = eb.make_module_req()
+        if get_module_syntax() == 'Tcl':
+            self.assertTrue(re.match(r"^\nprepend-path\s+PATH\s+\$root/bin\n$", txt, re.M))
+        elif get_module_syntax() == 'Lua':
+            self.assertTrue(re.match(r'^\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n$', txt, re.M))
+        else:
+            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+
         # cleanup
         eb.close_log()
         os.remove(eb.logfile)


### PR DESCRIPTION
minor enhancement to avoid weird problems when passing a string value rather than a list

without this, you may run into an error like:

```
Absolute path / passed to prepend_paths which only expects relative paths
```

caused by `make_module_req` looping over the string value as if it were a list...

cc @wpoely86: please review?