### PR TITLE
Revert "easybuild is a namespace package"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,5 +111,4 @@ implement support for installing particular (groups of) software packages.""",
     extras_require = {
         'yeb': ["PyYAML >= 3.11"],
     },
-    namespace_packages=['easybuild'],
 )


### PR DESCRIPTION
This reverts commit f6f96be40b53cdf4cde6fe0e044d6f107eebbd44 (cfr. #1591)

When `python setup.py install` is used, this error is thrown:

```
error: Namespace package problem: easybuild is a namespace package, but its
__init__.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.)
```