### PR TITLE
undefine unwanted env vars *after* setting up build environment via toolchain mechanism

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -190,6 +190,10 @@ class EasyBlock(object):
         # list of loaded modules
         self.loaded_modules = []
 
+        # dictionary of unwanted environment variables that were unset and should be restored
+        # defined when env vars are unset in prepare_step, used when env vars are restored in cleanup_step
+        self.unwanted_env_vars = {}
+
         # iterate configure/build/options
         self.iter_opts = {}
 
@@ -1505,11 +1509,11 @@ class EasyBlock(object):
         if self.dry_run:
             self.dry_run_msg("Defining build environment, based on toolchain (options) and specified dependencies...\n")
 
-        # clean environment, undefine any unwanted environment variables that may be harmful
-        self.cfg['unwanted_env_vars'] = env.unset_env_vars(self.cfg['unwanted_env_vars'])
-
         # prepare toolchain: load toolchain module and dependencies, set up build environment
         self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent)
+
+        # clean environment, undefine any unwanted environment variables that may be harmful
+        self.unwanted_env_vars = env.unset_env_vars(self.cfg['unwanted_env_vars'])
 
         # guess directory to start configure/build/install process in, and move there
         self.guess_start_dir()
@@ -1893,7 +1897,7 @@ class EasyBlock(object):
         if not build_option('cleanup_builddir'):
             self.log.info("Keeping builddir %s" % self.builddir)
 
-        env.restore_env_vars(self.cfg['unwanted_env_vars'])
+        env.restore_env_vars(self.unwanted_env_vars)
 
     def make_module_step(self, fake=False):
         """


### PR DESCRIPTION
(fix for issue reported by @ocaisa during EB telco, cfr. https://github.com/hpcugent/easybuild/wiki/Conference-call-notes-20160120#other)

This is a backwards incompatible change, so I'd love feedback on this.

Currently, `unwanted_env_vars` is only used in two places: the easyblocks for GCC and imkl; neither should be affected by this:

* GCC is normally built with dummy toolchain, where no build env is set up by `toolchain.prepare()`
* for `imkl` only `$IMKLROOT` is undefined, which should not get defined/changed by `toolchain.prepare()`

I couldn't find any easyconfig files where this is used, but some EasyBuild users may be using `unwanted_env_vars` in their own 'private' easyconfig files...

Feedback from @wpoely86 would be nice, since he originally implemented the support for `unwanted_env_vars` (in fact, it was his first (framework?) contribution), cfr. https://github.com/hpcugent/easybuild-framework/pull/673.