### PR TITLE
fix error message on missing module command

### DIFF
--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -201,9 +201,10 @@ def check_module_command(tmpdir):
                 break
 
     if easybuild_modules_tool is None:
+        mod_cmds = [m for (m, _) in known_module_commands]
         msg = [
             "Could not find any module command, make sure one available in your $PATH.",
-            "Known module commands are checked in order, and include: %s" % ', '.join(known_module_commands),
+            "Known module commands are checked in order, and include: %s" % ', '.join(mod_cmds),
             "Check the output of 'type module' to determine the location of the module command you are using.",
         ]
         error('\n'.join(msg))


### PR DESCRIPTION
reported by @robertdfrench

without this patch, in case no module commands were found in `$PATH` (and with `$LMOD_CMD` and `$EASYBUILD_MODULES_TOOL` undefined):

```
[[INFO]] Installation prefix /tmp/adfsghjm
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/easybuild/scripts/bootstrap_eb.py", line 788, in <module>
    main()
  File "/Users/kehoste/work/easybuild-framework/easybuild/scripts/bootstrap_eb.py", line 554, in main
    modtool = check_module_command(tmpdir)
  File "/Users/kehoste/work/easybuild-framework/easybuild/scripts/bootstrap_eb.py", line 208, in check_module_command
    "Known module commands are checked in order, and include: %s" % ', '.join(mod_cmds),
TypeError: sequence item 0: expected string, tuple found
```

with this patch:

```
[[INFO]] Installation prefix /tmp/adfsghjm
[[ERROR]] Could not find any module command, make sure one available in your $PATH.
Known module commands are checked in order, and include: modulecmd, lmod, modulecmd.tcl
Check the output of 'type module' to determine the location of the module command you are using.
```