### PR TITLE
make sure user write permissions are set after failed removal attempt

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -947,6 +947,9 @@ def rmtree2(path, n=3):
         except OSError, err:
             _log.debug("Failed to remove path %s with shutil.rmtree at attempt %d: %s" % (path, n, err))
             time.sleep(2)
+
+            # make sure write permissions are enabled on entire directory
+            adjust_permissions(path, stat.S_IWUSR, add=True, recursive=True)
     if not ok:
         raise EasyBuildError("Failed to remove path %s with shutil.rmtree, even after %d attempts.", path, n)
     else:


### PR DESCRIPTION
Sometimes performing a forced reinstallation fails because the install directory can not be removed due to some files/directories not having write permissions enabled (see for example https://github.com/hpcugent/easybuild-easyconfigs/pull/2879#issuecomment-209831991).

This change should resolve that issue.