### PR TITLE
Add read permission to all installed files for everybody

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1998,13 +1998,22 @@ class EasyBlock(object):
             perms = stat.S_IWGRP | stat.S_IWOTH
             adjust_permissions(self.installdir, perms, add=False, recursive=True, relative=True, ignore_errors=True)
             self.log.info("Successfully removed write permissions recursively for group/other on install dir.")
-            # add read permissions for everybody on all files
-            perms = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-            if build_option('umask') is not None:
-                perms &= build_option('umask')
-                self.log.debug("Taking umask into account %s when adding read permissions to all files.")
+
+            # add read permissions for everybody on all files, taking into account group (if any)
+            perms = stat.S_IRUSR | stat.S_IRGRP
+            self.log.debug("Ensuring read permissions for user/group on install dir (recursively)")
+            if self.group is None:
+                perms |= stat.S_IROTH
+                self.log.debug("Also ensuring read permissions for others on install dir (no group specified)")
+
+            umask = build_option('umask')
+            if umask is not None:
+                # umask is specified as a string, so interpret it first as integer in octal, then take complement (~)
+                perms &= ~int(umask, 8)
+                self.log.debug("Taking umask '%s' into account when ensuring read permissions to install dir", umask)
+
             adjust_permissions(self.installdir, perms, add=True, recursive=True, relative=True, ignore_errors=True)
-            self.log.info("Successfully added read permissions %s recursively for everybody on install dir.", perms)
+            self.log.info("Successfully added read permissions '%s' recursively on install dir", oct(perms))
 
     def test_cases_step(self):
         """

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1998,6 +1998,10 @@ class EasyBlock(object):
             perms = stat.S_IWGRP | stat.S_IWOTH
             adjust_permissions(self.installdir, perms, add=False, recursive=True, relative=True, ignore_errors=True)
             self.log.info("Successfully removed write permissions recursively for group/other on install dir.")
+            # add read permissions for everybody on all files
+            perms = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+            adjust_permissions(self.installdir, perms, add=True, recursive=True, relative=True, ignore_errors=True)
+            self.log.info("Successfully added read permissions recursively for everybody on install dir.")
 
     def test_cases_step(self):
         """

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1999,9 +1999,12 @@ class EasyBlock(object):
             adjust_permissions(self.installdir, perms, add=False, recursive=True, relative=True, ignore_errors=True)
             self.log.info("Successfully removed write permissions recursively for group/other on install dir.")
             # add read permissions for everybody on all files
-            perms = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+            perms = (stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+            if build_option('umask') is not None:
+                perms &= build_option('umask')
+                self.log.debug("Taking umask into account %s when adding read permissions to all files.")
             adjust_permissions(self.installdir, perms, add=True, recursive=True, relative=True, ignore_errors=True)
-            self.log.info("Successfully added read permissions recursively for everybody on install dir.")
+            self.log.info("Successfully added read permissions %s recursively for everybody on install dir.", perms)
 
     def test_cases_step(self):
         """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -473,7 +473,8 @@ class ToyBuildTest(EnhancedTestCase):
             for path, correct_perms in paths_perms:
                 fullpath = glob.glob(os.path.join(self.test_installpath, *path))[0]
                 perms = os.stat(fullpath).st_mode & 0777
-                msg = "Path %s has %s permissions: %s" % (fullpath, oct(correct_perms), oct(perms))
+                tup = (fullpath, oct(correct_perms), oct(perms), umask, cfg_group, ec_group)
+                msg = "Path %s has %s permissions: %s (umask: %s, group: %s - %s)" % tup
                 self.assertEqual(perms, correct_perms, msg)
                 if group is not None:
                     path_gid = os.stat(fullpath).st_gid


### PR DESCRIPTION
If nothing is specified, all installed files will have read permissions
for everybody.

edit: we ran into this with VarScan, where the `.jar` was only readable for the install user