### PR TITLE
fix test_modules_tool_stateless unit test for stateless ModulesTool with Lmod as modules tool

### DIFF
--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -334,6 +334,9 @@ class ModulesTest(EnhancedTestCase):
         """Check whether ModulesTool instance is stateless between runs."""
         test_modules_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
 
+        # copy GCC modules; Lmod will be aware they're there outside of $MODULEPATH
+        shutil.copytree(os.path.join(test_modules_path, 'GCC'), os.path.join(self.test_prefix, 'GCC'))
+
         # copy test Core/Compiler modules, we need to rewrite the 'module use' statement in the one we're going to load
         shutil.copytree(os.path.join(test_modules_path, 'Core'), os.path.join(self.test_prefix, 'Core'))
         shutil.copytree(os.path.join(test_modules_path, 'Compiler'), os.path.join(self.test_prefix, 'Compiler'))
@@ -352,6 +355,7 @@ class ModulesTest(EnhancedTestCase):
         # force reset of any singletons by reinitiating config
         init_config()
 
+        os.environ['MODULEPATH_ROOT'] = self.test_prefix
         os.environ['MODULEPATH'] = os.path.join(self.test_prefix, 'Core')
         modtool = modules_tool()
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -392,8 +392,9 @@ class ModulesTest(EnhancedTestCase):
 
         # OpenMPI/1.6.4 is *not* available with current $MODULEPATH (loaded GCC/4.7.2 was not a hierarchical module)
         if isinstance(modtool, Lmod):
-            # OpenMPI/1.6.4 exists, but is not available for load
-            load_err_msg = r"These module\(s\) exist but cannot be"
+            # OpenMPI/1.6.4 exists, but is not available for load;
+            # exact error message depends on Lmod version
+            load_err_msg = r"These module\(s\) exist but cannot be|The following module\(s\) are unknown"
         else:
             load_err_msg = "Unable to locate a modulefile"
 


### PR DESCRIPTION
fix for #1539

I'd love to hear @rtmclay's thoughts on this, I'm not 100% sure this is correct.

The problem reported in #1539 doens't seem to be very reproducible.... Suddenly, it becomes very hard to reproduce, seemingly after Lmod throwing the expected error once.

I'm not sure why that happens, it seems like Lmod is remembering stuff somewhere?