### PR TITLE
Fix running test suite `test.framework.options` on my EB install

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1766,6 +1766,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_include_easyblocks(self):
         """Test --include-easyblocks."""
+        orig_local_sys_path = sys.path[:]
+
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -1787,7 +1789,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # 'undo' import of foo easyblock
         del sys.modules['easybuild.easyblocks.foo']
-        sys.path = self.orig_sys_path
+        sys.path = orig_local_sys_path
         import easybuild.easyblocks
         reload(easybuild.easyblocks)
         import easybuild.easyblocks.generic
@@ -1826,6 +1828,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_include_generic_easyblocks(self):
         """Test --include-easyblocks with a generic easyblock."""
+        orig_local_sys_path = sys.path[:]
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -1864,7 +1867,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # 'undo' import of foobar easyblock
         del sys.modules['easybuild.easyblocks.generic.foobar']
         os.remove(os.path.join(self.test_prefix, 'generic', 'foobar.py'))
-        sys.path = self.orig_sys_path
+        sys.path = orig_local_sys_path
         import easybuild.easyblocks
         reload(easybuild.easyblocks)
         import easybuild.easyblocks.generic


### PR DESCRIPTION
Actual patch by @boegel but I'm commiting it since it's on my laptop.

edit (by @boegel): to clarify: this fixes the problem where the easyblocks from the EasyBuild installation were being picked up by the `test_include_easyblocks*` tests, even though the `setUp` of each tests tries to isolate the tests from non-test easyblocks...

The problem was that the original `sys.path` is being restored in the middle of the `test_include_easyblocks*` tests, which potentially reinstated the location to non-test easyblocks in the Python search path, breaking the 2nd part of these tests.