### PR TITLE
use pgCC for PGI versions prior to 16, pgc++ for PGI 16.x and newer

### DIFF
--- a/easybuild/toolchains/compiler/pgi.py
+++ b/easybuild/toolchains/compiler/pgi.py
@@ -78,7 +78,8 @@ class Pgi(Compiler):
     }
 
     COMPILER_CC = 'pgcc'
-    COMPILER_CXX = 'pgc++'
+    # C++ compiler command is version-dependent, see below
+    COMPILER_CXX = None
 
     COMPILER_F77 = 'pgf77'
     COMPILER_F90 = 'pgfortran'
@@ -94,3 +95,15 @@ class Pgi(Compiler):
         if not self.options.get('optarch', False):
             self.variables.nextend('OPTFLAGS', ['tp=x64'])
         super(Pgi, self)._set_compiler_flags()
+
+    def _set_compiler_vars(self):
+        """Set the compiler variables"""
+        pgi_version = self.get_software_version(self.COMPILER_MODULE_NAME)[0]
+
+        # for older versions of PGI, pgCC was the recommended C++ compiler
+        if LooseVersion(pgi_version) >= LooseVersion('16'):
+            self.COMPILER_CXX = 'pgc++'
+        else:
+            self.COMPILER_CXX = 'pgCC'
+
+        super(Pgi, self)._set_compiler_vars()

--- a/easybuild/toolchains/compiler/pgi.py
+++ b/easybuild/toolchains/compiler/pgi.py
@@ -100,8 +100,8 @@ class Pgi(Compiler):
         """Set the compiler variables"""
         pgi_version = self.get_software_version(self.COMPILER_MODULE_NAME)[0]
 
-        # for older versions of PGI, pgCC was the recommended C++ compiler
-        if LooseVersion(pgi_version) >= LooseVersion('16'):
+        # based on feedback from PGI support: use pgc++ with PGI 14.10 and newer, pgCC for older versions
+        if LooseVersion(pgi_version) >= LooseVersion('14.10'):
             self.COMPILER_CXX = 'pgc++'
         else:
             self.COMPILER_CXX = 'pgCC'

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -766,6 +766,32 @@ class ToolchainTest(EnhancedTestCase):
                 self.assertEqual(str(tc.variables['CFLAGS']), expected_cflags, msg)
                 self.assertEqual(os.environ['CFLAGS'], expected_cflags, msg)
 
+    def test_pgi_toolchain(self):
+        """Tests for PGI toolchain."""
+        # add dummy PGI modules to play with
+        write_file(os.path.join(self.test_prefix, 'PGI', '15.10'), '#%Module\nsetenv EBVERSIONPGI 15.10')
+        write_file(os.path.join(self.test_prefix, 'PGI', '16.3'), '#%Module\nsetenv EBVERSIONPGI 16.3')
+        self.modtool.use(self.test_prefix)
+
+        tc = self.get_toolchain('PGI', version='15.10')
+        tc.prepare()
+
+        self.assertEqual(tc.get_variable('CC'), 'pgcc')
+        self.assertEqual(tc.get_variable('CXX'), 'pgCC')
+        self.assertEqual(tc.get_variable('F77'), 'pgf77')
+        self.assertEqual(tc.get_variable('F90'), 'pgfortran')
+        self.assertEqual(tc.get_variable('FC'), 'pgfortran')
+        self.modtool.purge()
+
+        tc = self.get_toolchain('PGI', version='16.3')
+        tc.prepare()
+
+        self.assertEqual(tc.get_variable('CC'), 'pgcc')
+        self.assertEqual(tc.get_variable('CXX'), 'pgc++')
+        self.assertEqual(tc.get_variable('F77'), 'pgf77')
+        self.assertEqual(tc.get_variable('F90'), 'pgfortran')
+        self.assertEqual(tc.get_variable('FC'), 'pgfortran')
+
 
 def suite():
     """ return all the tests"""

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -769,11 +769,12 @@ class ToolchainTest(EnhancedTestCase):
     def test_pgi_toolchain(self):
         """Tests for PGI toolchain."""
         # add dummy PGI modules to play with
-        write_file(os.path.join(self.test_prefix, 'PGI', '15.10'), '#%Module\nsetenv EBVERSIONPGI 15.10')
+        write_file(os.path.join(self.test_prefix, 'PGI', '14.9'), '#%Module\nsetenv EBVERSIONPGI 14.9')
+        write_file(os.path.join(self.test_prefix, 'PGI', '14.10'), '#%Module\nsetenv EBVERSIONPGI 14.10')
         write_file(os.path.join(self.test_prefix, 'PGI', '16.3'), '#%Module\nsetenv EBVERSIONPGI 16.3')
         self.modtool.use(self.test_prefix)
 
-        tc = self.get_toolchain('PGI', version='15.10')
+        tc = self.get_toolchain('PGI', version='14.9')
         tc.prepare()
 
         self.assertEqual(tc.get_variable('CC'), 'pgcc')
@@ -783,14 +784,15 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(tc.get_variable('FC'), 'pgfortran')
         self.modtool.purge()
 
-        tc = self.get_toolchain('PGI', version='16.3')
-        tc.prepare()
+        for pgi_ver in ['14.10', '16.3']:
+            tc = self.get_toolchain('PGI', version=pgi_ver)
+            tc.prepare()
 
-        self.assertEqual(tc.get_variable('CC'), 'pgcc')
-        self.assertEqual(tc.get_variable('CXX'), 'pgc++')
-        self.assertEqual(tc.get_variable('F77'), 'pgf77')
-        self.assertEqual(tc.get_variable('F90'), 'pgfortran')
-        self.assertEqual(tc.get_variable('FC'), 'pgfortran')
+            self.assertEqual(tc.get_variable('CC'), 'pgcc')
+            self.assertEqual(tc.get_variable('CXX'), 'pgc++')
+            self.assertEqual(tc.get_variable('F77'), 'pgf77')
+            self.assertEqual(tc.get_variable('F90'), 'pgfortran')
+            self.assertEqual(tc.get_variable('FC'), 'pgfortran')
 
 
 def suite():


### PR DESCRIPTION
issue brought up by @damianam: for older versions of PGI, `pgCC` should be used rather than `pgc++`