### PR TITLE
make sure setuptools installed in stage0 is still available at end of stage1

### DIFF
--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -266,7 +266,7 @@ def stage0(tmpdir):
     return distribute_egg_dir
 
 
-def stage1(tmpdir, sourcepath):
+def stage1(tmpdir, sourcepath, distribute_egg_dir):
     """STAGE 1: temporary install EasyBuild using distribute's easy_install."""
 
     info("\n\n+++ STAGE 1: installing EasyBuild in temporary dir with easy_install...\n\n")
@@ -327,7 +327,7 @@ def stage1(tmpdir, sourcepath):
 
     # clear the Python search path, we only want the individual eggs dirs to be in the PYTHONPATH (see below)
     # this is needed to avoid easy-install.pth controlling what Python packages are actually used
-    os.environ['PYTHONPATH'] = ''
+    os.environ['PYTHONPATH'] = distribute_egg_dir
 
     # template string to inject in template easyconfig
     templates = {}
@@ -557,7 +557,7 @@ def main():
         distribute_egg_dir = stage0(tmpdir)
 
     # STAGE 1: install EasyBuild using easy_install to tmp dir
-    templates = stage1(tmpdir, sourcepath)
+    templates = stage1(tmpdir, sourcepath, distribute_egg_dir)
 
     # STAGE 2: install EasyBuild using EasyBuild (to final target installation dir)
     stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath)


### PR DESCRIPTION
fix for problem reported by @andreas-h on EasyBuild mailing list, which manifests itself as:

```
[[DEBUG]] Determining EasyBuild version using command '/usr/bin/python -c 'from easybuild.tools.version import this_is_easybuild; print(this_is_easybuild())' > /tmpx/jtmp.hilboll/tmpYppHcj/eb_version.out 2>&1'
[[ERROR]] Stage 1 failed, could not determine EasyBuild version (txt: Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmpx/jtmp.hilboll/tmpYppHcj/eb_stage1/lib/python2.7/site-packages/easybuild_easyblocks-2.7.0-py2.7.egg/easybuild/__init__.py", line 31, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
).
```

The problem is that `easybuild` is being imported without having `setuptools` (which provides `pkg_resources`) available at all.

The fix proposed in this patch makes sure that the `distribute` (basically an old version of `setuptools`) being installed in `stage0` remains available.