### PR TITLE
add support for 'eb --check-conflicts'

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -227,11 +227,13 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # software name/version, toolchain name/version, extra patches, ...
     (try_to_generate, build_specs) = process_software_build_specs(options)
 
+    search_query = options.search or options.search_filename or options.search_short
+
     # determine robot path
     # --try-X, --dep-graph, --search use robot path for searching, so enable it with path of installed easyconfigs
     tweaked_ecs = try_to_generate and build_specs
     tweaked_ecs_path, pr_path = alt_easyconfig_paths(eb_tmpdir, tweaked_ecs=tweaked_ecs, from_pr=options.from_pr)
-    auto_robot = try_to_generate or options.dep_graph or options.search or options.search_short
+    auto_robot = try_to_generate or options.check_conflicts or options.dep_graph or search_query
     robot_path = det_robot_path(options.robot_paths, tweaked_ecs_path, pr_path, auto_robot=auto_robot)
     _log.debug("Full robot path: %s" % robot_path)
 
@@ -266,9 +268,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         _log.debug("Packaging not enabled, so not checking for packaging support.")
 
     # search for easyconfigs, if a query is specified
-    query = options.search or options.search_filename or options.search_short
-    if query:
-        search_easyconfigs(query, short=options.search_short, filename_only=options.search_filename,
+    if search_query:
+        search_easyconfigs(search_query, short=options.search_short, filename_only=options.search_filename,
                            terse=options.terse)
 
     # GitHub integration
@@ -292,8 +293,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         _log.warning("Failed to determine install path for easybuild-easyconfigs package.")
 
     # command line options that do not require any easyconfigs to be specified
-    no_ec_opts = [options.aggregate_regtest, options.new_pr, options.review_pr, options.search,
-                  options.search_filename, options.search_short, options.regtest, options.update_pr]
+    no_ec_opts = [options.aggregate_regtest, options.new_pr, options.review_pr, search_query,
+                  options.regtest, options.update_pr]
 
     # determine paths to easyconfigs
     paths = det_easyconfig_paths(orig_paths)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -339,7 +339,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
             print_error("One or more conflicts detected!")
             sys.exit(1)
         else:
-            print_msg("No conflicts detected.")
+            print_msg("\nNo conflicts detected!\n", prefix=False)
 
     # dump source script to set up build environment
     if options.dump_env_script:

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -317,7 +317,8 @@ def init_build_options(build_options=None, cmdline_options=None):
             cmdline_options.force = True
             retain_all_deps = True
 
-        auto_ignore_osdeps_options = [cmdline_options.dep_graph, cmdline_options.dry_run, cmdline_options.dry_run_short,
+        auto_ignore_osdeps_options = [cmdline_options.check_conflicts, cmdline_options.dep_graph,
+                                      cmdline_options.dry_run, cmdline_options.dry_run_short,
                                       cmdline_options.extended_dry_run, cmdline_options.dump_env_script]
         if any(auto_ignore_osdeps_options):
             _log.info("Ignoring OS dependencies for --dep-graph/--dry-run")

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -400,6 +400,7 @@ class EasyBuildOptions(GeneralOption):
             'avail-easyconfig-templates': (("Show all template names and template constants "
                                             "that can be used in easyconfigs"),
                                            None, 'store_true', False),
+            'check-conflicts': ("Check for version conflicts in dependency graphs", None, 'store_true', False),
             'dep-graph': ("Create dependency graph", None, 'store', None, {'metavar': 'depgraph.<ext>'}),
             'dump-env-script': ("Dump source script to set up build environment based on toolchain/dependencies",
                                 None, 'store_true', False),

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -66,7 +66,13 @@ def det_robot_path(robot_paths_option, tweaked_ecs_path, pr_path, auto_robot=Fal
 
 
 def check_conflicts(easyconfigs, modtool):
-    """Check for conflicts in dependency graphs for specified easyconfigs."""
+    """
+    Check for conflicts in dependency graphs for specified easyconfigs.
+
+    @param easyconfigs: list of easyconfig files (EasyConfig instances) to check for conflicts
+    @param modtool: ModulesTool instance to use
+    @return: True if one or more conflicts were found, False otherwise
+    """
 
     ordered_ecs = resolve_dependencies(easyconfigs, modtool, retain_all_deps=True)
 

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -33,8 +33,11 @@ Dependency resolution functionality, a.k.a. robot.
 @author: Toon Willems (Ghent University)
 @author: Ward Poelmans (Ghent University)
 """
+import copy
 import os
+import sys
 from vsc.utils import fancylogger
+from vsc.utils.missing import nub
 
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS, process_easyconfig, robot_find_easyconfig
 from easybuild.framework.easyconfig.tools import find_resolved_modules, skip_available
@@ -60,6 +63,67 @@ def det_robot_path(robot_paths_option, tweaked_ecs_path, pr_path, auto_robot=Fal
         _log.info("Prepended list of robot search paths with %s: %s" % (pr_path, robot_path))
 
     return robot_path
+
+
+def check_conflicts(easyconfigs, modtool):
+    """Check for conflicts in dependency graphs for specified easyconfigs."""
+    ordered_ecs = resolve_dependencies(easyconfigs, modtool)
+
+    def mk_key(spec):
+        """Create key for dictionary with all dependencies."""
+        if 'ec' in spec:
+            spec = spec['ec']
+        return (spec['name'], det_full_ec_version(spec))
+
+    # construct a dictionary: (name, installver) tuple to (build) dependencies
+    deps_for = {}
+    for node in ordered_ecs:
+        # exclude external modules, since we can't check conflicts on them (we don't even know the software name)
+        build_deps = [mk_key(d) for d in node['builddependencies'] if not d.get('external_module', False)]
+        deps = [mk_key(d) for d in node['ec'].all_dependencies if not d.get('external_module', False)]
+
+        # separate runtime deps from build deps
+        runtime_deps = [d for d in deps if d not in build_deps]
+
+        deps_for[mk_key(node)] = [build_deps, runtime_deps]
+
+    # iteratively expand list of dependencies
+    last_deps_for = None
+    while deps_for != last_deps_for:
+        last_deps_for = copy.deepcopy(deps_for)
+        for (key, (build_deps, runtime_deps)) in last_deps_for.items():
+            # extend runtime dependencies with non-build dependencies of own runtime dependencies
+            for dep in runtime_deps:
+                deps_for[key][1].extend([d for d in deps_for[dep][1] if d not in deps_for[dep][0]])
+            deps_for[key][1] = sorted(nub(deps_for[key][1]))
+            # extend build dependencies with non-build dependencies of own build dependencies
+            for dep in build_deps:
+                deps_for[key][0].extend([d for d in deps_for[dep][1] if d not in deps_for[dep][0]])
+            deps_for[key][0] = sorted(nub(deps_for[key][0]))
+
+    def is_conflict((name, installver), (name1, installver1), (name2, installver2)):
+        """Check whether dependencies with given name/(install) version conflict with each other."""
+        # dependencies with the same name should have the exact same install version
+        # if not => CONFLICT!
+        conflict = name1 == name2 and installver1 != installver2
+        if conflict:
+            specname = '%s-%s' % (name, installver)
+            vs_msg = "%s-%s vs %s-%s" % (name1, installver1, name2, installver2)
+            sys.stderr.write("Conflict found for dependencies of %s: %s\n" % (specname, vs_msg))
+
+        return conflict
+
+    # for each of the easyconfigs, check whether the dependencies (incl. build deps) contain any conflicts
+    conflicts = False
+    for (key, (build_deps, runtime_deps)) in deps_for.items():
+        # also check whether module itself clashes with any of its dependencies
+        for i, dep1 in enumerate(build_deps + runtime_deps + [key]):
+            for dep2 in (build_deps + runtime_deps)[i+1:]:
+                # don't worry about conflicts between module itself and any of its build deps
+                if dep1 != key or dep2 not in build_deps:
+                    conflicts |= is_conflict(key, dep1, dep2)
+
+    return conflicts
 
 
 def dry_run(easyconfigs, modtool, short=False):

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -67,7 +67,7 @@ def det_robot_path(robot_paths_option, tweaked_ecs_path, pr_path, auto_robot=Fal
 
 def check_conflicts(easyconfigs, modtool):
     """Check for conflicts in dependency graphs for specified easyconfigs."""
-    ordered_ecs = resolve_dependencies(easyconfigs, modtool)
+    ordered_ecs = resolve_dependencies(easyconfigs, modtool, retain_all_deps=True)
 
     def mk_key(spec):
         """Create key for dictionary with all dependencies."""
@@ -114,16 +114,16 @@ def check_conflicts(easyconfigs, modtool):
         return conflict
 
     # for each of the easyconfigs, check whether the dependencies (incl. build deps) contain any conflicts
-    conflicts = False
+    res = False
     for (key, (build_deps, runtime_deps)) in deps_for.items():
         # also check whether module itself clashes with any of its dependencies
         for i, dep1 in enumerate(build_deps + runtime_deps + [key]):
             for dep2 in (build_deps + runtime_deps)[i+1:]:
                 # don't worry about conflicts between module itself and any of its build deps
                 if dep1 != key or dep2 not in build_deps:
-                    conflicts |= is_conflict(key, dep1, dep2)
+                    res |= is_conflict(key, dep1, dep2)
 
-    return conflicts
+    return res
 
 
 def dry_run(easyconfigs, modtool, short=False):

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -944,6 +944,34 @@ class RobotTest(EnhancedTestCase):
         self.assertTrue(conflicts)
         self.assertTrue("Conflict found for dependencies of goolf-1.4.10: GCC-4.6.4 vs GCC-4.7.2" in stderr)
 
+        # conflicts between specified easyconfigs are also detected
+
+        # direct conflict on software version
+        ecs, _ = parse_easyconfigs([
+            (os.path.join(test_easyconfigs, 'GCC-4.7.2.eb'), False),
+            (os.path.join(test_easyconfigs, 'GCC-4.9.3-2.25.eb'), False),
+        ])
+        self.mock_stderr(True)
+        conflicts = check_conflicts(ecs, self.modtool)
+        stderr = self.get_stderr()
+        self.mock_stderr(False)
+
+        self.assertTrue(conflicts)
+        self.assertTrue("Conflict between (dependencies of) easyconfigs: GCC-4.7.2 vs GCC-4.9.3-2.25" in stderr)
+
+        # indirect conflict on dependencies
+        ecs, _ = parse_easyconfigs([
+            (os.path.join(test_easyconfigs, 'bzip2-1.0.6-GCC-4.9.2.eb'), False),
+            (os.path.join(test_easyconfigs, 'hwloc-1.6.2-GCC-4.6.4.eb'), False),
+        ])
+        self.mock_stderr(True)
+        conflicts = check_conflicts(ecs, self.modtool)
+        stderr = self.get_stderr()
+        self.mock_stderr(False)
+
+        self.assertTrue(conflicts)
+        self.assertTrue("Conflict between (dependencies of) easyconfigs: GCC-4.6.4 vs GCC-4.9.2" in stderr)
+
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
The code that powers the `check_conflicts` function was taken from the easyconfig test suite, where it has been in use for quite a while already in the tests, and has been successful in detecting conflicts.

When this PR is merged, I'll adjust the easyconfigs test suite to use `check_conflicts` provided by the framework...