### PR TITLE
set $LMOD_REDIRECT to 'no' when initialising Lmod

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -887,6 +887,8 @@ class Lmod(ModulesTool):
         os.environ['LMOD_QUIET'] = '1'
         # make sure Lmod ignores the spider cache ($LMOD_IGNORE_CACHE supported since Lmod 5.2)
         os.environ['LMOD_IGNORE_CACHE'] = '1'
+        # hard disable output redirection, we expect output messages (list, avail) to always go to stderr
+        os.environ['LMOD_REDIRECT'] = 'no'
 
         super(Lmod, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
cc @wpoely86 

@rtmclay: always setting to `$LMOD_REDIRECT` to `no` to avoid Lmod redirecting output to `stdout` by issuing `echo` commands makes sense, right?

In EasyBuild, we *want* output messages to go to stderr since then we can separate them from the changes to the environment easily...