### PR TITLE
filter out duplicates in find_flexlm_license

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1231,7 +1231,8 @@ def find_flexlm_license(custom_env_vars=None, lic_specs=None):
     Find FlexLM license.
 
     Considered specified list of environment variables;
-    checks for path to existing license file or valid license server specification.
+    checks for path to existing license file or valid license server specification;
+    duplicate paths are not retained in the returned list of license specs.
 
     If no license is found through environment variables, also consider 'lic_specs'.
 
@@ -1256,7 +1257,7 @@ def find_flexlm_license(custom_env_vars=None, lic_specs=None):
     cand_lic_specs = {}
     for env_var in lic_env_vars:
         if env_var in os.environ:
-            cand_lic_specs[env_var] = os.environ[env_var].split(os.pathsep)
+            cand_lic_specs[env_var] = nub(os.environ[env_var].split(os.pathsep))
 
     # also consider provided license spec (last)
     # use None as key to indicate that these license specs do not have an environment variable associated with them
@@ -1297,8 +1298,9 @@ def find_flexlm_license(custom_env_vars=None, lic_specs=None):
                     except IOError as err:
                         _log.warning("License file %s found, but failed to open it for reading: %s", lic_file, err)
 
-        # stop after finding valid license specs
+        # stop after finding valid license specs, filter out duplicates
         if valid_lic_specs:
+            valid_lic_specs = nub(valid_lic_specs)
             lic_env_var = env_var
             break
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -615,6 +615,10 @@ class FileToolsTest(EnhancedTestCase):
         os.environ['LM_LICENSE_FILE'] = lic_server
         self.assertEqual(ft.find_flexlm_license(), ([lic_server], 'LM_LICENSE_FILE'))
 
+        # duplicates are filtered out, order is maintained
+        os.environ['LM_LICENSE_FILE'] = ':'.join([lic_file1, lic_server, self.test_prefix, lic_file2, lic_file1])
+        self.assertEqual(ft.find_flexlm_license(), ([lic_file1, lic_server, lic_file2], 'LM_LICENSE_FILE'))
+
         # invalid server spec (missing port)
         os.environ['LM_LICENSE_FILE'] = 'test.license.server'
         self.assertEqual(ft.find_flexlm_license(), ([], None))


### PR DESCRIPTION
This is probably enough to fix the regression reported in https://github.com/hpcugent/easybuild-easyblocks/issues/933, but it seems like there's more going on (in `IntelBase`, that is).

@damianam: you're somewhat familiar with this, please review? ;)