### PR TITLE
Add option to daemonize EB

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -44,7 +44,7 @@ import traceback
 
 # IMPORTANT this has to be the first easybuild import as it customises the logging
 #  expect missing log output when this not the case!
-from easybuild.tools.build_log import EasyBuildError, init_logging, print_msg, print_error, stop_logging
+from easybuild.tools.build_log import EasyBuildError, NonTerminatingLoggerProxy, init_logging, print_msg, print_error, stop_logging
 
 import easybuild.tools.config as config
 import easybuild.tools.options as eboptions

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -168,6 +168,21 @@ class EasyBuildLog(fancylogger.FancyLogger):
         raise EasyBuildError(ebmsg, *args)
 
 
+class NonTerminatingLoggerProxy(object):
+    """
+    Monkeypatch an existing `EasyBuildLog` object so that calling
+    `.error()` does not raise an exception and terminate the program.
+    """
+    def __init__(self, logger):
+        self._logger = logger
+
+    def error(self, *args, **kwargs):
+        self._logger._error_no_raise(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._logger, name)
+
+
 # set format for logger
 LOGGING_FORMAT = EB_MSG_PREFIX + ' %(asctime)s %(filename)s:%(lineno)s %(levelname)s %(message)s'
 fancylogger.setLogFormat(LOGGING_FORMAT)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -185,6 +185,7 @@ class EasyBuildOptions(GeneralOption):
         descr = ("Basic options", "Basic runtime options for EasyBuild.")
 
         opts = OrderedDict({
+            'daemonize': ("After startup, run as a daemon in the background", None, 'store_true', False),
             'dry-run': ("Print build overview incl. dependencies (full paths)", None, 'store_true', False),
             'dry-run-short': ("Print build overview incl. dependencies (short paths)", None, 'store_true', False, 'D'),
             'extended-dry-run': ("Print build environment and (expected) build procedure that will be performed",

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ implement support for installing particular (groups of) software packages.""",
     install_requires=[
         'setuptools >= 0.6',
         "vsc-base >= 2.4.18",
+        'daemonize >= 2.4.6',
     ],
     extras_require = {
         'yeb': ["PyYAML >= 3.11"],


### PR DESCRIPTION
With the new option `--daemonize` implemented here, EB can detach itself from the controlling terminal and continue running in the background.

A PID file is written so one can kill the running daemon. Note that compilation processes, etc. will go on for a while when the daemon is killed.