### PR TITLE
remove --experimental for tests related to --package

### DIFF
--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -154,9 +154,6 @@ class PackageTest(EnhancedTestCase):
 
     def test_check_pkg_support(self):
         """Test check_pkg_support()."""
-        # hard enable experimental
-        orig_experimental = easybuild.tools.build_log.EXPERIMENTAL
-        easybuild.tools.build_log.EXPERIMENTAL = True
 
         # clear $PATH to make sure fpm/rpmbuild can not be found
         os.environ['PATH'] = ''
@@ -171,9 +168,6 @@ class PackageTest(EnhancedTestCase):
 
         # no errors => support check passes
         check_pkg_support()
-
-        # restore
-        easybuild.tools.build_log.EXPERIMENTAL = orig_experimental
 
     def test_active_pns(self):
         """Test use of ActivePNS."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -995,7 +995,6 @@ class ToyBuildTest(EnhancedTestCase):
         pkgpath = os.path.join(self.test_prefix, 'pkgs')
 
         extra_args = [
-            '--experimental',
             '--package',
             '--package-release=321',
             '--package-tool=fpm',
@@ -1016,7 +1015,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.test_toy_build(['--packagepath=%s' % pkgpath])
         self.assertFalse(os.path.exists(pkgpath), "%s is not created without use of --package" % pkgpath)
 
-        self.test_toy_build(extra_args=['--experimental', '--package', '--skip'], verify=False)
+        self.test_toy_build(extra_args=['--package', '--skip'], verify=False)
 
         toypkg = os.path.join(pkgpath, 'toy-0.0-eb-%s.1.rpm' % EASYBUILD_VERSION)
         self.assertTrue(os.path.exists(toypkg), "%s is there" % toypkg)


### PR DESCRIPTION
Packaging support was tagged stable in v2.5.0 (cfr. #1510)