### PR TITLE
raise EasyBuildError rather than ImportError in only_if_module_is_available decorator

### DIFF
--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -142,7 +142,7 @@ def only_if_module_is_available(modname, pkgname=None, url=None):
                     msg += " (provided by Python package %s, available from %s)" % (pkgname, url)
                 elif url:
                     msg += " (available from %s)" % url
-                raise ImportError(msg)
+                raise EasyBuildError("ImportError: %s", msg)
             return error
 
     return wrap

--- a/test/framework/general.py
+++ b/test/framework/general.py
@@ -35,6 +35,7 @@ from unittest import TestLoader, main
 import vsc
 
 import easybuild.framework
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file
 from easybuild.tools.utilities import only_if_module_is_available
 
@@ -84,7 +85,7 @@ class GeneralTest(EnhancedTestCase):
             pass
 
         err_pat = "required module 'nosuchmoduleoutthere' is not available.*package nosuchpkg.*pypi/nosuchpkg"
-        self.assertErrorRegex(ImportError, err_pat, bar)
+        self.assertErrorRegex(EasyBuildError, err_pat, bar)
 
         class Foo():
             @only_if_module_is_available('thisdoesnotexist', url='http://example.com')
@@ -92,7 +93,7 @@ class GeneralTest(EnhancedTestCase):
                 pass
 
         err_pat = r"required module 'thisdoesnotexist' is not available \(available from http://example.com\)"
-        self.assertErrorRegex(ImportError, err_pat, Foo().foobar)
+        self.assertErrorRegex(EasyBuildError, err_pat, Foo().foobar)
 
 
 def suite():


### PR DESCRIPTION
This ensures cleaner error messages in case a required Python package is not available, cfr. https://github.com/hpcugent/easybuild-easyconfigs/issues/2670:

Now:

```
== temporary log file in case of crash /tmp/eb-uts8ZU/easybuild-nm6hF1.log
ERROR: No module named git; required module 'git' is not available (provided by Python package GitPython, available from https://pypi.python.org/pypi/GitPython)
```

was:

```
== temporary log file in case of crash /tmp/eb-3ioxWD/easybuild-oeMsuZ.log
Traceback (most recent call last):
  File "/home/adam/.local/easybuild/software/Python/2.7.10-foss-2015b/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/home/adam/.local/easybuild/software/Python/2.7.10-foss-2015b/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/adam/.local/easybuild/software/EasyBuild/2.6.0/lib/python2.7/site-packages/easybuild_framework-2.6.0-py2.7.egg/easybuild/main.py", line 381, in <module>
    main()
  File "/home/adam/.local/easybuild/software/EasyBuild/2.6.0/lib/python2.7/site-packages/easybuild_framework-2.6.0-py2.7.egg/easybuild/main.py", line 248, in main
    new_pr(orig_paths, title=options.pr_title, descr=options.pr_descr, commit_msg=options.pr_commit_msg)
  File "/home/adam/.local/easybuild/software/EasyBuild/2.6.0/lib/python2.7/site-packages/easybuild_framework-2.6.0-py2.7.egg/easybuild/tools/utilities.py", line 145, in error
    raise ImportError(msg)
ImportError: 'gitdb' could not be found in your PYTHONPATH; required module 'git' is not available (provided by Python package GitPython, available from https://pypi.python.org/pypi/GitPython)
```

cc @verdurin