### PR TITLE
change to install dir rather than buildpath in sanity check of extension, latter may not exist

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -118,9 +118,9 @@ class Extension(object):
         """
 
         try:
-            os.chdir(build_path())
+            os.chdir(self.master.installdir)
         except OSError, err:
-            raise EasyBuildError("Failed to change directory: %s", err)
+            raise EasyBuildError("Failed to change %s: %s", self.master.installdir, err)
 
         # disabling templating is required here to support legacy string templates like name/version
         self.cfg.enable_templating = False


### PR DESCRIPTION
ran into this when installing something with `buildininstalldir = True` on a system where the parent build path in /tmp was not created yet...

we also change to the install dir in the `sanity_check_step` in `easyblock.py`