### PR TITLE
only load modules using short module names

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1186,16 +1186,16 @@ class EasyBlock(object):
         """
         fake_mod_path, env = fake_mod_data
         # unload module and remove temporary module directory
-        # self.full_mod_name might not be set (e.g. during unit tests)
-        if fake_mod_path and self.full_mod_name is not None:
+        # self.short_mod_name might not be set (e.g. during unit tests)
+        if fake_mod_path and self.short_mod_name is not None:
             try:
-                self.modules_tool.unload([self.full_mod_name])
-                self.modules_tool.remove_module_path(fake_mod_path)
+                self.modules_tool.unload([self.short_mod_name])
+                self.modules_tool.remove_module_path(os.path.join(fake_mod_path, self.mod_subdir))
                 rmtree2(os.path.dirname(fake_mod_path))
             except OSError, err:
                 raise EasyBuildError("Failed to clean up fake module dir %s: %s", fake_mod_path, err)
-        elif self.full_mod_name is None:
-            self.log.warning("Not unloading module, since self.full_mod_name is not set.")
+        elif self.short_mod_name is None:
+            self.log.warning("Not unloading module, since self.short_mod_name is not set.")
 
         # restore original environment
         restore_env(env)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1145,7 +1145,15 @@ class EasyBlock(object):
             if mod_paths is None:
                 mod_paths = []
             all_mod_paths = mod_paths + ActiveMNS().det_init_modulepaths(self.cfg)
-            mods = [self.full_mod_name]
+
+            if self.short_mod_name == self.full_mod_name:
+                # for flat module naming schemes, we can load the module directly
+                mods = [self.short_mod_name]
+            else:
+                # for non-flat (hierarchical) module naming schemes, we may need to load the toolchain module first
+                # to update $MODULEPATH such that the module can be loaded using the short module name
+                mods = [self.toolchain.det_short_module_name(), self.short_mod_name]
+
             self.modules_tool.load(mods, mod_paths=all_mod_paths, purge=purge, init_env=self.initial_environ)
         else:
             self.log.warning("Not loading module, since self.full_mod_name is not set.")

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -357,7 +357,13 @@ class Toolchain(object):
     def add_dependencies(self, dependencies):
         """ Verify if the given dependencies exist and add them """
         self.log.debug("add_dependencies: adding toolchain dependencies %s" % dependencies)
-        dep_mod_names = [dep['short_mod_name'] for dep in dependencies]
+
+        # use *full* module name to check existence of dependencies, since the modules may not be avaialble in the
+        # current $MODULEPATH without loading the prior dependencies in a module hierarchy
+        # (e.g. OpenMPI module may only be available after loading GCC module);
+        # when actually loading the modules for the dependencies, the *short* module name is used,
+        # see _load_dependencies_modules()
+        dep_mod_names = [dep['full_mod_name'] for dep in dependencies]
 
         # check whether modules exist
         if self.dry_run:

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -357,7 +357,7 @@ class Toolchain(object):
     def add_dependencies(self, dependencies):
         """ Verify if the given dependencies exist and add them """
         self.log.debug("add_dependencies: adding toolchain dependencies %s" % dependencies)
-        dep_mod_names = [dep['full_mod_name'] for dep in dependencies]
+        dep_mod_names = [dep['short_mod_name'] for dep in dependencies]
 
         # check whether modules exist
         if self.dry_run:

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -358,7 +358,7 @@ class Toolchain(object):
         """ Verify if the given dependencies exist and add them """
         self.log.debug("add_dependencies: adding toolchain dependencies %s" % dependencies)
 
-        # use *full* module name to check existence of dependencies, since the modules may not be avaialble in the
+        # use *full* module name to check existence of dependencies, since the modules may not be available in the
         # current $MODULEPATH without loading the prior dependencies in a module hierarchy
         # (e.g. OpenMPI module may only be available after loading GCC module);
         # when actually loading the modules for the dependencies, the *short* module name is used,

--- a/test/framework/modules/Core/goolf/1.4.10
+++ b/test/framework/modules/Core/goolf/1.4.10
@@ -9,9 +9,9 @@ proc ModulesHelp { } {
 module-whatis {Description: GNU Compiler Collection (GCC) based compiler toolchain,
  including OpenMPI for MPI support. - Homepage: (none)}
 
-set root    /tmp/software/Core/gompi/1.4.10
+set root    /tmp/software/Core/goolf/1.4.10
 
-conflict    gompi
+conflict    goolf
 
 if { ![is-loaded GCC/4.7.2] } {
     module load GCC/4.7.2
@@ -33,7 +33,7 @@ if { ![is-loaded ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2] } {
     module load ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2
 }
 
-setenv	EBROOTGOMPI		"$root"
-setenv	EBVERSIONGOMPI		"1.4.10"
-setenv	EBDEVELGOMPI		"$root/easybuild/Core-gompi-1.4.10-easybuild-devel"
+setenv	EBROOTGOOLF		"$root"
+setenv	EBVERSIONGOOLF		"1.4.10"
+setenv	EBDEVELGOOLF		"$root/easybuild/Core-goolf-1.4.10-easybuild-devel"
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -698,7 +698,7 @@ class ToyBuildTest(EnhancedTestCase):
         modtxt = read_file(toy_module_path)
         modpath_extension = os.path.join(mod_prefix, 'Compiler', 'toy', '0.0')
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search('^module\s*use\s*"%s"' % modpath_extension, modtxt, re.M))
+            self.assertTrue(re.search(r'^module\s*use\s*"%s"' % modpath_extension, modtxt, re.M))
         elif get_module_syntax() == 'Lua':
             fullmodpath_extension = os.path.join(self.test_installpath, modpath_extension)
             regex = re.compile(r'^prepend_path\("MODULEPATH", "%s"\)' % fullmodpath_extension, re.M)
@@ -708,13 +708,19 @@ class ToyBuildTest(EnhancedTestCase):
         os.remove(toy_module_path)
 
         # building a toolchain module should also work
-        args[0] = os.path.join(test_easyconfigs, 'gompi-1.4.10.eb')
-        self.modtool.purge()
-        self.eb_main(args, logfile=self.dummylogfn, do_build=True, verbose=True, raise_error=False)
         gompi_module_path = os.path.join(mod_prefix, 'Core', 'gompi', '1.4.10')
+
+        # make sure Core/gompi/1.4.10 module that may already be there is removed (both Tcl/Lua variants)
+        for modfile in glob.glob(gompi_module_path + '*'):
+            os.remove(modfile)
+
         if get_module_syntax() == 'Lua':
             gompi_module_path += '.lua'
-        self.assertTrue(os.path.exists(gompi_module_path))
+
+        args[0] = os.path.join(test_easyconfigs, 'gompi-1.4.10.eb')
+        self.modtool.purge()
+        self.eb_main(args, logfile=self.dummylogfn, do_build=True, verbose=True, raise_error=True)
+        self.assertTrue(os.path.exists(gompi_module_path), "%s found" % gompi_module_path)
 
     def test_toy_advanced(self):
         """Test toy build with extensions and non-dummy toolchain."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1082,6 +1082,51 @@ class ToyBuildTest(EnhancedTestCase):
         load1_regex = re.compile('load.*toy/0.0-one', re.M)
         self.assertTrue(load1_regex.search(mod2_txt), "Pattern '%s' found in: %s" % (load1_regex.pattern, mod2_txt))
 
