### PR TITLE
enhance ModulesTool.exist to also recognize partial module names

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -357,9 +357,17 @@ class ModulesTool(object):
     def exist(self, mod_names, mod_exists_regex_template=r'^\s*\S*/%s:\s*$'):
         """
         Check if modules with specified names exists.
+
+        @param mod_names: list of module names
+        @param mod_exists_regex_template: template regular expression to search 'module show' output with
         """
         def mod_exists_via_show(mod_name, partial=False):
-            """Helper function to check whether specified module name exists through 'module show'."""
+            """
+            Helper function to check whether specified module name exists through 'module show'.
+
+            @param mod_name: module name
+            @param partial: indicates whether this is a partial module name
+            """
             if partial:
                 mod_exists_regex = mod_exists_regex_template % ('%s.*' % re.escape(mod_name))
             else:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -354,25 +354,20 @@ class ModulesTool(object):
         self.log.debug("'module available %s' gave %d answers: %s" % (mod_name, len(ans), ans))
         return ans
 
-    def exist(self, mod_names, mod_exists_regex_template=r'^\s*\S*/%s:\s*$'):
+    def exist(self, mod_names, mod_exists_regex_template=r'^\s*\S*/%s.*:\s*$'):
         """
         Check if modules with specified names exists.
 
         @param mod_names: list of module names
         @param mod_exists_regex_template: template regular expression to search 'module show' output with
         """
-        def mod_exists_via_show(mod_name, partial=False):
+        def mod_exists_via_show(mod_name):
             """
             Helper function to check whether specified module name exists through 'module show'.
 
             @param mod_name: module name
-            @param partial: indicates whether this is a partial module name
             """
-            if partial:
-                mod_exists_regex = mod_exists_regex_template % ('%s.*' % re.escape(mod_name))
-            else:
-                mod_exists_regex = mod_exists_regex_template % re.escape(mod_name)
-
+            mod_exists_regex = mod_exists_regex_template % re.escape(mod_name)
             txt = self.show(mod_name)
             mod_exists_regex = re.compile(mod_exists_regex, re.M)
             return bool(mod_exists_regex.search(txt))
@@ -386,7 +381,7 @@ class ModulesTool(object):
         for (mod_name, visible) in mod_names:
             if visible:
                 # module name may be partial, so also check via 'module show' as fallback
-                mods_exist.append(mod_name in avail_mod_names or mod_exists_via_show(mod_name, partial=True))
+                mods_exist.append(mod_name in avail_mod_names or mod_exists_via_show(mod_name))
             else:
                 # hidden modules are not visible in 'avail', need to use 'show' instead
                 self.log.debug("checking whether hidden module %s exists via 'show'..." % mod_name)
@@ -876,7 +871,7 @@ class Lmod(ModulesTool):
         # module file may be either in Tcl syntax (no file extension) or Lua sytax (.lua extension);
         # the current configuration for matters little, since the module may have been installed with a different cfg;
         # Lmod may pick up both Tcl and Lua module files, regardless of the EasyBuild configuration
-        return super(Lmod, self).exist(mod_names, mod_exists_regex_template=r'^\s*\S*/%s(.lua)?:\s*$')
+        return super(Lmod, self).exist(mod_names, mod_exists_regex_template=r'^\s*\S*/%s.*(\.lua)?:\s*$')
 
 
 def get_software_root_env_var_name(name):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -369,8 +369,7 @@ class ModulesTool(object):
             """
             mod_exists_regex = mod_exists_regex_template % re.escape(mod_name)
             txt = self.show(mod_name)
-            mod_exists_regex = re.compile(mod_exists_regex, re.M)
-            return bool(mod_exists_regex.search(txt))
+            return bool(re.search(mod_exists_regex, txt, re.M))
 
 
         avail_mod_names = self.available()

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -111,11 +111,14 @@ class ModulesTest(EnhancedTestCase):
         self.init_testmods()
         self.assertEqual(self.testmods.exist(['OpenMPI/1.6.4-GCC-4.6.4']), [True])
         self.assertEqual(self.testmods.exist(['foo/1.2.3']), [False])
-        # exists should not return True for incomplete module names
-        self.assertEqual(self.testmods.exist(['GCC']), [False])
 
         # exists works on hidden modules
         self.assertEqual(self.testmods.exist(['toy/.0.0-deps']), [True])
+
+        # also partial module names work
+        self.assertEqual(self.testmods.exist(['OpenMPI']), [True])
+        # but this doesn't...
+        self.assertEqual(self.testmods.exist(['OpenMPI/1.6.4']), [False])
 
         # exists works on hidden modules in Lua syntax (only with Lmod)
         if isinstance(self.testmods, Lmod):
@@ -131,7 +134,7 @@ class ModulesTest(EnhancedTestCase):
                      'ScaLAPACK/1.8.0-gompi-1.1.0-no-OFED',
                      'ScaLAPACK/1.8.0-gompi-1.1.0-no-OFED-ATLAS-3.8.4-LAPACK-3.4.0-BLACS-1.1',
                      'Compiler/GCC/4.7.2/OpenMPI/1.6.4', 'toy/.0.0-deps']
-        self.assertEqual(self.testmods.exist(mod_names), [True, False, False, False, True, True, True])
+        self.assertEqual(self.testmods.exist(mod_names), [True, False, True, False, True, True, True])
 
     def test_load(self):
         """ test if we load one module it is in the loaded_modules """


### PR DESCRIPTION
required to be able to list partial module names as dependency when using external modules (cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/2554)