### PR TITLE
Isolate tests system wide cfg

### DIFF
--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -80,7 +80,8 @@ class EasyBuildConfigTest(EnhancedTestCase):
     def purge_environment(self):
         """Remove any leftover easybuild variables"""
         for var in os.environ.keys():
-            if var.startswith('EASYBUILD_'):
+            # retain $EASYBUILD_IGNORECONFIGFILES, to make sure the test is isolated from system-wide config files!
+            if var.startswith('EASYBUILD_') and var != 'EASYBUILD_IGNORECONFIGFILES':
                 del os.environ[var]
 
     def tearDown(self):
@@ -425,7 +426,10 @@ class EasyBuildConfigTest(EnhancedTestCase):
         mkdir(os.path.join(dir3, 'easybuild.d'), parents=True)
         write_file(os.path.join(dir3, 'easybuild.d', 'foobarbaz.cfg'), cfg_template % '/foobarbaz')
 
-        # only $XDG_CONFIG_HOME set
+        # set $XDG_CONFIG_DIRS to non-existing dir to isolate ourselves from possible system-wide config files
+        os.environ['XDG_CONFIG_DIRS'] = '/there/should/be/no/such/directory/we/hope'
+
+        # only $XDG_CONFIG_HOME set (to existing path)
         os.environ['XDG_CONFIG_HOME'] = homedir
         cfg_files = [os.path.join(homedir, 'easybuild', 'config.cfg')]
         reload(eboptions)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -72,7 +72,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def purge_environment(self):
         """Remove any leftover easybuild variables"""
         for var in os.environ.keys():
-            if var.startswith('EASYBUILD_'):
+            # retain $EASYBUILD_IGNORECONFIGFILES, to make sure the test is isolated from system-wide config files!
+            if var.startswith('EASYBUILD_') and var != 'EASYBUILD_IGNORECONFIGFILES':
                 del os.environ[var]
 
     def test_help_short(self, txt=None):

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1671,14 +1671,24 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_generate_cmd_line(self):
         """Test for generate_cmd_line."""
-        ebopts = EasyBuildOptions()
-        self.assertEqual(ebopts.generate_cmd_line(), [])
+        self.purge_environment()
 
-        ebopts = EasyBuildOptions(go_args=['--force'])
-        self.assertEqual(ebopts.generate_cmd_line(), ['--force'])
+        def generate_cmd_line(ebopts):
+            """Helper function to filter generated command line (to ignore $EASYBUILD_IGNORECONFIGFILES)."""
+            return [x for x in ebopts.generate_cmd_line() if not x.startswith('--ignoreconfigfiles=')]
 
-        ebopts = EasyBuildOptions(go_args=['--search=bar', '--search', 'foobar'])
-        self.assertEqual(ebopts.generate_cmd_line(), ['--search=foobar'])
+        ebopts = EasyBuildOptions(envvar_prefix='EASYBUILD')
+        self.assertEqual(generate_cmd_line(ebopts), [])
+
+        ebopts = EasyBuildOptions(go_args=['--force'], envvar_prefix='EASYBUILD')
+        self.assertEqual(generate_cmd_line(ebopts), ['--force'])
+
+        ebopts = EasyBuildOptions(go_args=['--search=bar', '--search', 'foobar'], envvar_prefix='EASYBUILD')
+        self.assertEqual(generate_cmd_line(ebopts), ['--search=foobar'])
+
+        os.environ['EASYBUILD_DEBUG'] = '1'
+        ebopts = EasyBuildOptions(go_args=['--force'], envvar_prefix='EASYBUILD')
+        self.assertEqual(generate_cmd_line(ebopts), ['--debug', '--force'])
 
     def test_include_easyblocks(self):
         """Test --include-easyblocks."""


### PR DESCRIPTION
fixes #1467 (and #1478, #1509)

`$EASYBUILD_IGNORECONFIGFILES` is defined in `test/framework/utilities.py` to try and make sure existing configuration files are ignored, but this is undone in a handful of tests

this patch fixes this, and isolates the tests that are potentially affected by potential (system-wide) configuration files

cc @geimer, @nathanhaigh, @jhein32: can you try applying these changes in your EasyBuild install, and verify whether this effectively isolates the tests from your system-wide configuration file?