### PR TITLE
forcibly create target branch in --update-pr

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -603,7 +603,9 @@ def _easyconfigs_pr_common(paths, start_branch=None, pr_branch=None, target_acco
         name_version = file_info['ecs'][0].name + string.translate(file_info['ecs'][0].version, None, '-.')
         pr_branch = '%s_new_pr_%s' % (time.strftime("%Y%m%d%H%M%S"), name_version)
 
-    git_repo.create_head(pr_branch).checkout()
+    # create branch to commit to and push;
+    # use force to avoid errors if branch already exists (OK since this is a local temporary copy of the repo)
+    git_repo.create_head(pr_branch, force=True).checkout()
     _log.info("New branch '%s' created to commit files to", pr_branch)
 
     # stage


### PR DESCRIPTION
Target branch for PR may already exist, especially when `--git-working-dirs-path` is also used.

See for example fail in the tests:

```
======================================================================
ERROR [33.282s]: test_new_update_pr (test.framework.options.CommandLineOptionsTest)
Test use of --new-pr (dry run only).
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/jenkins/workspace/easybuild-framework_unit-test_hpcugent_develop-python27/test/framework/options.py", line 2322, in test_new_update_pr
    self.eb_main(args, do_build=True, raise_error=True, testing=False)
  File "/data/jenkins/workspace/easybuild-framework_unit-test_hpcugent_develop-python27/test/framework/utilities.py", line 270, in eb_main
    raise myerr
OSError: Reference at u'refs/heads/develop' does already exist, pointing to u'31a970811ede636eb58f7699c8bc1b76dfce8a4c', requested was 'f4c22aa9e199eb04cb36bb19347ccf2b8ef8e4f9'

----------------------------------------------------------------------
```