### PR TITLE
Allow fixed install dir scheme

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1233,13 +1233,13 @@ class ActiveMNS(object):
 
     def det_install_subdir(self, ec):
         """Determine name of software installation subdirectory."""
+        self.log.debug("Determining software installation subdir for %s", ec)
         if build_option('fixed_installdir_naming_scheme'):
             subdir = os.path.join(ec['name'], det_full_ec_version(ec))
-            self.log.debug("Using fixed naming software installation subdir: %s (ec: %s)", subdir, ec)
+            self.log.debug("Using fixed naming software installation subdir: %s", subdir)
         else:
-            self.log.debug("Determining software installation subdir for %s", ec)
             subdir = self.mns.det_install_subdir(self.check_ec_type(ec))
-        self.log.debug("Obtained subdir %s", subdir)
+            self.log.debug("Obtained subdir %s", subdir)
         return subdir
 
     def det_devel_module_filename(self, ec, force_visible=False):

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1234,7 +1234,11 @@ class ActiveMNS(object):
     def det_install_subdir(self, ec):
         """Determine name of software installation subdirectory."""
         self.log.debug("Determining software installation subdir for %s", ec)
-        subdir = self.mns.det_install_subdir(self.check_ec_type(ec))
+        if build_option('fixed_installdir_naming_scheme'):
+            self.log.debug("Using fixed naming software installation subdir for %s", ec)
+            subdir = os.path.join(ec['name'], det_full_ec_version(ec))
+        else:
+            subdir = self.mns.det_install_subdir(self.check_ec_type(ec))
         self.log.debug("Obtained subdir %s", subdir)
         return subdir
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1233,11 +1233,11 @@ class ActiveMNS(object):
 
     def det_install_subdir(self, ec):
         """Determine name of software installation subdirectory."""
-        self.log.debug("Determining software installation subdir for %s", ec)
         if build_option('fixed_installdir_naming_scheme'):
             subdir = os.path.join(ec['name'], det_full_ec_version(ec))
             self.log.debug("Using fixed naming software installation subdir: %s (ec: %s)", subdir, ec)
         else:
+            self.log.debug("Determining software installation subdir for %s", ec)
             subdir = self.mns.det_install_subdir(self.check_ec_type(ec))
         self.log.debug("Obtained subdir %s", subdir)
         return subdir

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1236,7 +1236,7 @@ class ActiveMNS(object):
         self.log.debug("Determining software installation subdir for %s", ec)
         if build_option('fixed_installdir_naming_scheme'):
             subdir = os.path.join(ec['name'], det_full_ec_version(ec))
-            self.log.debug("Using fixed naming software installation subdir: %s (ec: %s)", subdir, ec.path)
+            self.log.debug("Using fixed naming software installation subdir: %s (ec: %s)", subdir, ec)
         else:
             subdir = self.mns.det_install_subdir(self.check_ec_type(ec))
         self.log.debug("Obtained subdir %s", subdir)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1235,8 +1235,8 @@ class ActiveMNS(object):
         """Determine name of software installation subdirectory."""
         self.log.debug("Determining software installation subdir for %s", ec)
         if build_option('fixed_installdir_naming_scheme'):
-            self.log.debug("Using fixed naming software installation subdir for %s", ec)
             subdir = os.path.join(ec['name'], det_full_ec_version(ec))
+            self.log.debug("Using fixed naming software installation subdir: %s (ec: %s)", subdir, ec.path)
         else:
             subdir = self.mns.det_install_subdir(self.check_ec_type(ec))
         self.log.debug("Obtained subdir %s", subdir)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -123,6 +123,7 @@ BUILD_OPTIONS_CMDLINE = {
         'dump_autopep8',
         'extended_dry_run',
         'experimental',
+        'fixed_installdir_naming_scheme',
         'force',
         'group_writable_installdir',
         'hidden',

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -29,10 +29,14 @@ Module naming scheme API.
 @author: Kenneth Hoste (Ghent University)
 """
 import re
+import os
+
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
 
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
+from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 
 
 class ModuleNamingScheme(object):
@@ -94,7 +98,10 @@ class ModuleNamingScheme(object):
         @return: string with name of subdirectory, e.g.: '<compiler>/<mpi_lib>/<name>/<version>'
         """
         # by default: use full module name as name for install subdir
-        return self.det_full_module_name(ec)
+        if build_option('fixed_installdir_naming_scheme'):
+            return os.path.join(ec['name'], det_full_ec_version(ec))
+        else:
+            return self.det_full_module_name(ec)
 
     def det_module_subdir(self, ec):
         """

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -29,14 +29,10 @@ Module naming scheme API.
 @author: Kenneth Hoste (Ghent University)
 """
 import re
-import os
-
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
 
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
-from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 
 
 class ModuleNamingScheme(object):
@@ -98,10 +94,7 @@ class ModuleNamingScheme(object):
         @return: string with name of subdirectory, e.g.: '<compiler>/<mpi_lib>/<name>/<version>'
         """
         # by default: use full module name as name for install subdir
-        if build_option('fixed_installdir_naming_scheme'):
-            return os.path.join(ec['name'], det_full_ec_version(ec))
-        else:
-            return self.det_full_module_name(ec)
+        return self.det_full_module_name(ec)
 
     def det_module_subdir(self, ec):
         """

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -220,6 +220,8 @@ class EasyBuildOptions(GeneralOption):
                           None, 'store', None, 'e', {'metavar': 'CLASS'}),
             'experimental': ("Allow experimental code (with behaviour that can be changed/removed at any given time).",
                              None, 'store_true', False),
+            'fixed-installdir-naming-scheme': ("Use fixed naming scheme for installation directories", None,
+                                               'store_true', False),
             'group': ("Group to be used for software installations (only verified, not set)", None, 'store', None),
             'group-writable-installdir': ("Enable group write permissions on installation directory after installation",
                                           None, 'store_true', False),


### PR DESCRIPTION
This is fix for #1535 that defaults to keeping things as they are but adds the flexibility to use a fixed install scheme which would make it trivial to switch/trial other MNS