### PR TITLE
Edge attributes for build dependencies

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -468,6 +468,10 @@ def dep_graph(filename, specs):
         all_nodes.add(spec['module'])
         spec['ec'].all_dependencies = [mk_node_name(s) for s in spec['ec'].all_dependencies]
         all_nodes.update(spec['ec'].all_dependencies)
+        
+        # Get the build dependencies for each spec so we can distinguish them later
+        spec['ec'].build_dependencies = [mk_node_name(s) for s in spec['ec']['builddependencies']]
+        all_nodes.update(spec['ec'].build_dependencies)
 
     # build directed graph
     dgr = digraph()
@@ -475,6 +479,8 @@ def dep_graph(filename, specs):
     for spec in specs:
         for dep in spec['ec'].all_dependencies:
             dgr.add_edge((spec['module'], dep))
+            if dep in spec['ec'].build_dependencies:
+                dgr.add_edge_attributes((spec['module'], dep), attrs=[('style','dotted'), ('color','blue'), ('arrowhead','diamond')])
 
     _dep_graph_dump(dgr, filename)
 


### PR DESCRIPTION
This PR adds edge attributes to build dependencies so they can be easily distinguished in the resulting dependency graph (#1545).

I have hardcoded the following attributes for build dependencies:
  * dotted edge style
  * blue colour
  * arrowhead is a diamond

Here's what the resulting graph looks like for a couple of easyconfigs:

`GNU-4.9.3-2.25`:
![gnu-4 9 3-2 25](https://cloud.githubusercontent.com/assets/2037575/12339130/2a0b8170-bb63-11e5-9dfa-8dc34dcb40a8.png)

`Pango-1.39.0-foss-2015b`:
![pango-1 39 0-foss-2015b](https://cloud.githubusercontent.com/assets/2037575/12339157/5f5ef596-bb63-11e5-9c69-dd17a4883302.png)
