### PR TITLE
fix chdir in sanity check for extensions

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -118,9 +118,9 @@ class Extension(object):
         """
 
         try:
-            os.chdir(self.master.installdir)
+            os.chdir(self.installdir)
         except OSError, err:
-            raise EasyBuildError("Failed to change %s: %s", self.master.installdir, err)
+            raise EasyBuildError("Failed to change %s: %s", self.installdir, err)
 
         # disabling templating is required here to support legacy string templates like name/version
         self.cfg.enable_templating = False


### PR DESCRIPTION
introduced in #1746

`self.master` is not defined for extensions that are being installed stand-alone (via `ExtensionEasyblock`), see below

`self.installdir` is always defined though, since `Extension` is only instantiated through `ExtensionEasyblock`, which ensures `self.installdir` is defined as `self.master.installdir` for extensions

```
 File "/user/scratchdelcatty/gent/gvo000/gvo00002/vsc40023/easybuild_easy_installed/lib/python2.6/site-packages/easybuild_framework-2.8.0.dev0-py2.7.egg/easybuild/main.py", line 114, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.7/site-packages/easybuild_framework-2.8.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2302, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.7/site-packages/easybuild_framework-2.8.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2218, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.7/site-packages/easybuild_framework-2.8.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2097, in run_step
    step_method(self)()
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.7/site-packages/easybuild_framework-2.8.0.dev0-py2.7.egg/easybuild/framework/extensioneasyblock.py", line 121, in sanity_check_step
    sanity_check_ok = Extension.sanity_check_step(self)
  File "/user/scratch/gent/vsc400/vsc40023/easybuild_easy_installed/lib/python2.7/site-packages/easybuild_framework-2.8.0.dev0-py2.7.egg/easybuild/framework/extension.py", line 121, in sanity_check_step
    os.chdir(self.master.installdir)
AttributeError: 'RubyGem' object has no attribute 'master'
 (at easybuild/main.py:147 in build_and_install_software)
```