### PR TITLE
fix syntax for set_alias statement in Lua syntax

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -495,7 +495,7 @@ class ModuleGeneratorLua(ModuleGenerator):
         Generate set-alias statement in modulefile for the given key/value pair.
         """
         # quotes are needed, to ensure smooth working of EBDEVEL* modulefiles
-        return 'setalias("%s", %s)\n' % (key, quote_str(value))
+        return 'set_alias("%s", %s)\n' % (key, quote_str(value))
 
 
 def avail_module_generators():

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -287,7 +287,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
             self.assertEqual('set-alias\tkey\t\t"va\'lue"\n', self.modgen.set_alias("key", "va'lue"))
             self.assertEqual('set-alias\tkey\t\t"""va"l\'ue"""\n', self.modgen.set_alias("key", """va"l'ue"""))
         else:
-            self.assertEqual('setalias("key", "value")\n', self.modgen.set_alias("key", "value"))
+            self.assertEqual('set_alias("key", "value")\n', self.modgen.set_alias("key", "value"))
 
     def test_load_msg(self):
         """Test including a load message in the module file."""


### PR DESCRIPTION
For lmod, correct syntax is [`set_alias()`](https://www.tacc.utexas.edu/research-development/tacc-projects/lmod/system-administrators-guide/module-commands-tutorial)