### PR TITLE
Fix error when 'file' backend is not available in Python keyring

### DIFF
--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -45,7 +45,7 @@ from easybuild.tools.options import set_tmpdir
 try:
     import keyring
     keyring.set_keyring(keyring.backends.file.PlaintextKeyring())
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 # disable all logging to significantly speed up tests


### PR DESCRIPTION
On our cluster (Debian Wheezy), the 'file' backend is not available in the Python Keyring.
This causes the tests to crash with:

```
$ python -m test.framework.suite
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/mnt/gaiagpfs/users/homedirs/xbesseron/easybuild/easybuild-develop/easybuild-framework/test/framework/suite.py", line 47, in <module>
    keyring.set_keyring(keyring.backends.file.PlaintextKeyring())
AttributeError: 'module' object has no attribute 'file'
```
