### PR TITLE
Update gcc.py

### DIFF
--- a/easybuild/toolchains/gcc.py
+++ b/easybuild/toolchains/gcc.py
@@ -28,9 +28,10 @@ EasyBuild support for GCC compiler toolchain.
 @author: Kenneth Hoste (Ghent University)
 """
 
+from easybuild.toolchains.compiler.gcc import Gcc
 from easybuild.toolchains.gcccore import GCCcore
 
-class GccToolchain(GCCcore):
+class GccToolchain(Gcc):
     """Simple toolchain with just the GCC compilers."""
     NAME = 'GCC'
     COMPILER_MODULE_NAME = [NAME]


### PR DESCRIPTION
The old way has unintended consequences like including libs from GCCCore compiler as well as GCC (although I wonder if that comes GCCCore being a dependency of GCC)