### PR TITLE
add PrgEnv-pgi module to avoid modulecmd.tcl tripping over 'unload PrgEnv-pgi'

### DIFF
--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -46,7 +46,7 @@ from easybuild.tools.modules import Lmod, get_software_root, get_software_versio
 
 
 # number of modules included for testing purposes
-TEST_MODULES_COUNT = 75
+TEST_MODULES_COUNT = 76
 
 
 class ModulesTest(EnhancedTestCase):

--- a/test/framework/modules/PrgEnv-pgi/5.2.40
+++ b/test/framework/modules/PrgEnv-pgi/5.2.40
@@ -1,0 +1,2 @@
+#%Module
+# dummy PrgEnv-cray/5.2.40 module


### PR DESCRIPTION
fix for this failing test when `modulecmd.tcl` is used a modules tool, which requires that files for modules being unloaded are actually available (even if they're not loaded)

```
======================================================================
ERROR [0.994s]: Test independency of toolchain instances.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/framework/toolchain.py", line 743, in test_independence
    tc.prepare()
  File "easybuild/toolchains/craycce.py", line 45, in prepare
    super(CrayCCE, self).prepare(*args, **kwargs)
  File "easybuild/toolchains/compiler/craype.py", line 124, in prepare
    super(CrayPECompiler, self).prepare(*args, **kwargs)
  File "easybuild/tools/toolchain/toolchain.py", line 575, in prepare
    self._load_modules(silent=silent)
  File "easybuild/tools/toolchain/toolchain.py", line 524, in _load_modules
    self._load_toolchain_module(silent=silent)
  File "easybuild/tools/toolchain/toolchain.py", line 462, in _load_toolchain_module
    self.modules_tool.load([tc_mod])
  File "easybuild/tools/modules.py", line 428, in load
    self.run_module('load', mod)
  File "easybuild/tools/modules.py", line 764, in run_module
    return super(EnvironmentModulesTcl, self).run_module(*args, **kwargs)
  File "easybuild/tools/modules.py", line 566, in run_module
    raise EasyBuildError(line)
EasyBuildError: "+(0):ERROR:0: Unable to locate a modulefile for 'PrgEnv-pgi'"

----------------------------------------------------------------------
```