### PR TITLE
make default is_short_modname_for check less strict to support versionless external modules as deps

### DIFF
--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -158,7 +158,7 @@ class ModuleNamingScheme(object):
         Default implementation checks via a strict regex pattern, and assumes short module names are of the form:
             <name>/<version>[-<toolchain>]
         """
-        modname_regex = re.compile('^%s/\S+$' % re.escape(name))
+        modname_regex = re.compile('^%s(/\S+)?$' % re.escape(name))
         res = bool(modname_regex.match(short_modname))
 
         self.log.debug("Checking whether '%s' is a module name for software with name '%s' via regex %s: %s",

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -620,6 +620,8 @@ class ModuleGeneratorTest(EnhancedTestCase):
             ('ScaLAPACK/1.8.0-gompi-1.1.0-no-OFED-ATLAS-3.8.4-LAPACK-3.4.0-BLACS-1.1', 'BLACS', False),
             ('apps/blacs/1.1', 'BLACS', False),
             ('lib/math/BLACS-stable/1.1', 'BLACS', False),
+            # required so PrgEnv can be listed versionless as external module in Cray toolchains
+            ('PrgEnv', 'PrgEnv', True),
         ]
         for modname, softname, res in test_cases:
             if res:


### PR DESCRIPTION
required for https://github.com/hpcugent/easybuild-easyconfigs/pull/2554