### PR TITLE
fix --show-config in case of no config files being present

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -966,7 +966,8 @@ class EasyBuildOptions(GeneralOption):
         for opt in ['configfiles', 'ignoreconfigfiles']:
             # add option to list of arguments to pass when figuring out configuration level for all options
             opt_val = getattr(self.options, opt)
-            args.append('--%s=%s' % (opt, ','.join(opt_val or [])))
+            if opt_val:
+                args.append('--%s=%s' % (opt, ','.join(opt_val or [])))
 
             # keep track of location where this option was defined
             is_default = opt_val == default_opts_dict[''][opt]


### PR DESCRIPTION
This was overlooked in #1611.