### PR TITLE
avoid changing $MODULEPATH when prepending with symlink of path already at head of $MODULEPATH

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -46,7 +46,7 @@ from vsc.utils.missing import get_subclasses
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, get_modules_tool, install_path
 from easybuild.tools.environment import ORIG_OS_ENVIRON, restore_env
-from easybuild.tools.filetools import convert_name, mkdir, read_file, path_matches, which
+from easybuild.tools.filetools import convert_name, mkdir, path_matches, read_file, which
 from easybuild.tools.module_naming_scheme import DEVEL_MODULE_SUFFIX
 from easybuild.tools.run import run_cmd
 from vsc.utils.missing import nub
@@ -358,7 +358,7 @@ class ModulesTool(object):
         modulepath = curr_module_paths()
         if not modulepath:
             self.add_module_path(path, set_mod_paths=set_mod_paths)
-        elif modulepath[0] != path:
+        elif os.path.realpath(modulepath[0]) != os.path.realpath(path):
             self.remove_module_path(path, set_mod_paths=False)
             self.add_module_path(path, set_mod_paths=set_mod_paths)
 
@@ -983,7 +983,7 @@ class Lmod(ModulesTool):
         """
         # Lmod pushes a path to the front on 'module use', no need for (costly) 'module unuse'
         modulepath = curr_module_paths()
-        if not modulepath or modulepath[0] != path:
+        if not modulepath or os.path.realpath(modulepath[0]) != os.path.realpath(path):
             self.use(path)
             if set_mod_paths:
                 self.set_mod_paths()

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -43,8 +43,8 @@ from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.tools import config
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import mkdir, read_file, write_file
-from easybuild.tools.modules import Lmod, get_software_root, get_software_version, get_software_libdir
-from easybuild.tools.modules import invalidate_module_caches_for, modules_tool
+from easybuild.tools.modules import Lmod, curr_module_paths, get_software_root, get_software_version
+from easybuild.tools.modules import get_software_libdir, invalidate_module_caches_for, modules_tool
 from easybuild.tools.run import run_cmd
 
 
@@ -155,11 +155,37 @@ class ModulesTest(EnhancedTestCase):
 
         # trying to load a module not on the top level of a hierarchy should fail
         mods = [
-            'Compiler/GCC/4.7.2/OpenMPI/1.6.4',  # module use on non-existent dir (Tcl-based env mods), or missing dep (Lmod)
-            'MPI/GCC/4.7.2/OpenMPI/1.6.4/ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2',  # missing dep
+            # module use on non-existent dir (Tcl-based env mods), or missing dep (Lmod)
+            'Compiler/GCC/4.7.2/OpenMPI/1.6.4',
+            # missing dep
+            'MPI/GCC/4.7.2/OpenMPI/1.6.4/ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2',
         ]
         for mod in mods:
             self.assertErrorRegex(EasyBuildError, '.*', self.modtool.load, [mod])
+
+    def test_prepend_module_path(self):
+        """Test prepend_module_path method."""
+        test_path = tempfile.mkdtemp(prefix=self.test_prefix)
+        self.modtool.prepend_module_path(test_path)
+        self.assertTrue(os.path.samefile(curr_module_paths()[0], test_path))
+
+        # prepending same path again is fine, no changes to $MODULEPATH
+        modulepath = curr_module_paths()
+        self.modtool.prepend_module_path(test_path)
+        self.assertEqual(modulepath, curr_module_paths())
+
+        # prepending path that is 'deeper down' in $MODULEPATH works, brings it back to front
+        test_mods_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
+        self.assertTrue(any(os.path.samefile(test_mods_dir, p) for p in modulepath))
+        self.modtool.prepend_module_path(test_mods_dir)
+        self.assertTrue(os.path.samefile(curr_module_paths()[0], test_mods_dir))
+
+        # prepending path that is a symlink to the current head of $MODULEPATH is a no-op
+        modulepath = curr_module_paths()
+        symlink_path = os.path.join(self.test_prefix, 'symlink_modules')
+        os.symlink(modulepath[0], symlink_path)
+        self.modtool.prepend_module_path(symlink_path)
+        self.assertEqual(modulepath, curr_module_paths())
 
     def test_ld_library_path(self):
         """Make sure LD_LIBRARY_PATH is what it should be when loaded multiple modules."""


### PR DESCRIPTION
Although this should be fine in theory, it sometimes has repercussions in practice, even beyond performance, cfr. #1775.