### PR TITLE
fix fetch_easyconfigs_from_pr w.r.t. duplicate files in PRs

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -351,18 +351,24 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
 
     # obtain most recent version of patched files
     for patched_file in patched_files:
-        fn = os.path.basename(patched_file)
+        # path to patch file, incl. subdir it is in
+        fn = os.path.join(os.path.basename(os.path.dirname(patched_file)), os.path.basename(patched_file))
         sha = last_commit['sha']
         full_url = URL_SEPARATOR.join([GITHUB_RAW, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, sha, patched_file])
         _log.info("Downloading %s from %s" % (fn, full_url))
         download_file(fn, full_url, path=os.path.join(path, fn), forced=True)
 
-    all_files = [os.path.basename(x) for x in patched_files]
-    tmp_files = os.listdir(path)
+    # sanity check: make sure all patched files are downloaded
+    all_files = [os.path.join(os.path.basename(os.path.dirname(x)), os.path.basename(x)) for x in patched_files]
+
+    tmp_files = []
+    for (dirpath, _, filenames) in os.walk(path):
+        tmp_files.extend([os.path.join(os.path.basename(dirpath), f) for f in filenames])
+
     if not sorted(tmp_files) == sorted(all_files):
         raise EasyBuildError("Not all patched files were downloaded to %s: %s vs %s", path, tmp_files, all_files)
 
-    ec_files = [os.path.join(path, filename) for filename in tmp_files]
+    ec_files = [os.path.join(path, f) for f in tmp_files]
 
     return ec_files
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -352,14 +352,14 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     # obtain most recent version of patched files
     for patched_file in patched_files:
         # path to patch file, incl. subdir it is in
-        fn = os.path.join(os.path.basename(os.path.dirname(patched_file)), os.path.basename(patched_file))
+        fn = os.path.sep.join(patched_file.split(os.path.sep)[-2:])
         sha = last_commit['sha']
         full_url = URL_SEPARATOR.join([GITHUB_RAW, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, sha, patched_file])
         _log.info("Downloading %s from %s" % (fn, full_url))
         download_file(fn, full_url, path=os.path.join(path, fn), forced=True)
 
     # sanity check: make sure all patched files are downloaded
-    all_files = [os.path.join(os.path.basename(os.path.dirname(x)), os.path.basename(x)) for x in patched_files]
+    all_files = [os.path.sep.join(f.split(os.path.sep)[-2:]) for f in patched_files]
 
     tmp_files = []
     for (dirpath, _, filenames) in os.walk(path):

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -26,8 +26,9 @@
 Unit tests for talking to GitHub.
 
 @author: Jens Timmerman (Ghent University)
+@author: Kenneth Hoste (Ghent University)
 """
-
+import glob
 import os
 import re
 import shutil
@@ -122,7 +123,7 @@ class GithubTest(EnhancedTestCase):
         try:
             ec_files = gh.fetch_easyconfigs_from_pr(2481, path=tmpdir, github_user=GITHUB_TEST_ACCOUNT)
             self.assertEqual(all_ecs, sorted([os.path.basename(f) for f in ec_files]))
-            self.assertEqual(all_ecs, sorted(os.listdir(tmpdir)))
+            self.assertEqual(all_ecs, sorted([os.path.basename(f) for f in glob.glob(os.path.join(tmpdir, '*', '*'))]))
 
             # PR for EasyBuild v1.13.0 release (250+ commits, 218 files changed)
             err_msg = "PR #897 contains more than .* commits, can't obtain last commit"


### PR DESCRIPTION
some PRs include files with the same name in multiple places (e.g. patch files)

example: https://github.com/hpcugent/easybuild-easyconfigs/pull/2546

This fix makes sure that `--from-pr` can deal with it.