+    def test_toy_sanity_check_commands(self):
+        """Test toy build with extra sanity check commands."""
+
+        self.setup_hierarchical_modules()
+
+        test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs')
+        toy_ec_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'toy-0.0.eb')
+        toy_ec_txt = read_file(os.path.join(test_easyconfigs, 'toy-0.0.eb'))
+
+        toy_ec_txt = '\n'.join([
+            toy_ec_txt,
+            "toolchain = {'name': 'goolf', 'version': '1.4.10'}",
+            # specially construct (sort of senseless) sanity check commands,
+            # that will fail if the corresponding modules are not loaded
+            # cfr. https://github.com/hpcugent/easybuild-framework/pull/1754
+            "sanity_check_commands = [",
+            "   ('env | grep EBROOTFFTW', ''),",
+            "   ('env | grep EBROOTGCC', ''),",
+            "   ('env | grep EBROOTGOOLF', ''),",
+            "]",
+        ])
+
+        tweaked_toy_ec = os.path.join(self.test_prefix, 'toy-0.0-tweaked.eb')
+        write_file(tweaked_toy_ec, toy_ec_txt)
+
+        args = [
+            tweaked_toy_ec,
+            '--sourcepath=%s' % self.test_sourcepath,
+            '--buildpath=%s' % self.test_buildpath,
+            '--installpath=%s' % self.test_installpath,
+            '--debug',
+            '--unittest-file=%s' % self.logfile,
+            '--force',
+            '--robot=%s' % test_easyconfigs,
+            '--module-naming-scheme=HierarchicalMNS',
+        ]
+        self.eb_main(args, logfile=self.dummylogfn, do_build=True, verbose=True, raise_error=True)
+
+        modpath = os.path.join(self.test_installpath, 'modules', 'all')
+        toy_modfile = os.path.join(modpath, 'MPI', 'GCC', '4.7.2', 'OpenMPI', '1.6.4', 'toy', '0.0')
+        if get_module_syntax() == 'Lua':
+            toy_modfile += '.lua'
+
+        self.assertTrue(os.path.exists(toy_modfile))
+
 
 def suite():
     """ return all the tests in this file """


### PR DESCRIPTION
This fixes a long-standing bug, which has remain hidden up until now because it only causes actual problems in particular circumstances, e.g. when running the sanity check commands during the sanity check of installing OpenMPI with a PGI toolchain when using a hierarchical module naming scheme, cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/2899. The combination of sanity check commands with a toolchain that actually corresponds to a software package (rather than just a bundle of other modules) and a hierarchical module naming scheme is required to trigger this bug...

The problem is that the temporary module that is generated and loaded at the start of the sanity check was being loaded with  the *full* name (e.g. `Compiler/GCC/4.7.2/OpenMPI/1.6.4`) rather than the *short* name (e.g. `OpenMPI/1.6.4`).

The latter requires that the module for the toolchain used to perform must be loaded first, to make sure that `$MODULEPATH` is extended properly for the load with the short name to be work, and it's exactly this missing load that was causing problems when performing the sanity check commands for OpenMPI installed on top of PGI, i.e. that the PGI compiler commands (e.g. `pgcc`) were not available in `$PATH` (because the `PGI` module wasn't actually loaded during the sanity check).

This change fixes this problem, by making sure that all `loads` performed by EasyBuild are done with the *short* module name and that `$MODULEPATH` is prepended as needed to make the temporary (fake) module loadable.

(WIP because I want to look into a dedicated test to catch this...)

cc @bartoldeman, @ocaisa, @damianam, @geimer