### PR TITLE
define HOME constant that can be used in easyconfig files

### DIFF
--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -30,6 +30,7 @@ be used within an Easyconfig file.
 @author: Stijn De Weirdt (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
+import os
 import platform
 from vsc.utils import fancylogger
 
@@ -43,10 +44,11 @@ EXTERNAL_MODULE_MARKER = 'EXTERNAL_MODULE'
 # constants that can be used in easyconfig
 EASYCONFIG_CONSTANTS = {
     'EXTERNAL_MODULE': (EXTERNAL_MODULE_MARKER, "External module marker"),
-    'SYS_PYTHON_VERSION': (platform.python_version(), "System Python version (platform.python_version())"),
+    'HOME': (os.path.expanduser('~'), "Home directory ($HOME)"),
     'OS_TYPE': (get_os_type(), "System type (e.g. 'Linux' or 'Darwin')"),
     'OS_NAME': (get_os_name(), "System name (e.g. 'fedora' or 'RHEL')"),
     'OS_VERSION': (get_os_version(), "System version"),
+    'SYS_PYTHON_VERSION': (platform.python_version(), "System Python version (platform.python_version())"),
 }
 
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -762,6 +762,7 @@ class EasyConfigTest(EnhancedTestCase):
                 'Perl: %%(perlver)s, %%(perlshortver)s',
                 'R: %%(rver)s, %%(rshortver)s',
             ]),
+            'license_file = HOME + "/licenses/PI/license.txt"',
         ]) % inp
         self.prep()
         eb = EasyConfig(self.eb_file, validate=False)
@@ -779,6 +780,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb['sanity_check_paths']['dirs'][0], 'libfoo.%s' % get_shared_lib_ext())
         self.assertEqual(eb['homepage'], "http://example.com/P/p")
         self.assertEqual(eb['modloadmsg'], "Java: 1.7.80, 1.7; Python: 2.7.10, 2.7; Perl: 5.22.0, 5.22; R: 3.2.3, 3.2")
+        self.assertEqual(eb['license_file'], os.path.join(os.environ['HOME'], 'licenses', 'PI', 'license.txt'))
 
         # test the escaping insanity here (ie all the crap we allow in easyconfigs)
         eb['description'] = "test easyconfig % %% %s% %%% %(name)s %%(name)s %%%(name)s %%%%(name)s"


### PR DESCRIPTION
This will allow use to get rid of `import os; os.environ['HOME']` in easyconfig files...