### PR TITLE
include '-ldl' in $LIBBLAS*/* & co when linking with Intel MKL 11.x or newer

### DIFF
--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -87,8 +87,8 @@ class IntelFFTW(Fftw):
         # so make sure libraries are there before FFT_LIB is set
         imklroot = get_software_root(self.FFT_MODULE_NAME[0])
         fft_lib_dirs = [os.path.join(imklroot, d) for d in self.FFT_LIB_DIR]
-        # filter out gfortran from list of FFTW libraries to check for, since it's not provided by imkl
-        check_fftw_libs = [lib for lib in fftw_libs if lib != 'gfortran']
+        # filter out gfortran, libm, libdl from list of FFTW libraries to check for, since they're not provided by imkl
+        check_fftw_libs = [lib for lib in fftw_libs if lib not in ['dl', 'gfortran', 'm']]
         fftw_lib_exists = lambda x: any([os.path.exists(os.path.join(d, "lib%s.a" % x)) for d in fft_lib_dirs])
         if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
             self.FFT_LIB = fftw_libs

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -87,8 +87,8 @@ class IntelFFTW(Fftw):
         # so make sure libraries are there before FFT_LIB is set
         imklroot = get_software_root(self.FFT_MODULE_NAME[0])
         fft_lib_dirs = [os.path.join(imklroot, d) for d in self.FFT_LIB_DIR]
-        # filter out gfortran, libm, libdl from list of FFTW libraries to check for, since they're not provided by imkl
-        check_fftw_libs = [lib for lib in fftw_libs if lib not in ['dl', 'gfortran', 'm']]
+        # filter out libraries from list of FFTW libraries to check for if they are not provided by Intel MKL
+        check_fftw_libs = [lib for lib in fftw_libs if lib not in ['dl', 'gfortran']]
         fftw_lib_exists = lambda x: any([os.path.exists(os.path.join(d, "lib%s.a" % x)) for d in fft_lib_dirs])
         if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
             self.FFT_LIB = fftw_libs

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -83,17 +83,17 @@ class IntelMKL(LinAlg):
     def set_variables(self):
         """Set the variables"""
 
-        # for recent versions of Intel MKL, -lm -ldl should be used for linking
-        # according to the Intel MKL Link Advisor, this should always be done,
-        # but it only seems to be strictly required for certain compilers
+        # for recent versions of Intel MKL, -ldl should be used for linking
+        # the Intel MKL Link Advisor specifies to always do this,
+        # but it is only needed when statically linked with Intel MKL,
+        # and only strictly needed for some compilers (e.g. PGI)
         mkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         if LooseVersion(mkl_version) >= LooseVersion('11'):
-        #if LooseVersion(mkl_version) >= LooseVersion('11') and self.COMPILER_FAMILY in [TC_CONSTANT_PGI]:
-            math_libs = ['m', 'dl']
+            self.log.info("Adding -ldl as extra library when linking with Intel MKL libraries (for v11.x and newer)")
             if self.LIB_EXTRA is None:
-                self.LIB_EXTRA = math_libs
-            else:
-                self.LIB_EXTRA.extend([l for l in math_libs if l not in self.LIB_EXTRA])
+                self.LIB_EXTRA = ['dl']
+            elif 'dl' not in self.LIB_EXTRA:
+                self.LIB_EXTRA.append('dl')
 
         super(IntelMKL, self).set_variables()
 

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -84,13 +84,16 @@ class IntelMKL(LinAlg):
         """Set the variables"""
 
         # for recent versions of Intel MKL, -lm -ldl should be used for linking
+        # according to the Intel MKL Link Advisor, this should always be done,
+        # but it only seems to be strictly required for certain compilers
         mkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         if LooseVersion(mkl_version) >= LooseVersion('11'):
+        #if LooseVersion(mkl_version) >= LooseVersion('11') and self.COMPILER_FAMILY in [TC_CONSTANT_PGI]:
             math_libs = ['m', 'dl']
-            if self.LIB_MATH is None:
-                self.LIB_MATH = math_libs
+            if self.LIB_EXTRA is None:
+                self.LIB_EXTRA = math_libs
             else:
-                self.LIB_MATH.extend([l for l in math_libs if l not in self.LIB_MATH])
+                self.LIB_EXTRA.extend([l for l in math_libs if l not in self.LIB_EXTRA])
 
         super(IntelMKL, self).set_variables()
 

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -80,6 +80,20 @@ class IntelMKL(LinAlg):
         class_constants.extend(['BLAS_LIB_MAP', 'SCALAPACK_LIB', 'SCALAPACK_LIB_MT', 'SCALAPACK_LIB_MAP'])
         super(IntelMKL, self).__init__(*args, **kwargs)
 
+    def set_variables(self):
+        """Set the variables"""
+
+        # for recent versions of Intel MKL, -lm -ldl should be used for linking
+        mkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
+        if LooseVersion(mkl_version) >= LooseVersion('11'):
+            math_libs = ['m', 'dl']
+            if self.LIB_MATH is None:
+                self.LIB_MATH = math_libs
+            else:
+                self.LIB_MATH.extend([l for l in math_libs if l not in self.LIB_MATH])
+
+        super(IntelMKL, self).set_variables()
+
     def _set_blas_variables(self):
         """Fix the map a bit"""
         interfacemap = {

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -76,6 +76,8 @@ class LinAlg(Toolchain):
     SCALAPACK_LIB_DIR = ['lib']
     SCALAPACK_INCLUDE_DIR = ['include']
 
+    LIB_EXTRA = None
+
     def __init__(self, *args, **kwargs):
         Toolchain.base_init(self)
 
@@ -118,9 +120,9 @@ class LinAlg(Toolchain):
             if getattr(self, 'LIB_MULTITHREAD', None) is not None:
                 self.variables.nappend('LIBBLAS_MT', self.LIB_MULTITHREAD, position=10)
 
-        if getattr(self, 'LIB_MATH', None) is not None:
-            self.variables.nappend('LIBBLAS', self.LIB_MATH, position=20)
-            self.variables.nappend('LIBBLAS_MT', self.LIB_MATH, position=20)
+        if getattr(self, 'LIB_EXTRA', None) is not None:
+            self.variables.nappend('LIBBLAS', self.LIB_EXTRA, position=20)
+            self.variables.nappend('LIBBLAS_MT', self.LIB_EXTRA, position=20)
 
         self.variables.join('BLAS_STATIC_LIBS', 'LIBBLAS')
         self.variables.join('BLAS_MT_STATIC_LIBS', 'LIBBLAS_MT')
@@ -174,9 +176,9 @@ class LinAlg(Toolchain):
                 self.variables.nappend('LIBLAPACK', 'LIBLAPACK_ONLY')
                 self.variables.nappend('LIBLAPACK_MT', 'LIBLAPACK_MT_ONLY')
 
-            if getattr(self, 'LIB_MATH', None) is not None:
-                self.variables.nappend('LIBLAPACK', self.LIB_MATH, position=20)
-                self.variables.nappend('LIBLAPACK_MT', self.LIB_MATH, position=20)
+            if getattr(self, 'LIB_EXTRA', None) is not None:
+                self.variables.nappend('LIBLAPACK', self.LIB_EXTRA, position=20)
+                self.variables.nappend('LIBLAPACK_MT', self.LIB_EXTRA, position=20)
 
             self.variables.join('LAPACK_STATIC_LIBS', 'LIBLAPACK')
             self.variables.join('LAPACK_MT_STATIC_LIBS', 'LIBLAPACK_MT')
@@ -219,9 +221,9 @@ class LinAlg(Toolchain):
                                                          toggle_startstopgroup=self.BLACS_LIB_GROUP,
                                                          toggle_staticdynamic=self.BLACS_LIB_STATIC)
 
-        if getattr(self, 'LIB_MATH', None) is not None:
-            self.variables.nappend('LIBBLACS', self.LIB_MATH, position=20)
-            self.variables.nappend('LIBBLACS_MT', self.LIB_MATH, position=20)
+        if getattr(self, 'LIB_EXTRA', None) is not None:
+            self.variables.nappend('LIBBLACS', self.LIB_EXTRA, position=20)
+            self.variables.nappend('LIBBLACS_MT', self.LIB_EXTRA, position=20)
 
         self.variables.join('BLACS_STATIC_LIBS', 'LIBBLACS')
         self.variables.join('BLACS_MT_STATIC_LIBS', 'LIBBLACS_MT')
@@ -284,9 +286,9 @@ class LinAlg(Toolchain):
         else:
             raise EasyBuildError("_set_scalapack_variables: LIBSCALAPACK without SCALAPACK_REQUIRES not implemented")
 
-        if getattr(self, 'LIB_MATH', None) is not None:
-            self.variables.nappend('LIBSCALAPACK', self.LIB_MATH, position=20)
-            self.variables.nappend('LIBSCALAPACK_MT', self.LIB_MATH, position=20)
+        if getattr(self, 'LIB_EXTRA', None) is not None:
+            self.variables.nappend('LIBSCALAPACK', self.LIB_EXTRA, position=20)
+            self.variables.nappend('LIBSCALAPACK_MT', self.LIB_EXTRA, position=20)
 
         self.variables.join('SCALAPACK_STATIC_LIBS', 'LIBSCALAPACK')
         self.variables.join('SCALAPACK_MT_STATIC_LIBS', 'LIBSCALAPACK_MT')

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -118,6 +118,10 @@ class LinAlg(Toolchain):
             if getattr(self, 'LIB_MULTITHREAD', None) is not None:
                 self.variables.nappend('LIBBLAS_MT', self.LIB_MULTITHREAD, position=10)
 
+        if getattr(self, 'LIB_MATH', None) is not None:
+            self.variables.nappend('LIBBLAS', self.LIB_MATH, position=20)
+            self.variables.nappend('LIBBLAS_MT', self.LIB_MATH, position=20)
+
         self.variables.join('BLAS_STATIC_LIBS', 'LIBBLAS')
         self.variables.join('BLAS_MT_STATIC_LIBS', 'LIBBLAS_MT')
         for root in self.get_software_root(self.BLAS_MODULE_NAME):
@@ -164,11 +168,15 @@ class LinAlg(Toolchain):
                 lapack_mt = ["%s_MT" % x for x in self.LAPACK_REQUIRES]
                 self.variables.join('LIBLAPACK_MT', 'LIBLAPACK_MT_ONLY', *lapack_mt)
                 if getattr(self, 'LIB_MULTITHREAD', None) is not None:
-                    self.variables.nappend('LIBLAPACK_MT', self.LIB_MULTITHREAD)
+                    self.variables.nappend('LIBLAPACK_MT', self.LIB_MULTITHREAD, position=10)
 
             else:
                 self.variables.nappend('LIBLAPACK', 'LIBLAPACK_ONLY')
                 self.variables.nappend('LIBLAPACK_MT', 'LIBLAPACK_MT_ONLY')
+
+            if getattr(self, 'LIB_MATH', None) is not None:
+                self.variables.nappend('LIBLAPACK', self.LIB_MATH, position=20)
+                self.variables.nappend('LIBLAPACK_MT', self.LIB_MATH, position=20)
 
             self.variables.join('LAPACK_STATIC_LIBS', 'LIBLAPACK')
             self.variables.join('LAPACK_MT_STATIC_LIBS', 'LIBLAPACK_MT')
@@ -201,6 +209,7 @@ class LinAlg(Toolchain):
             self.variables.add_begin_end_linkerflags(self.BLACS_LIB,
                                                      toggle_startstopgroup=self.BLACS_LIB_GROUP,
                                                      toggle_staticdynamic=self.BLACS_LIB_STATIC)
+
         if self.BLACS_LIB_MT is None:
             self.variables.join('LIBBLACS_MT', 'LIBBLACS')
         else:
@@ -209,6 +218,10 @@ class LinAlg(Toolchain):
                 self.variables.add_begin_end_linkerflags(self.BLACS_LIB_MT,
                                                          toggle_startstopgroup=self.BLACS_LIB_GROUP,
                                                          toggle_staticdynamic=self.BLACS_LIB_STATIC)
+
+        if getattr(self, 'LIB_MATH', None) is not None:
+            self.variables.nappend('LIBBLACS', self.LIB_MATH, position=20)
+            self.variables.nappend('LIBBLACS_MT', self.LIB_MATH, position=20)
 
         self.variables.join('BLACS_STATIC_LIBS', 'LIBBLACS')
         self.variables.join('BLACS_MT_STATIC_LIBS', 'LIBBLACS_MT')
@@ -271,6 +284,9 @@ class LinAlg(Toolchain):
         else:
             raise EasyBuildError("_set_scalapack_variables: LIBSCALAPACK without SCALAPACK_REQUIRES not implemented")
 
+        if getattr(self, 'LIB_MATH', None) is not None:
+            self.variables.nappend('LIBSCALAPACK', self.LIB_MATH, position=20)
+            self.variables.nappend('LIBSCALAPACK_MT', self.LIB_MATH, position=20)
 
         self.variables.join('SCALAPACK_STATIC_LIBS', 'LIBSCALAPACK')
         self.variables.join('SCALAPACK_MT_STATIC_LIBS', 'LIBSCALAPACK_MT')

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -32,6 +32,7 @@ import os
 import re
 import shutil
 import tempfile
+from distutils.version import LooseVersion
 from unittest import TestLoader, main
 from test.framework.utilities import EnhancedTestCase, find_full_path, init_config
 
@@ -412,14 +413,11 @@ class ToolchainTest(EnhancedTestCase):
         self.modtool.purge()
 
         # check another one
-        tmpdir, imkl_module_path, imkl_module_txt = self.setup_sandbox_for_intel_fftw()
+        self.setup_sandbox_for_intel_fftw(self.test_prefix)
+        self.modtool.prepend_module_path(self.test_prefix)
         tc = self.get_toolchain("ictce", version="4.1.13")
         tc.prepare()
         self.assertEqual(tc.mpi_family(), "IntelMPI")
-
-        # cleanup
-        shutil.rmtree(tmpdir)
-        write_file(imkl_module_path, imkl_module_txt)
 
     def test_goolfc(self):
         """Test whether goolfc is handled properly."""
@@ -449,31 +447,37 @@ class ToolchainTest(EnhancedTestCase):
         # check CUDA runtime lib
         self.assertTrue("-lrt -lcudart" in tc.get_variable('LIBS'))
 
-    def setup_sandbox_for_intel_fftw(self, imklver='10.3.12.361'):
+    def setup_sandbox_for_intel_fftw(self, moddir, imklver='10.3.12.361'):
         """Set up sandbox for Intel FFTW"""
         # hack to make Intel FFTW lib check pass
-        # rewrite $root in imkl module so we can put required lib*.a files in place
-        tmpdir = tempfile.mkdtemp()
+        # create dummy imkl module and put required lib*.a files in place
 
-        test_modules_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'modules'))
-        imkl_module_path = os.path.join(test_modules_path, 'imkl', imklver)
-        imkl_module_txt = open(imkl_module_path, 'r').read()
-        regex = re.compile('^(set\s*root).*$', re.M)
-        imkl_module_alt_txt = regex.sub(r'\1\t%s' % tmpdir, imkl_module_txt)
-        open(imkl_module_path, 'w').write(imkl_module_alt_txt)
+        imkl_module_path = os.path.join(moddir, 'imkl', imklver)
+        imkl_dir = os.path.join(self.test_prefix, 'software', 'imkl', imklver)
 
-        fftw_libs = ['fftw3xc_intel', 'fftw3x_cdft', 'mkl_cdft_core', 'mkl_blacs_intelmpi_lp64']
-        fftw_libs += ['mkl_blacs_intelmpi_lp64', 'mkl_intel_lp64', 'mkl_sequential', 'mkl_core', 'mkl_intel_ilp64']
+        imkl_mod_txt = '\n'.join([
+            "#%Module",
+            "setenv EBROOTIMKL %s" % imkl_dir,
+            "setenv EBVERSIONIMKL %s" % imklver,
+        ])
+        write_file(imkl_module_path, imkl_mod_txt)
+
+        fftw_libs = ['fftw3xc_intel', 'fftw3xc_pgi', 'mkl_cdft_core', 'mkl_blacs_intelmpi_lp64']
+        fftw_libs += ['mkl_intel_lp64', 'mkl_sequential', 'mkl_core', 'mkl_intel_ilp64']
+        if LooseVersion(imklver) >= LooseVersion('11'):
+            fftw_libs.extend(['fftw3x_cdft_ilp64', 'fftw3x_cdft_lp64'])
+        else:
+            fftw_libs.append('fftw3x_cdft')
+
         for subdir in ['mkl/lib/intel64', 'compiler/lib/intel64', 'lib/em64t']:
-            os.makedirs(os.path.join(tmpdir, subdir))
+            os.makedirs(os.path.join(imkl_dir, subdir))
             for fftlib in fftw_libs:
-                write_file(os.path.join(tmpdir, subdir, 'lib%s.a' % fftlib), 'foo')
-
-        return tmpdir, imkl_module_path, imkl_module_txt
+                write_file(os.path.join(imkl_dir, subdir, 'lib%s.a' % fftlib), 'foo')
 
     def test_ictce_toolchain(self):
         """Test for ictce toolchain."""
-        tmpdir, imkl_module_path, imkl_module_txt = self.setup_sandbox_for_intel_fftw()
+        self.setup_sandbox_for_intel_fftw(self.test_prefix)
+        self.modtool.prepend_module_path(self.test_prefix)
 
         tc = self.get_toolchain("ictce", version="4.1.13")
         tc.prepare()
@@ -526,26 +530,17 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(tc.get_variable('MPIF77'), 'mpif77')
         self.assertEqual(tc.get_variable('MPIF90'), 'mpif90')
 
-        # cleanup
-        shutil.rmtree(tmpdir)
-        write_file(imkl_module_path, imkl_module_txt)
-
         # different flag for OpenMP with old Intel compilers (11.x)
         modules.modules_tool().purge()
-        tmpdir, imkl_module_path, imkl_module_txt = self.setup_sandbox_for_intel_fftw(imklver='10.2.6.038')
+        self.setup_sandbox_for_intel_fftw(self.test_prefix, imklver='10.2.6.038')
+        self.modtool.prepend_module_path(self.test_prefix)
         tc = self.get_toolchain('ictce', version='3.2.2.u3')
         opts = {'openmp': True}
         tc.set_options(opts)
         tc.prepare()
         self.assertEqual(tc.get_variable('MPIFC'), 'mpif90')
-        write_file(imkl_module_path, imkl_module_txt)
-
         for var in ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']:
             self.assertTrue('-openmp' in tc.get_variable(var))
-
-        # cleanup
-        shutil.rmtree(tmpdir)
-        write_file(imkl_module_path, imkl_module_txt)
 
     def test_toolchain_verification(self):
         """Test verification of toolchain definition."""
@@ -576,17 +571,14 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_mpi_cmd_for(self):
         """Test mpi_cmd_for function."""
-        tmpdir, imkl_module_path, imkl_module_txt = self.setup_sandbox_for_intel_fftw()
+        self.setup_sandbox_for_intel_fftw(self.test_prefix)
+        self.modtool.prepend_module_path(self.test_prefix)
 
         tc = self.get_toolchain('ictce', version='4.1.13')
         tc.prepare()
 
         mpi_cmd_for_re = re.compile("^mpirun --file=.*/mpdboot -machinefile .*/nodes -np 4 test$")
         self.assertTrue(mpi_cmd_for_re.match(tc.mpi_cmd_for('test', 4)))
