### PR TITLE
remove reload statements in include.py, since they are not required and break --include-toolchains

### DIFF
--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -174,12 +174,9 @@ def include_easyblocks(tmpdir, paths):
     sys.path.insert(0, easyblocks_path)
     fixup_namespace_packages(easyblocks_path)
 
-    # make sure easybuild.easyblocks(.generic) are imported;
-    # reload them to pick up all possible paths they may be in
+    # make sure easybuild.easyblocks(.generic)
     import easybuild.easyblocks
-    reload(easybuild.easyblocks)
     import easybuild.easyblocks.generic
-    reload(easybuild.easyblocks.generic)
 
     # hard inject location to included (generic) easyblocks into Python search path
     # only prepending to sys.path is not enough due to 'declare_namespace' in easybuild/easyblocks/__init__.py
@@ -217,7 +214,6 @@ def include_module_naming_schemes(tmpdir, paths):
     # inject path into Python search path, and reload modules to get it 'registered' in sys.modules
     sys.path.insert(0, mns_path)
     fixup_namespace_packages(mns_path)
-    reload(easybuild.tools.module_naming_scheme)
 
     # hard inject location to included module naming schemes into Python search path
     # only prepending to sys.path is not enough due to 'declare_namespace' in module_naming_scheme/__init__.py
@@ -267,11 +263,9 @@ def include_toolchains(tmpdir, paths):
 
     # reload toolchain modules and hard inject location to included toolchains into Python search path
     # only prepending to sys.path is not enough due to 'declare_namespace' in toolchains/*/__init__.py
-    reload(easybuild.toolchains)
     easybuild.toolchains.__path__.insert(0, os.path.join(toolchains_path, 'easybuild', 'toolchains'))
     for subpkg in toolchain_subpkgs:
         tcpkg = 'easybuild.toolchains.%s' % subpkg
-        reload(sys.modules[tcpkg])
         sys.modules[tcpkg].__path__.insert(0, os.path.join(toolchains_path, 'easybuild', 'toolchains', subpkg))
 
     # sanity check: verify that included toolchain modules can be imported (from expected location)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1914,10 +1914,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # TestIncludedMNS module naming scheme is not available by default
         args = [
             '--avail-module-naming-schemes',
-            '--unittest-file=%s' % self.logfile,
         ]
-        self.eb_main(args, logfile=dummylogfn, raise_error=True)
-        logtxt = read_file(self.logfile)
+        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
         self.assertFalse(mns_regex.search(logtxt), "Unexpected pattern '%s' found in: %s" % (mns_regex.pattern, logtxt))
 
         # include extra test MNS
@@ -1934,14 +1932,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             '--avail-module-naming-schemes',
             '--include-module-naming-schemes=%s/*.py' % self.test_prefix,
-            '--unittest-file=%s' % self.logfile,
         ]
-        self.eb_main(args, logfile=dummylogfn, raise_error=True)
-        logtxt = read_file(self.logfile)
+        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
         self.assertTrue(mns_regex.search(logtxt), "Pattern '%s' *not* found in: %s" % (mns_regex.pattern, logtxt))
-
-        # undo successful import
-        del sys.modules['easybuild.tools.module_naming_scheme.test_mns']
 
     def test_use_included_module_naming_scheme(self):
         """Test using an included module naming scheme."""
@@ -1995,10 +1988,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # TestIncludedCompiler is not available by default
         args = [
             '--list-toolchains',
-            '--unittest-file=%s' % self.logfile,
         ]
-        self.eb_main(args, logfile=dummylogfn, raise_error=True)
-        logtxt = read_file(self.logfile)
+        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
         self.assertFalse(tc_regex.search(logtxt), "Pattern '%s' *not* found in: %s" % (tc_regex.pattern, logtxt))
 
         # include extra test toolchain
@@ -2020,15 +2011,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             '--include-toolchains=%s/*.py,%s/*/*.py' % (self.test_prefix, self.test_prefix),
             '--list-toolchains',
-            '--unittest-file=%s' % self.logfile,
         ]
-        self.eb_main(args, logfile=dummylogfn, raise_error=True)
-        logtxt = read_file(self.logfile)
-        self.assertTrue(tc_regex.search(logtxt), "Pattern '%s' *not* found in: %s" % (tc_regex.pattern, logtxt))
-
-        # undo successful import
-        del sys.modules['easybuild.toolchains.compiler.test_comp']
-        del sys.modules['easybuild.toolchains.test_tc']
+        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
+        self.assertTrue(tc_regex.search(logtxt), "Pattern '%s' found in: %s" % (tc_regex.pattern, logtxt))
 
     def test_cleanup_tmpdir(self):
         """Test --cleanup-tmpdir."""


### PR DESCRIPTION
fix for issue reported in #1677 by @chrisacbr

The changes in the tests are required to trigger the bug being fixed.