### PR TITLE
skip dependencies marked as external modules when packaging

### DIFF
--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -106,9 +106,12 @@ def package_with_fpm(easyblock):
                pprint.pformat([easyblock.toolchain.as_dict()] + easyblock.cfg.dependencies()))
     depstring = ''
     for dep in deps:
-        _log.debug("The dep added looks like %s ", dep)
-        dep_pkgname = package_naming_scheme.name(dep)
-        depstring += " --depends %s" % quote_str(dep_pkgname)
+        if dep.get('external_module', False):
+            _log.debug("Skipping dep marked as external module: %s", dep['name'])
+        else:
+            _log.debug("The dep added looks like %s ", dep)
+            dep_pkgname = package_naming_scheme.name(dep)
+            depstring += " --depends %s" % quote_str(dep_pkgname)
 
     cmdlist = [
         PKG_TOOL_FPM,


### PR DESCRIPTION
fix for issue reported in https://github.com/hpcugent/easybuild/issues/188

@rjeschmi: please review?