### PR TITLE
only include -ldl in $LIBBLAS & co for Intel MKL with PGI

### DIFF
--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -83,12 +83,12 @@ class IntelMKL(LinAlg):
     def set_variables(self):
         """Set the variables"""
 
-        # for recent versions of Intel MKL, -ldl should be used for linking
+        # for recent versions of Intel MKL, -ldl should be used for linking;
         # the Intel MKL Link Advisor specifies to always do this,
         # but it is only needed when statically linked with Intel MKL,
         # and only strictly needed for some compilers (e.g. PGI)
         mkl_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
-        if LooseVersion(mkl_version) >= LooseVersion('11'):
+        if LooseVersion(mkl_version) >= LooseVersion('11') and self.COMPILER_FAMILY in [TC_CONSTANT_PGI]:
             self.log.info("Adding -ldl as extra library when linking with Intel MKL libraries (for v11.x and newer)")
             if self.LIB_EXTRA is None:
                 self.LIB_EXTRA = ['dl']


### PR DESCRIPTION
follow-up for #1761

always including `-ldl` in `$LIBBLAS` leads to problem, e.g. breaking linking of numpy with Intel MKL, because the `numpy` easyblock grabs and reformats `$LIBBLAS`, and only expects Intel MKL libraries to be listed there (other than `-lpthread`)

since it's only really needed for PGI, we should only include it when Intel MKL and PGI are combined in the same toolchain, to avoid breaking backwards compatibility