### PR TITLE
fix availability check for external modules with partial module name

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1364,7 +1364,7 @@ class EasyBlock(object):
         # - if a current module can be found, skip is ok
         # -- this is potentially very dangerous
         if self.cfg['skip']:
-            if self.modules_tool.exist([self.full_mod_name])[0]:
+            if self.modules_tool.exist([self.full_mod_name], skip_avail=True)[0]:
                 self.skip = True
                 self.log.info("Module %s found." % self.full_mod_name)
                 self.log.info("Going to skip actual main build and potential existing extensions. Expert only.")

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1299,8 +1299,9 @@ def robot_find_minimal_toolchain_of_dependency(dep, parent_tc=None):
             # if necessary check if module exists
             if build_option('use_existing_modules') and not build_option('retain_all_deps'):
                 full_mod_name = ActiveMNS().det_full_module_name(newdep)
-                hidden_and_exists = newdep['hidden'] and modtool.exist([full_mod_name])[0]
-                module_exists = full_mod_name in avail_modules or hidden_and_exists
+                # fallback to checking with modtool.exist is required,
+                # for hidden modules and external modules where module name may be partial
+                module_exists = full_mod_name in avail_modules or modtool.exist([full_mod_name])[0]
             # add the toolchain to list of possibilities
             possible_toolchains.append({'toolchain': tc, 'module_exists': module_exists})
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1301,7 +1301,7 @@ def robot_find_minimal_toolchain_of_dependency(dep, parent_tc=None):
                 full_mod_name = ActiveMNS().det_full_module_name(newdep)
                 # fallback to checking with modtool.exist is required,
                 # for hidden modules and external modules where module name may be partial
-                module_exists = full_mod_name in avail_modules or modtool.exist([full_mod_name])[0]
+                module_exists = full_mod_name in avail_modules or modtool.exist([full_mod_name], skip_avail=True)[0]
             # add the toolchain to list of possibilities
             possible_toolchains.append({'toolchain': tc, 'module_exists': module_exists})
 

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -127,7 +127,9 @@ def find_resolved_modules(easyconfigs, avail_modules, retain_all_deps=False):
                 _log.debug("Retaining new dep %s in 'retain all deps' mode", dep)
                 deps.append(dep)
 
-            elif full_mod_name not in avail_modules and not (dep['hidden'] and modtool.exist([full_mod_name])[0]):
+            # fallback to checking with modtool.exist is required,
+            # for hidden modules and external modules where module name may be partial
+            elif full_mod_name not in avail_modules and not modtool.exist([full_mod_name])[0]:
                 # no module available (yet) => retain dependency as one to be resolved
                 _log.debug("No module available for dep %s, retaining it", dep)
                 deps.append(dep)

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -129,7 +129,7 @@ def find_resolved_modules(easyconfigs, avail_modules, retain_all_deps=False):
 
             # fallback to checking with modtool.exist is required,
             # for hidden modules and external modules where module name may be partial
-            elif full_mod_name not in avail_modules and not modtool.exist([full_mod_name])[0]:
+            elif full_mod_name not in avail_modules and not modtool.exist([full_mod_name], skip_avail=True)[0]:
                 # no module available (yet) => retain dependency as one to be resolved
                 _log.debug("No module available for dep %s, retaining it", dep)
                 deps.append(dep)

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -105,7 +105,7 @@ class CrayPECompiler(Compiler):
             raise EasyBuildError("Don't know which 'craype' module to load, 'optarch' build option is unspecified.")
         else:
             craype_mod_name = self.CRAYPE_MODULE_NAME_TEMPLATE % {'optarch': optarch}
-            if self.modules_tool.exist([craype_mod_name])[0]:
+            if self.modules_tool.exist([craype_mod_name], skip_avail=True)[0]:
                 self.modules_tool.load([craype_mod_name])
             else:
                 raise EasyBuildError("Necessary craype module with name '%s' is not available (optarch: '%s')",

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -298,7 +298,7 @@ class Toolchain(object):
             if self.mod_short_name is None:
                 raise EasyBuildError("Toolchain module name was not set yet (using set_module_info).")
             # check whether a matching module exists if self.mod_short_name contains a module name
-            return self.modules_tool.exist([self.mod_full_name])[0]
+            return self.modules_tool.exist([self.mod_full_name], skip_avail=True)[0]
 
     def set_options(self, options):
         """ Process toolchain options """
@@ -423,7 +423,7 @@ class Toolchain(object):
             dry_run_msg("Loading toolchain module...\n", silent=silent)
 
             # load toolchain module, or simulate load of toolchain components if it is not available
-            if self.modules_tool.exist([tc_mod])[0]:
+            if self.modules_tool.exist([tc_mod], skip_avail=True)[0]:
                 self.modules_tool.load([tc_mod])
                 dry_run_msg("module load %s" % tc_mod, silent=silent)
             else:

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -110,15 +110,20 @@ class ModulesTest(EnhancedTestCase):
         """Test if testing for module existence works."""
         self.init_testmods()
         self.assertEqual(self.testmods.exist(['OpenMPI/1.6.4-GCC-4.6.4']), [True])
+        self.assertEqual(self.testmods.exist(['OpenMPI/1.6.4-GCC-4.6.4'], skip_avail=True), [True])
         self.assertEqual(self.testmods.exist(['foo/1.2.3']), [False])
+        self.assertEqual(self.testmods.exist(['foo/1.2.3'], skip_avail=True), [False])
 
         # exists works on hidden modules
         self.assertEqual(self.testmods.exist(['toy/.0.0-deps']), [True])
+        self.assertEqual(self.testmods.exist(['toy/.0.0-deps'], skip_avail=True), [True])
 
         # also partial module names work
         self.assertEqual(self.testmods.exist(['OpenMPI']), [True])
+        self.assertEqual(self.testmods.exist(['OpenMPI'], skip_avail=True), [True])
         # but this doesn't...
         self.assertEqual(self.testmods.exist(['OpenMPI/1.6.4']), [False])
+        self.assertEqual(self.testmods.exist(['OpenMPI/1.6.4'], skip_avail=True), [False])
 
         # exists works on hidden modules in Lua syntax (only with Lmod)
         if isinstance(self.testmods, Lmod):
@@ -135,6 +140,7 @@ class ModulesTest(EnhancedTestCase):
                      'ScaLAPACK/1.8.0-gompi-1.1.0-no-OFED-ATLAS-3.8.4-LAPACK-3.4.0-BLACS-1.1',
                      'Compiler/GCC/4.7.2/OpenMPI/1.6.4', 'toy/.0.0-deps']
         self.assertEqual(self.testmods.exist(mod_names), [True, False, True, False, True, True, True])
+        self.assertEqual(self.testmods.exist(mod_names, skip_avail=True), [True, False, True, False, True, True, True])
 
     def test_load(self):
         """ test if we load one module it is in the loaded_modules """


### PR DESCRIPTION
required to make `--robot --from-pr` work on https://github.com/hpcugent/easybuild-easyconfigs/pull/2554

without this, you run into this:

```
kehoste@daint102:~> eb --from-pr 2554 -dfr
== temporary log file in case of crash /tmp/eb-SCGaNv/easybuild-nBdPrL.log
== resolving dependencies ...
ERROR: Missing modules for one or more dependencies marked as external modules: ['PrgEnv-gnu', 'PrgEnv-gnu', 'PrgEnv-cray', 'PrgEnv-cray', 'PrgEnv-intel', 'PrgEnv-intel']
```