-
-        # cleanup
-        shutil.rmtree(tmpdir)
-        write_file(imkl_module_path, imkl_module_txt)
 
     def test_prepare_deps(self):
         """Test preparing for a toolchain when dependencies are involved."""
@@ -662,8 +654,9 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_old_new_iccifort(self):
         """Test whether preparing for old/new Intel compilers works correctly."""
-        tmpdir1, imkl_module_path1, imkl_module_txt1 = self.setup_sandbox_for_intel_fftw(imklver='10.3.12.361')
-        tmpdir2, imkl_module_path2, imkl_module_txt2 = self.setup_sandbox_for_intel_fftw(imklver='10.2.6.038')
+        self.setup_sandbox_for_intel_fftw(self.test_prefix, imklver='10.3.12.361')
+        self.setup_sandbox_for_intel_fftw(self.test_prefix, imklver='10.2.6.038')
+        self.modtool.prepend_module_path(self.test_prefix)
 
         # incl. -lguide
         libblas_mt_ictce3 = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
@@ -726,12 +719,6 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(os.environ['LIBBLAS_MT'], libblas_mt_goolfc)
         self.assertEqual(os.environ['LIBSCALAPACK'], libscalack_goolfc)
 
-        # cleanup
-        shutil.rmtree(tmpdir1)
-        shutil.rmtree(tmpdir2)
-        write_file(imkl_module_path1, imkl_module_txt1)
-        write_file(imkl_module_path2, imkl_module_txt2)
-
     def test_independence(self):
         """Test independency of toolchain instances."""
 
