### PR TITLE
add support for --show-current-config (REVIEW)

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -93,7 +93,11 @@ _log = fancylogger.getLogger('options', fname=False)
 
 
 def cleanup_and_exit(tmpdir):
-    """Clean up temporary directory and exit."""
+    """
+    Clean up temporary directory and exit.
+
+    @param tmpdir: path to temporary directory to clean up
+    """
     try:
         shutil.rmtree(tmpdir)
     except OSError as err:
@@ -102,7 +106,11 @@ def cleanup_and_exit(tmpdir):
     sys.exit(0)
 
 def pretty_print_opts(opts_dict):
-    """Pretty print options dict."""
+    """
+    Pretty print options dict.
+
+    @param opts_dict: dictionary with option names as keys, and (value, location) tuples as values
+    """
 
     # rewrite option names/values a bit for pretty printing
     for opt in sorted(opts_dict):

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -113,13 +113,10 @@ def pretty_print_opts(opts_dict):
         elif isinstance(opt_val, list):
             opt_val = ', '.join(opt_val)
 
-        del opts_dict[opt]
-        opt = opt.replace('_', '-')
         opts_dict[opt] = (opt_val, loc)
 
-    # determine max width or option names/values
+    # determine max width or option names
     nwopt = max([len(opt) for opt in opts_dict])
