### PR TITLE
add extra test for --include-easyblocks for generic easyblocks

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1780,13 +1780,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_msg, get_easyblock_class, 'FooBar')
 
         # include extra test easyblocks
-        foo_txt = '\n'.join([
+        txt = '\n'.join([
             'from easybuild.framework.easyblock import EasyBlock',
             'class FooBar(EasyBlock):',
             '   pass',
             ''
         ])
-        write_file(os.path.join(self.test_prefix, 'generic', 'foobar.py'), foo_txt)
+        write_file(os.path.join(self.test_prefix, 'generic', 'foobar.py'), txt)
 
         args = [
             '--include-easyblocks=%s/generic/*.py' % self.test_prefix,
@@ -1806,9 +1806,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # 'undo' import of foobar easyblock
         del sys.modules['easybuild.easyblocks.generic.foobar']
-        reload(easybuild.easyblocks.generic)
-
         os.remove(os.path.join(self.test_prefix, 'generic', 'foobar.py'))
+        reload(easybuild.easyblocks.generic)
 
         error_msg = "Failed to obtain class for FooBar easyblock"
         self.assertErrorRegex(EasyBuildError, error_msg, get_easyblock_class, 'FooBar')
@@ -1817,22 +1816,28 @@ class CommandLineOptionsTest(EnhancedTestCase):
         write_file(self.logfile, '')
 
         # importing without specifying 'generic' also works, and generic easyblock can be imported as well
-        write_file(os.path.join(self.test_prefix, 'foobar.py'), foo_txt)
+        txt = '\n'.join([
+            'from easybuild.framework.easyblock import EasyBlock',
+            'class GenericTest(EasyBlock):',
+            '   pass',
+            ''
+        ])
+        write_file(os.path.join(self.test_prefix, 'generictest.py'), txt)
 
         args[0] = '--include-easyblocks=%s/*.py' % self.test_prefix
         self.eb_main(args, logfile=dummylogfn, raise_error=True)
         logtxt = read_file(self.logfile)
 
         path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks', 'easybuild', 'easyblocks',
-                                    'foobar.py')
-        foo_regex = re.compile(r"^\|-- FooBar \(easybuild.easyblocks.foobar @ %s\)"  % path_pattern, re.M)
+                                    'generictest.py')
+        foo_regex = re.compile(r"^\|-- GenericTest \(easybuild.easyblocks.generictest @ %s\)"  % path_pattern, re.M)
         self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
 
-        klass = get_easyblock_class('FooBar')
+        klass = get_easyblock_class('GenericTest')
         self.assertTrue(issubclass(klass, EasyBlock), "%s is an EasyBlock derivative class" % klass)
 
         # 'undo' import of foo easyblock
-        del sys.modules['easybuild.easyblocks.foobar']
+        del sys.modules['easybuild.easyblocks.generictest']
 
     def test_include_module_naming_schemes(self):
         """Test --include-module-naming-schemes."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1806,6 +1806,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # 'undo' import of foobar easyblock
         del sys.modules['easybuild.easyblocks.generic.foobar']
+        reload(easybuild.easyblocks.generic)
 
         os.remove(os.path.join(self.test_prefix, 'generic', 'foobar.py'))
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -44,7 +44,7 @@ import easybuild.tools.toolchain
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import BUILD, CUSTOM, DEPENDENCIES, EXTENSIONS, FILEMANAGEMENT, LICENSE
 from easybuild.framework.easyconfig import MANDATORY, MODULES, OTHER, TOOLCHAIN
-from easybuild.framework.easyconfig.easyconfig import EasyConfig
+from easybuild.framework.easyconfig.easyconfig import EasyConfig, get_easyblock_class
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import DEFAULT_MODULECLASSES
 from easybuild.tools.config import find_last_log, get_build_log_path, get_module_syntax, module_classes
@@ -1760,8 +1760,73 @@ class CommandLineOptionsTest(EnhancedTestCase):
         foo_regex = re.compile(r"^\|-- EB_foo \(easybuild.easyblocks.foo @ %s\)"  % path_pattern, re.M)
         self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
 
+        # easyblock is found via get_easyblock_class
+        klass = get_easyblock_class('EB_foo')
+        self.assertTrue(issubclass(klass, EasyBlock), "%s is an EasyBlock derivative class" % klass)
+
         # 'undo' import of foo easyblock
         del sys.modules['easybuild.easyblocks.foo']
+
+    def test_include_generic_easyblocks(self):
+        """Test --include-easyblocks with a generic easyblock."""
+        fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
+        os.close(fd)
+
+        # clear log
+        write_file(self.logfile, '')
+
+        # generic easyblock FooBar is not there initially
+        error_msg = "Failed to obtain class for FooBar easyblock"
+        self.assertErrorRegex(EasyBuildError, error_msg, get_easyblock_class, 'FooBar')
+
+        # include extra test easyblocks
+        foo_txt = '\n'.join([
+            'from easybuild.framework.easyblock import EasyBlock',
+            'class FooBar(EasyBlock):',
+            '   pass',
+            ''
+        ])
+        write_file(os.path.join(self.test_prefix, 'generic', 'foobar.py'), foo_txt)
+
+        args = [
+            '--include-easyblocks=%s/generic/*.py' % self.test_prefix,
+            '--list-easyblocks=detailed',
+            '--unittest-file=%s' % self.logfile,
+        ]
+        self.eb_main(args, logfile=dummylogfn, raise_error=True)
+        logtxt = read_file(self.logfile)
+
+        path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks', 'easybuild', 'easyblocks',
+                                    'generic', 'foobar.py')
+        foo_regex = re.compile(r"^\|-- FooBar \(easybuild.easyblocks.generic.foobar @ %s\)"  % path_pattern, re.M)
+        self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
+
+        klass = get_easyblock_class('FooBar')
+        self.assertTrue(issubclass(klass, EasyBlock), "%s is an EasyBlock derivative class" % klass)
+
+        # 'undo' import of foo easyblock
+        del sys.modules['easybuild.easyblocks.generic.foobar']
+
+        error_msg = "Failed to obtain class for FooBar easyblock"
+        self.assertErrorRegex(EasyBuildError, error_msg, get_easyblock_class, 'FooBar')
+
+        # importing without specifying 'generic' also works, and generic easyblock can be imported as well
+        write_file(os.path.join(self.test_prefix, 'foobar.py'), foo_txt)
+
+        args[0] = '--include-easyblocks=%s/*.py' % self.test_prefix
+        self.eb_main(args, logfile=dummylogfn, raise_error=True)
+        logtxt = read_file(self.logfile)
+
+        path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks', 'easybuild', 'easyblocks',
+                                    'foobar.py')
+        foo_regex = re.compile(r"^\|-- FooBar \(easybuild.easyblocks.foobar @ %s\)"  % path_pattern, re.M)
+        self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
+
+        klass = get_easyblock_class('FooBar')
+        self.assertTrue(issubclass(klass, EasyBlock), "%s is an EasyBlock derivative class" % klass)
+
+        # 'undo' import of foo easyblock
+        del sys.modules['easybuild.easyblocks.foobar']
 
     def test_include_module_naming_schemes(self):
         """Test --include-module-naming-schemes."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1804,11 +1804,16 @@ class CommandLineOptionsTest(EnhancedTestCase):
         klass = get_easyblock_class('FooBar')
         self.assertTrue(issubclass(klass, EasyBlock), "%s is an EasyBlock derivative class" % klass)
 
-        # 'undo' import of foo easyblock
+        # 'undo' import of foobar easyblock
         del sys.modules['easybuild.easyblocks.generic.foobar']
+
+        os.remove(os.path.join(self.test_prefix, 'generic', 'foobar.py'))
 
         error_msg = "Failed to obtain class for FooBar easyblock"
         self.assertErrorRegex(EasyBuildError, error_msg, get_easyblock_class, 'FooBar')
+
+        # clear log
+        write_file(self.logfile, '')
 
         # importing without specifying 'generic' also works, and generic easyblock can be imported as well
         write_file(os.path.join(self.test_prefix, 'foobar.py'), foo_txt)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1816,6 +1816,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         write_file(self.logfile, '')
 
         # importing without specifying 'generic' also works, and generic easyblock can be imported as well
+        # this works thanks to a fallback mechanism in get_easyblock_class
         txt = '\n'.join([
             'from easybuild.framework.easyblock import EasyBlock',
             'class GenericTest(EasyBlock):',


### PR DESCRIPTION
test case for an unintended yet very useful side-effect of a fallback mechanism in `get_easyblock_class`

pointed out by @gppezzi