### PR TITLE
add sanity check in easybuild/__init__.py w.r.t. current working dir

### DIFF
--- a/easybuild/__init__.py
+++ b/easybuild/__init__.py
@@ -28,5 +28,14 @@ Declares EasyBuild namespace, in an extendable way.
 @author: Jens Timmerman (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
+import os
 import pkg_resources
+import sys
+
+# check whether EasyBuild is being run from a directory that contains easybuild/__init__.py;
+# that doesn't work (fails with import errors), due to weirdness to Python packaging/setuptools/namespaces
+if __path__[0] == 'easybuild':
+    sys.stderr.write("ERROR: Running EasyBuild from %s does not work (Python packaging weirdness)...\n" % os.getcwd())
+    sys.exit(1)
+
 pkg_resources.declare_namespace(__name__)


### PR DESCRIPTION
With #1593 included, running `eb` from the `easybuild-framework` cloned repo working directory fails with errors like:

```
import_available_modules: Failed to import easybuild.toolchains.cgmpich: No module named cgmpich
```

This seems to occur when the path to `easybuild-framework` and `easybuild-easyblocks` is listed in `$PYTHONPATH`, *and* you're running `eb` from either of those locations.

Since the current directory is always part of the Python search path, this basically leads to having the same path twice in the Python search path, under a different 'name' (once absolute, once relative), which seems to be screwing up things.

With a simple check in `easybuild/__init__.py`, we can exit early and explain that running `eb` from this directories doesn't work; if `eb` is being outside of these directory, `__path__` will contain an absolute path rather than only `easybuild`.