-    nwval = max([len(str(val)) for (val, _) in opts_dict.values()])
 
     # header
     lines = [
@@ -132,7 +129,7 @@ def pretty_print_opts(opts_dict):
     # add one line per retained option
     for opt in sorted(opts_dict):
         opt_val, loc = opts_dict[opt]
-        lines.append("{0:<{nwopt}} ({1:}) = {2:<{nwval}}".format(opt, loc, opt_val, nwopt=nwopt, nwval=nwval))
+        lines.append("{0:<{nwopt}} ({1:}) = {2:}".format(opt, loc, opt_val, nwopt=nwopt))
 
     print '\n'.join(lines)
 
@@ -933,42 +930,61 @@ class EasyBuildOptions(GeneralOption):
         # options that should never/always be printed
         ignore_opts = ['show_config', 'show_full_config']
         include_opts = ['buildpath', 'installpath', 'repositorypath', 'robot_paths', 'sourcepath']
+        cmdline_opts_dict = self.dict_by_prefix()
 
-        # determine option dicts by selectively disabling configuration levels
+        def det_location(opt, prefix=''):
+            """Determine location where option was defined."""
+            cur_opt_val = cmdline_opts_dict[prefix][opt]
+
+            if cur_opt_val == default_opts_dict[prefix][opt]:
+                loc = 'D'  # default value
+            elif cur_opt_val == cfgfile_opts_dict[prefix][opt]:
+                loc = 'F'  # config file
+            elif cur_opt_val == env_opts_dict[prefix][opt]:
+                loc = 'E'  # environment variable
+            else:
+                loc = 'C'  # command line option
+
+            return loc
+
         default_opts_dict = EasyBuildOptions(go_args=[], envvar_prefix=None, go_useconfigfiles=False).dict_by_prefix()
         cfgfile_opts_dict = EasyBuildOptions(go_args=[], envvar_prefix=None).dict_by_prefix()
         env_opts_dict = EasyBuildOptions(go_args=[], envvar_prefix=CONFIG_ENV_VAR_PREFIX).dict_by_prefix()
-        cmdline_opts_dict = self.dict_by_prefix()
 
-        # construct dict of non-default options
+        # options relevant to config files should always be passed,
+        # but we need to figure out first where these options were defined...
+        args = []
         opts_dict = {}
+        for opt in ['configfiles', 'ignoreconfigfiles']:
+            # add option to list of arguments to pass when figuring out configuration level for all options
+            opt_val = getattr(self.options, opt)
+            args.append('--%s=%s' % (opt, ','.join(opt_val)))
+
+            # keep track of location where this option was defined
+            is_default = opt_val == default_opts_dict[''][opt]
+            if self.options.show_full_config or opt in include_opts or not is_default:
+                opts_dict[opt] = (opt_val, det_location(opt))
+
+        # determine option dicts by selectively disabling configuration levels (but specify configfiles)
+        cfgfile_opts_dict = EasyBuildOptions(go_args=args, envvar_prefix=None).dict_by_prefix()
+        env_opts_dict = EasyBuildOptions(go_args=args, envvar_prefix=CONFIG_ENV_VAR_PREFIX).dict_by_prefix()
+
+        # construct options dict to pretty print
         for prefix in sorted(default_opts_dict):
             for opt in sorted(default_opts_dict[prefix]):
                 cur_opt_val = cmdline_opts_dict[prefix][opt]
-                is_default = cur_opt_val == default_opts_dict[prefix][opt]
 
-                if opt in ignore_opts:
+                if opt in ignore_opts or opt in opts_dict:
                     continue
 
+                is_default = cur_opt_val == default_opts_dict[prefix][opt]
                 if self.options.show_full_config or opt in include_opts or not is_default:
-
-                    # figure out where this opt was defined
-                    if is_default:
-                        loc = 'D'
-                    elif cur_opt_val == cfgfile_opts_dict[prefix][opt]:
-                        # config file
-                        loc = 'F'
-                    elif cur_opt_val == env_opts_dict[prefix][opt]:
-                        # environment variable
-                        loc = 'E'
-                    else:
-                        # command line option
-                        loc = 'C'
-
+                    loc = det_location(opt, prefix=prefix)
+                    opt = opt.replace('_', '-')
                     if prefix:
                         opt = '%s-%s' % (prefix, opt)
 
-                    opts_dict.update({opt: (cur_opt_val, loc)})
+                    opts_dict[opt] = (cur_opt_val, loc)
 
         pretty_print_opts(opts_dict)
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -958,7 +958,7 @@ class EasyBuildOptions(GeneralOption):
         for opt in ['configfiles', 'ignoreconfigfiles']:
             # add option to list of arguments to pass when figuring out configuration level for all options
             opt_val = getattr(self.options, opt)
-            args.append('--%s=%s' % (opt, ','.join(opt_val)))
+            args.append('--%s=%s' % (opt, ','.join(opt_val or [])))
 
             # keep track of location where this option was defined
             is_default = opt_val == default_opts_dict[''][opt]

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2279,8 +2279,18 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_show_config(self):
         """"Test --show-config and --show-full-config."""
-        # unset $EASYBUILD_PREFIX, to check for defaults
-        del os.environ['EASYBUILD_PREFIX']
+
+        # only retain $EASYBUILD_* environment variables we expect for this test
+        retained_eb_env_vars = [
+            'EASYBUILD_DEPRECATED',
+            'EASYBUILD_IGNORECONFIGFILES',
+            'EASYBUILD_INSTALLPATH',
+            'EASYBUILD_ROBOT_PATHS',
+            'EASYBUILD_SOURCEPATH',
+        ]
+        for key in os.environ:
+            if key.startswith('EASYBUILD_') and key not in retained_eb_env_vars:
+                del os.environ[key]
 
         cfgfile = os.path.join(self.test_prefix, 'test.cfg')
         cfgtxt = '\n'.join([

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2305,9 +2305,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"# \(C: command line argument, D: default value, E: environment variable, F: configuration file\)",
             r"#",
             r"buildpath\s* \(C\) = /weird/build/dir",
-            r"configfiles\s* \(E\) = " + cfgfile,
+            r"configfiles\s* \(E\) = .*" + cfgfile,
             r"deprecated\s* \(E\) = 10000000",
-            r"ignoreconfigfiles\s* \(E\) = ",
+            r"ignoreconfigfiles\s* \(E\) = %s" % ', '.join(os.environ['EASYBUILD_IGNORECONFIGFILES'].split(',')),
             r"installpath\s* \(E\) = " + os.path.join(self.test_prefix, 'tmp.*'),
             r"repositorypath\s* \(D\) = " + os.path.join(default_prefix, 'ebfiles_repo'),
             r"robot-paths\s* \(E\) = " + os.path.join(test_dir, 'easyconfigs'),
@@ -2315,7 +2315,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"subdir-modules\s* \(F\) = mods",
         ]
 
-        self.assertTrue(re.match('\n'.join(expected_lines), txt.strip()))
+        self.assertTrue(re.search('\n'.join(expected_lines), txt.strip()))
 
         args = ['--show-full-config', '--buildpath=/weird/build/dir']
         self.mock_stdout(True)
@@ -2325,9 +2325,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # output of --show-full-config includes additional lines for options with default values
         expected_lines.extend([
-            r"force\s* (D) = False",
-            r"module-syntax\s* (D) = Tcl",
-            r"umask\s* (D) = None",
+            r"force\s* \(D\) = False",
+            r"module-syntax\s* \(D\) = Tcl",
+            r"umask\s* \(D\) = None",
         ])
 
         for expected_line in expected_lines:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2288,7 +2288,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             'EASYBUILD_ROBOT_PATHS',
             'EASYBUILD_SOURCEPATH',
         ]
-        for key in os.environ:
+        for key in os.environ.keys():
             if key.startswith('EASYBUILD_') and key not in retained_eb_env_vars:
                 del os.environ[key]
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2293,7 +2293,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = ['--show-config', '--buildpath=/weird/build/dir']
         self.mock_stdout(True)
         self.eb_main(args, do_build=True, raise_error=True, testing=False)
-        txt = self.get_stdout()
+        txt = self.get_stdout().strip()
         self.mock_stdout(False)
 
         default_prefix = os.path.join(os.environ['HOME'], '.local', 'easybuild')
@@ -2315,7 +2315,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"subdir-modules\s* \(F\) = mods",
         ]
 
-        self.assertTrue(re.search('\n'.join(expected_lines), txt.strip()))
+        regex = re.compile('\n'.join(expected_lines))
+        self.assertTrue(regex.match(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
         args = ['--show-full-config', '--buildpath=/weird/build/dir']
         self.mock_stdout(True)


### PR DESCRIPTION
Current output only shows values for configuration options if they're different from the default values.

```
$ eb --show-current-config --prefix /tmp --installpath=$HOME/eb --job-cores=4 
#
# Current EasyBuild configuration
# [C: command line option, E: environment variable, F: configuration file]
#
buildpath      = /tmp/eb-build           [F]
installpath    = /Users/kehoste/eb       [C]
job-cores      = 4                       [C]
modules-tool   = Lmod                    [E]
optarch        = ''                      [E]
packagepath    = /tmp/packages           [C]
prefix         = /tmp                    [C]
repositorypath = /tmp/ebfiles_repo       [C]
sourcepath     = /tmp/sources            [C]
```

I'm considering to always mention some key settings, regardless of whether they still have the default value or not, e.g. installpath, buildpath, sourcepath, module naming scheme, etc.

Also needs tests.