### PR TITLE
unset $PYTHONPATH in before tested bootstrapped EasyBuild module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,4 +69,7 @@ script:
     - cd $HOME
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID
+    # unset $PYTHONPATH to avoid mixing two EasyBuild 'installations' when testing bootstrapped EasyBuild module
+    - unset PYTHONPATH
+    # simply sanity check on bootstrapped EasyBuild module
     - module use /tmp/$TRAVIS_JOB_ID/modules/all; module load EasyBuild; eb --version


### PR DESCRIPTION
This avoids weird errors like:

```
$ module use /tmp/$TRAVIS_JOB_ID/modules/all; module load EasyBuild; eb --version
/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/git/odict.py:8: UserWarning: git-python needs the ordereddict module installed in python below 2.6 and below.
  warnings.warn("git-python needs the ordereddict module installed in python below 2.6 and below.")
/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/git/odict.py:9: UserWarning: Using standard dictionary as substitute, and cause reordering when writing git config
  warnings.warn("Using standard dictionary as substitute, and cause reordering when writing git config")
Couldn't import dot_parser, loading of dot files will not be possible.
Traceback (most recent call last):
  File "/opt/python/2.6.9/lib/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/python/2.6.9/lib/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/home/travis/build/hpcugent/easybuild-framework/easybuild/main.py", line 50, in <module>
    import easybuild.tools.options as eboptions
  File "/tmp/126323054/software/EasyBuild/2.7.0/lib/python2.6/site-packages/easybuild_framework-2.7.0-py2.6.egg/easybuild/tools/options.py", line 46, in <module>
    from easybuild.framework.easyblock import MODULE_ONLY_STEPS, SOURCE_STEP, EasyBlock
  File "/home/travis/build/hpcugent/easybuild-framework/easybuild/framework/easyblock.py", line 75, in <module>
    from easybuild.tools.modules import invalidate_module_caches_for, get_software_root, get_software_root_env_var_name
ImportError: cannot import name invalidate_module_caches_for
```

(occurred in tests for #1742)