### PR TITLE
move 'declare_namespace' statement last

### DIFF
--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -73,10 +73,10 @@ subdirs = [chr(l) for l in range(ord('a'), ord('z') + 1)] + ['0']
 for subdir in subdirs:
     __path__ = pkgutil.extend_path(__path__, '%s.%s' % (__name__, subdir))
 
+del l, subdir, subdirs
+
 # extend path so Python knows this is not the only place to look for modules in this package
 pkg_resources.declare_namespace(__name__)
-
-del l, subdir, subdirs
 """
 
 

--- a/test/framework/sandbox/easybuild/easyblocks/__init__.py
+++ b/test/framework/sandbox/easybuild/easyblocks/__init__.py
@@ -1,10 +1,10 @@
 import pkg_resources
 import pkgutil
 
-pkg_resources.declare_namespace(__name__)
-
 subdirs = [chr(l) for l in range(ord('a'), ord('z') + 1)] + ['0']
 for subdir in subdirs:
     __path__ = pkgutil.extend_path(__path__, '%s.%s' % (__name__, subdir))
 
 del l, subdir, subdirs
+
+pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
I saw a weird issue pop up that is hard to reproduce, where `l` was not defined anymore when it was being deleted.

I think this is because the `delclare_namespace` was triggering the `del` in another `__init__.py`, but in the same scope...
This issue is not uncovered by the tests because it may only occur with an EasyBuild installation that was performed with `easy_install`...

This trivial change makes sure that the `del` happens before calling out to `declare_namespace`, avoiding the issue all together.

Same change was made in easyblocks companion PR to #1593, i.e. https://github.com/hpcugent/easybuild-easyblocks/pull/827