### PR TITLE
[bugfix] only use glob in make_module_req on non-empty strings

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1067,9 +1067,13 @@ class EasyBlock(object):
                     reqs = [reqs]
 
                 for path in reqs:
-                    paths = sorted(glob.glob(path))
-                    if paths:
-                        lines.append(self.module_generator.prepend_paths(key, paths))
+                    # only use glob if the string is non-empty
+                    if path:
+                        paths = sorted(glob.glob(path))
+                    else:
+                        # empty string is a valid value here (i.e. to prepend the installation prefix, cfr $CUDA_HOME)
+                        paths = [path]
+                    lines.append(self.module_generator.prepend_paths(key, paths))
             try:
                 os.chdir(self.orig_workdir)
             except OSError, err:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -217,6 +217,19 @@ class EasyBlockTest(EnhancedTestCase):
         else:
             self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
 
+        # check for correct behaviour if empty string is specified as one of the values
+        # prepend-path statements should be included for both the 'bin' subdir and the install root
+        eb.make_module_req_guess = lambda: {'PATH': ['bin', '']}
+        txt = eb.make_module_req()
+        if get_module_syntax() == 'Tcl':
+            self.assertTrue(re.search(r"\nprepend-path\s+PATH\s+\$root/bin\n", txt, re.M))
+            self.assertTrue(re.search(r"\nprepend-path\s+PATH\s+\$root\n", txt, re.M))
+        elif get_module_syntax() == 'Lua':
+            self.assertTrue(re.search(r'\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n', txt, re.M))
+            self.assertTrue(re.search(r'\nprepend_path\("PATH", root\)\n', txt, re.M))
+        else:
+            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+
         # cleanup
         eb.close_log()
         os.remove(eb.logfile)


### PR DESCRIPTION
fix for *ancient* bug that popped up in https://github.com/hpcugent/easybuild-easyblocks/pull/758, which was introduced in #898 (March 2014!)

it managed to go undetected for a long time because only the CUDA easyblock passed empty string values via `make_module_req_guess` to `make_module_req`...

cc @damianam