### PR TITLE
enhance logging format: remove logger name, mention location instead

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -169,7 +169,7 @@ class EasyBuildLog(fancylogger.FancyLogger):
 
 
 # set format for logger
-LOGGING_FORMAT = EB_MSG_PREFIX + ' %(asctime)s %(name)s %(levelname)s %(message)s'
+LOGGING_FORMAT = EB_MSG_PREFIX + ' %(asctime)s %(pathname)s:%(lineno)s %(levelname)s %(message)s'
 fancylogger.setLogFormat(LOGGING_FORMAT)
 
 # set the default LoggerClass to EasyBuildLog


### PR DESCRIPTION
logging format in EasyBuild v2.6.0:

```
== 2016-03-03 11:08:55,835 runpy.EB_bzip2 INFO This is easyblock EB_bzip2 from module easybuild.easyblocks.bzip2 (/Users/kehoste/work/easybuild-easyblocks/easybuild/easyblocks/b/bzip2.pyc)
...
== 2016-03-03 11:07:26,007 runpy.EB_bzip2 INFO Running method configure_step part of step configure
```

in current `develop`, this has changed to this, because of running in optimised mode (cfr. #1357):

```
== 2016-03-03 11:08:46,118 not available in optimized mode.EB_bzip2 INFO This is easyblock EB_bzip2 from module easybuild.easyblocks.bzip2 (/Users/kehoste/work/easybuild-easyblocks/easybuild/easyblocks/b/bzip2.pyo)
...
== 2016-03-03 11:07:35,524 not available in optimized mode.EB_bzip2 INFO Running method configure_step part of step configure
```

The proposed change modifies this, by removing the logger name (which is pretty useless anyway), and replacing it with the location from which the log message is sent:

```
== 2016-03-03 11:08:18,697 easybuild/framework/easyblock.py:257 INFO This is easyblock EB_bzip2 from module easybuild.easyblocks.bzip2 (/Users/kehoste/work/easybuild-easyblocks/easybuild/easyblocks/b/bzip2.pyo)
...
== 2016-03-03 11:07:12,073 easybuild/framework/easyblock.py:2056 INFO Running method configure_step part of step configure
```