### PR TITLE
translate PyPI download URL to alternate URL with a hash

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -625,6 +625,8 @@ class EasyBlock(object):
                         self.log.warning("Source URL %s is of unknown type, so ignoring it." % url)
                         continue
 
+                    # PyPI URLs may need to be converted due to change in format of these URLs,
+                    # cfr. https://bitbucket.org/pypa/pypi/issues/438
                     if PYPI_PKG_URL_PATTERN in fullurl and not is_alt_pypi_url(fullurl):
                         alt_url = derive_alt_pypi_url(fullurl)
                         if alt_url:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -64,9 +64,9 @@ from easybuild.tools.config import build_option, build_path, get_log_filename, g
 from easybuild.tools.config import install_path, log_path, package_path, source_paths
 from easybuild.tools.environment import restore_env, sanitize_env
 from easybuild.tools.filetools import DEFAULT_CHECKSUM
-from easybuild.tools.filetools import adjust_permissions, apply_patch, convert_name, download_file, encode_class_name
-from easybuild.tools.filetools import extract_file, mkdir, move_logs, read_file, rmtree2
-from easybuild.tools.filetools import write_file, compute_checksum, verify_checksum, weld_paths
+from easybuild.tools.filetools import adjust_permissions, apply_patch, convert_name, derive_alt_pypi_url
+from easybuild.tools.filetools import download_file, encode_class_name, extract_file, is_alt_pypi_url, mkdir, move_logs
+from easybuild.tools.filetools import read_file, rmtree2, write_file, compute_checksum, verify_checksum, weld_paths
 from easybuild.tools.run import run_cmd
 from easybuild.tools.jenkins import write_to_xml
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, module_generator
@@ -100,6 +100,9 @@ TEST_STEP = 'test'
 TESTCASES_STEP = 'testcases'
 
 MODULE_ONLY_STEPS = [MODULE_STEP, PREPARE_STEP, READY_STEP, SANITYCHECK_STEP]
+
+# string part of URL for Python packages on PyPI that indicates needs to be rewritten (see derive_alt_pypi_url)
+PYPI_PKG_URL_PATTERN = 'pypi.python.org/packages/source/'
 
 
 _log = fancylogger.getLogger('easyblock')
@@ -621,6 +624,14 @@ class EasyBlock(object):
                     else:
                         self.log.warning("Source URL %s is of unknown type, so ignoring it." % url)
                         continue
+
+                    if PYPI_PKG_URL_PATTERN in fullurl and not is_alt_pypi_url(fullurl):
+                        alt_url = derive_alt_pypi_url(fullurl)
+                        if alt_url:
+                            _log.debug("Using alternate PyPI URL for %s: %s", fullurl, alt_url)
+                            fullurl = alt_url
+                        else:
+                            _log.debug("Failed to derive alternate PyPI URL for %s, so retaining the original", fullurl)
 
                     if self.dry_run:
                         self.dry_run_msg("  * %s will be downloaded to %s", filename, targetpath)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -111,9 +111,6 @@ CHECKSUM_FUNCTIONS = {
     'size': lambda p: os.path.getsize(p),
 }
 
