### PR TITLE
remove unnecessary fixup_namespace_packages in include.py

### DIFF
--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -30,7 +30,6 @@ Support for including additional Python modules, for easyblocks, module naming s
 """
 import os
 import sys
-from pkg_resources import fixup_namespace_packages
 from vsc.utils import fancylogger
 
 from easybuild.tools.build_log import EasyBuildError
@@ -172,7 +171,6 @@ def include_easyblocks(tmpdir, paths):
 
     # prepend new location to Python search path
     sys.path.insert(0, easyblocks_path)
-    fixup_namespace_packages(easyblocks_path)
 
     # make sure easybuild.easyblocks(.generic)
     import easybuild.easyblocks
@@ -213,7 +211,6 @@ def include_module_naming_schemes(tmpdir, paths):
 
     # inject path into Python search path, and reload modules to get it 'registered' in sys.modules
     sys.path.insert(0, mns_path)
-    fixup_namespace_packages(mns_path)
 
     # hard inject location to included module naming schemes into Python search path
     # only prepending to sys.path is not enough due to 'declare_namespace' in module_naming_scheme/__init__.py
@@ -259,7 +256,6 @@ def include_toolchains(tmpdir, paths):
 
     # inject path into Python search path, and reload modules to get it 'registered' in sys.modules
     sys.path.insert(0, toolchains_path)
-    fixup_namespace_packages(toolchains_path)
 
     # reload toolchain modules and hard inject location to included toolchains into Python search path
     # only prepending to sys.path is not enough due to 'declare_namespace' in toolchains/*/__init__.py

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -33,7 +33,6 @@ import re
 import shutil
 import sys
 import tempfile
-from pkg_resources import fixup_namespace_packages
 from test.framework.utilities import EnhancedTestCase, init_config
 from unittest import TestLoader, main
 
@@ -628,19 +627,9 @@ class EasyBlockTest(EnhancedTestCase):
 
     def test_get_easyblock_instance(self):
         """Test get_easyblock_instance function."""
-        # adjust PYTHONPATH such that test easyblocks are found
-        testdir = os.path.abspath(os.path.dirname(__file__))
-        import easybuild
-        eb_blocks_path = os.path.join(testdir, 'sandbox')
-        if eb_blocks_path not in sys.path:
-            sys.path.append(eb_blocks_path)
-            fixup_namespace_packages(eb_blocks_path)
-            easybuild = reload(easybuild)
-
-        import easybuild.easyblocks
-        reload(easybuild.easyblocks)
-
         from easybuild.easyblocks.toy import EB_toy
+        testdir = os.path.abspath(os.path.dirname(__file__))
+
         ec = process_easyconfig(os.path.join(testdir, 'easyconfigs', 'toy-0.0.eb'))[0]
         eb = get_easyblock_instance(ec)
         self.assertTrue(isinstance(eb, EB_toy))


### PR DESCRIPTION
fix for #1678

from what I can tell, using `fixup_namespace_packages` is not needed at all in `include.py` (tests and manual experiments with the various `--include-*` options work just fine, with different setuptools versions)

also includes workaround for `setuptools` bug (https://bitbucket.org/pypa/setuptools/issues/520) in `setUp` of tests, and some cleanup in the tests

use of `fixup_namespace_packages` is only needed in the setup of the tests, to make sure all modules in `sandbox` are picked up correctly