### PR TITLE
add support to specify alternative root/version for $EBROOT/$EBVERSION

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -941,8 +941,6 @@ class EasyBlock(object):
         # $EBROOT<NAME>
         root_envvar = ROOT_ENV_VAR_NAME_PREFIX + env_name
         if altroot:
-            if not os.path.isabs(altroot):
-                raise EasyBuildError("Alternative root must be an absolute path: %s", altroot)
             set_root_envvar = self.module_generator.set_environment(root_envvar, altroot)
         else:
             set_root_envvar = self.module_generator.set_environment(root_envvar, '', relpath=True)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -932,7 +932,10 @@ class EasyBlock(object):
 
     def make_module_extra(self, altroot=None, altversion=None):
         """
-        Sets optional variables (EBROOT, MPI tuning variables).
+        Set extra stuff in module file, e.g. $EBROOT*, $EBVERSION*, etc.
+
+        @param altroot: path to use to define $EBROOT*
+        @param altversion: version to use to define $EBVERSION*
         """
         lines = ['']
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -930,18 +930,29 @@ class EasyBlock(object):
         """
         return self.module_generator.get_description()
 
-    def make_module_extra(self):
+    def make_module_extra(self, altroot=None, altversion=None):
         """
         Sets optional variables (EBROOT, MPI tuning variables).
         """
         lines = ['']
 
-        # EBROOT + EBVERSION + EBDEVEL
         env_name = convert_name(self.name, upper=True)
 
-        lines.append(self.module_generator.set_environment(ROOT_ENV_VAR_NAME_PREFIX + env_name, '', relpath=True))
-        lines.append(self.module_generator.set_environment(VERSION_ENV_VAR_NAME_PREFIX + env_name, self.version))
+        # $EBROOT<NAME>
+        root_envvar = ROOT_ENV_VAR_NAME_PREFIX + env_name
+        if altroot:
+            if not os.path.isabs(altroot):
+                raise EasyBuildError("Alternative root must be an absolute path: %s", altroot)
+            set_root_envvar = self.module_generator.set_environment(root_envvar, altroot)
+        else:
+            set_root_envvar = self.module_generator.set_environment(root_envvar, '', relpath=True)
+        lines.append(set_root_envvar)
 
+        # $EBVERSION<NAME>
+        version_envvar = VERSION_ENV_VAR_NAME_PREFIX + env_name
+        lines.append(self.module_generator.set_environment(version_envvar, altversion or self.version))
+
+        # $EBDEVEL<NAME>
         devel_path = os.path.join(log_path(), ActiveMNS().det_devel_module_filename(self.cfg))
         devel_path_envvar = DEVEL_ENV_VAR_NAME_PREFIX + env_name
         lines.append(self.module_generator.set_environment(devel_path_envvar, devel_path, relpath=True))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -272,9 +272,6 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertTrue(expected_alt.match(alttxt),
                         "Pattern %s found in %s" % (expected_alt.pattern, alttxt))
 
-        error_pat = "Alternative root must be an absolute path"
-        self.assertErrorRegex(EasyBuildError, error_pat, eb.make_module_extra, altroot='pi/3.14.15')
-
     def test_make_module_dep(self):
         """Test for make_module_dep"""
         self.contents = '\n'.join([


### PR DESCRIPTION
I need this to use in the `Bundle` easyblock, to make sure that `$EBROOTGCC` is defined correctly in the module generated for the `GCC` bundle that is part of https://github.com/hpcugent/easybuild-easyconfigs/pull/2214.