-# string part of URL for Python packages on PyPI that indicates needs to be rewritten (see derive_alt_pypi_url)
-PYPI_PKG_URL_PATTERN = 'pypi.python.org/packages/source/'
-
 
 class ZlibChecksum(object):
     """
@@ -294,16 +291,6 @@ def download_file(filename, url, path, forced=False):
         # default system timeout (used is nothing is specified) may be infinite (?)
         timeout = 10
     _log.debug("Using timeout of %s seconds for initiating download" % timeout)
-
-    # catch PyPI download URLs, and translate them;
-    # required due to the mess discussed in https://bitbucket.org/pypa/pypi/issues/438
-    if PYPI_PKG_URL_PATTERN in url and not is_alt_pypi_url(url):
-        alt_url = derive_alt_pypi_url(url)
-        if alt_url:
-            _log.debug("Using alternate PyPI URL for %s: %s", url, alt_url)
-            url = alt_url
-        else:
-            _log.debug("Failed to derive alternate PyPI URL for %s, so retaining the original", url)
 
     # make sure directory exists
     basedir = os.path.dirname(path)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -260,6 +260,7 @@ def derive_alt_pypi_url(url):
     pkg_name, pkg_source = url.strip().split('/')[-2:]
 
     # e.g. https://pypi.python.org/simple/easybuild
+    # cfr. https://wiki.python.org/moin/PyPISimple
     simple_url = 'https://pypi.python.org/simple/%s' % re.sub(r'[-_.]+', '-', pkg_name.lower())
 
     tmpdir = tempfile.mkdtemp()

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -269,7 +269,12 @@ def derive_alt_pypi_url(url):
     if res is None:
         _log.debug("Failed to download %s to determine alternate PyPI URL for %s", simple_url, pkg_source)
     else:
-        links = [a.attrib['href'] for a in ElementTree.parse(links_html).iter('a')]
+        parsed_html = ElementTree.parse(links_html)
+        if hasattr(parsed_html, 'iter'):
+            links = [a.attrib['href'] for a in parsed_html.iter('a')]
+        else:
+            links = [a.attrib['href'] for a in parsed_html.getiterator('a')]
+
         regex = re.compile('.*/packages/(?P<hash>[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60})/%s#md5.*' % pkg_source, re.M)
         for link in links:
             res = regex.match(link)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -37,6 +37,7 @@ import tempfile
 import urllib2
 from test.framework.utilities import EnhancedTestCase, init_config
 from unittest import TestLoader, main
+from urllib2 import URLError
 
 import easybuild.tools.filetools as ft
 from easybuild.tools.build_log import EasyBuildError
@@ -627,6 +628,41 @@ class FileToolsTest(EnhancedTestCase):
         del os.environ['INTEL_LICENSE_FILE']
         del os.environ['LM_LICENSE_FILE']
         self.assertEqual(ft.find_flexlm_license(lic_specs=[None]), ([], None))
+
+    def test_is_alt_pypi_url(self):
+        """Test is_alt_pypi_url() function."""
+        url = 'https://pypi.python.org/packages/source/e/easybuild/easybuild-2.7.0.tar.gz'
+        self.assertFalse(ft.is_alt_pypi_url(url))
+
+        url = url.replace('source/e/easybuild', '5b/03/e135b19fadeb9b1ccb45eac9f60ca2dc3afe72d099f6bd84e03cb131f9bf')
+        self.assertTrue(ft.is_alt_pypi_url(url))
+
+    def test_derive_alt_pypi_url(self):
+        """Test derive_alt_pypi_url() function."""
+        url = 'https://pypi.python.org/packages/source/e/easybuild/easybuild-2.7.0.tar.gz'
+        alturl = url.replace('source/e/easybuild', '5b/03/e135b19fadeb9b1ccb45eac9f60ca2dc3afe72d099f6bd84e03cb131f9bf')
+        self.assertEqual(ft.derive_alt_pypi_url(url), alturl)
+
+        # no crash on non-existing version
+        url = 'https://pypi.python.org/packages/source/e/easybuild/easybuild-0.0.0.tar.gz'
+        self.assertEqual(ft.derive_alt_pypi_url(url), None)
+
+        # no crash on non-existing package
+        url = 'https://pypi.python.org/packages/source/n/nosuchpackageonpypiever/nosuchpackageonpypiever-0.0.0.tar.gz'
+        self.assertEqual(ft.derive_alt_pypi_url(url), None)
+
+    def test_download_pypi_pkg(self):
+        """Test downloading from PyPI with old-style URLs."""
+        # this version of python-dateutil is not available under this exact URL, only via the alternate URL with a hash
+        try:
+            url = 'https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.5.3.tar.gz'
+            pkg_source = 'python-dateutil-2.5.3.tar.gz'
+            ft.download_file(pkg_source, url, os.path.join(self.test_prefix, pkg_source))
+            md5sum = ft.compute_checksum(os.path.join(self.test_prefix, pkg_source))
+            self.assertEqual(md5sum, '05ffc6d2cc85a7fd93bb245807f715ef')
+
+        except URLError, err:
+            print "Ignoring URLError '%s' in test_download_pypi_pkg" % err
 
 
 def suite():

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -651,19 +651,6 @@ class FileToolsTest(EnhancedTestCase):
         url = 'https://pypi.python.org/packages/source/n/nosuchpackageonpypiever/nosuchpackageonpypiever-0.0.0.tar.gz'
         self.assertEqual(ft.derive_alt_pypi_url(url), None)
 
-    def test_download_pypi_pkg(self):
-        """Test downloading from PyPI with old-style URLs."""
-        # this version of python-dateutil is not available under this exact URL, only via the alternate URL with a hash
-        try:
-            url = 'https://pypi.python.org/packages/source/p/python-dateutil/python-dateutil-2.5.3.tar.gz'
-            pkg_source = 'python-dateutil-2.5.3.tar.gz'
-            ft.download_file(pkg_source, url, os.path.join(self.test_prefix, pkg_source))
-            md5sum = ft.compute_checksum(os.path.join(self.test_prefix, pkg_source))
-            self.assertEqual(md5sum, '05ffc6d2cc85a7fd93bb245807f715ef')
-
-        except URLError, err:
-            print "Ignoring URLError '%s' in test_download_pypi_pkg" % err
-
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
PyPI was changed to use totally differently formatted URLs for new package versions, see also https://bitbucket.org/pypa/pypi/issues/438 .

This change implements auto-translating URLs like https://pypi.python.org/packages/source/e/easybuild/easybuild-2.7.0.tar.gz to https://pypi.python.org/packages/5b/03/e135b19fadeb9b1ccb45eac9f60ca2dc3afe72d099f6bd84e03cb131f9bf/easybuild-2.7.0.tar.gz .

This new style of URLs works for both old and new versions of Python packages, so this change should be transparent.

That is, until they utterly break things again, of course...