@@ -772,7 +759,7 @@ class ToolchainTest(EnhancedTestCase):
         write_file(os.path.join(self.test_prefix, 'PGI', '14.9'), '#%Module\nsetenv EBVERSIONPGI 14.9')
         write_file(os.path.join(self.test_prefix, 'PGI', '14.10'), '#%Module\nsetenv EBVERSIONPGI 14.10')
         write_file(os.path.join(self.test_prefix, 'PGI', '16.3'), '#%Module\nsetenv EBVERSIONPGI 16.3')
-        self.modtool.use(self.test_prefix)
+        self.modtool.prepend_module_path(self.test_prefix)
 
         tc = self.get_toolchain('PGI', version='14.9')
         tc.prepare()
@@ -793,6 +780,37 @@ class ToolchainTest(EnhancedTestCase):
             self.assertEqual(tc.get_variable('F77'), 'pgf77')
             self.assertEqual(tc.get_variable('F90'), 'pgfortran')
             self.assertEqual(tc.get_variable('FC'), 'pgfortran')
+
+    def test_pgi_imkl(self):
+        """Test setup of build environment for toolchain with PGI and Intel MKL."""
+        pomkl_mod_txt = '\n'.join([
+            '#%Module',
+            "module load PGI/16.3",
+            "module load OpenMPI/1.10.2-PGI-16.3",
+            "module load imkl/11.3.2.181",
+        ])
+        write_file(os.path.join(self.test_prefix, 'pomkl', '2016.03'), pomkl_mod_txt)
+        pgi_mod_txt = '\n'.join([
+            '#%Module',
+            "setenv EBROOTPGI %s" % self.test_prefix,
+            "setenv EBVERSIONPGI 16.3",
+        ])
+        write_file(os.path.join(self.test_prefix, 'PGI', '16.3'), pgi_mod_txt)
+        ompi_mod_txt = '\n'.join([
+            '#%Module',
+            "setenv EBROOTOPENMPI %s" % self.test_prefix,
+            "setenv EBVERSIONOPENMPI 1.10.2",
+        ])
+        write_file(os.path.join(self.test_prefix, 'OpenMPI', '1.10.2-PGI-16.3'), ompi_mod_txt)
+        self.setup_sandbox_for_intel_fftw(self.test_prefix, imklver='11.3.2.181')
+        self.modtool.prepend_module_path(self.test_prefix)
+
+        tc = self.get_toolchain('pomkl', version='2016.03')
+        tc.prepare()
+
+        liblapack = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core "
+        liblapack += "-Wl,--end-group -Wl,-Bdynamic -lm -ldl"
+        self.assertEqual(os.environ.get('LIBLAPACK', '(not set)'), liblapack)
 
 
 def suite():

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -809,7 +809,7 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
 
         liblapack = "-Wl,-Bstatic -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core "
-        liblapack += "-Wl,--end-group -Wl,-Bdynamic -lm -ldl"
+        liblapack += "-Wl,--end-group -Wl,-Bdynamic -ldl"
         self.assertEqual(os.environ.get('LIBLAPACK', '(not set)'), liblapack)
 
 


### PR DESCRIPTION
This change results in `-lm -ldl` being added to `$LIBBLAS`, `$LIBLAPACK`, etc. for Intel MKL 11.0 and newer, following the discussion in https://github.com/hpcugent/easybuild-easyconfigs/pull/2900, and as instructed by the Intel MKL Link Advisor.

This is required in particular for building HPL with PGI, cfr. https://github.com/hpcugent/easybuild-easyconfigs/issues/3046.