### PR TITLE
remove check whether 'easybuild' is being imported from dir that contains easybuild/__init__.py

### DIFF
--- a/easybuild/__init__.py
+++ b/easybuild/__init__.py
@@ -28,14 +28,5 @@ Declares EasyBuild namespace, in an extendable way.
 @author: Jens Timmerman (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
-import os
 import pkg_resources
-import sys
-
-# check whether EasyBuild is being run from a directory that contains easybuild/__init__.py;
-# that doesn't work (fails with import errors), due to weirdness to Python packaging/setuptools/namespaces
-if __path__[0] == 'easybuild':
-    sys.stderr.write("ERROR: Running EasyBuild from %s does not work (Python packaging weirdness)...\n" % os.getcwd())
-    sys.exit(1)
-
 pkg_resources.declare_namespace(__name__)

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -150,6 +150,10 @@ class EnhancedTestCase(_EnhancedTestCase):
                 # keep track of 'easybuild' paths to inject into sys.path later
                 sys.path.append(os.path.join(path, 'easybuild'))
 
+        # required to make sure the 'easybuild' dir in the sandbox is picked up;
+        # this relates to the other 'reload' statements below
+        reload(easybuild)
+
         # this is strictly required to make the test modules in the sandbox available, due to declare_namespace
         fixup_namespace_packages(os.path.join(testdir, 'sandbox'))
 


### PR DESCRIPTION
This reverts #1667, which was needed because of #1593, but is no longer relevant after the use of `fixup_namespace_packages ` proved not be required (cfr. #1680).