### PR TITLE
don't use LooseVersion to define version_major/version_minor

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -171,13 +171,13 @@ def template_constant_dict(config, ignore=None, skip_lower=True):
             if version is not None:
 
                 _log.debug("version found in easyconfig is %s", version)
-                version = LooseVersion(version).version
+                version = version.split('.')
                 try:
-                    major = str(version[0])
+                    major = version[0]
                     template_values['version_major'] = major
-                    minor = str(version[1])
+                    minor = version[1]
                     template_values['version_minor'] = minor
-                    template_values['version_major_minor'] = ".".join([major, minor])
+                    template_values['version_major_minor'] = '.'.join([major, minor])
                 except IndexError:
                     # if there is no minor version, skip it
                     pass

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -732,7 +732,8 @@ class EasyConfigTest(EnhancedTestCase):
         """ test easyconfig templating """
         inp = {
            'name': 'PI',
-           'version': '3.14',
+           # purposely using minor version that starts with a 0, to check for correct version_minor value
+           'version': '3.04',
            'namelower': 'pi',
            'cmd': 'tar xfvz %s',
         }
@@ -742,13 +743,13 @@ class EasyConfigTest(EnhancedTestCase):
             'name = "%(name)s"',
             'version = "%(version)s"',
             'versionsuffix = "-Python-%%(pyver)s"',
-            'homepage = "http://example.com/%%(nameletter)s/%%(nameletterlower)s"',
+            'homepage = "http://example.com/%%(nameletter)s/%%(nameletterlower)s/v%%(version_major)s/"',
             'description = "test easyconfig %%(name)s"',
             'toolchain = {"name":"dummy", "version": "dummy2"}',
             'source_urls = [(GOOGLECODE_SOURCE)]',
             'sources = [SOURCE_TAR_GZ, (SOURCELOWER_TAR_GZ, "%(cmd)s")]',
             'sanity_check_paths = {',
-            '   "files": ["lib/python%%(pyshortver)s/site-packages"],',
+            '   "files": ["bin/pi_%%(version_major)s_%%(version_minor)s", "lib/python%%(pyshortver)s/site-packages"],',
             '   "dirs": ["libfoo.%%s" %% SHLIB_EXT],',
             '}',
             'dependencies = [',
@@ -777,9 +778,10 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb['sources'][1][1], 'tar xfvz %s')
         self.assertEqual(eb['source_urls'][0], const_dict['GOOGLECODE_SOURCE'] % inp)
         self.assertEqual(eb['versionsuffix'], '-Python-2.7.10')
-        self.assertEqual(eb['sanity_check_paths']['files'][0], 'lib/python2.7/site-packages')
+        self.assertEqual(eb['sanity_check_paths']['files'][0], 'bin/pi_3_04')
+        self.assertEqual(eb['sanity_check_paths']['files'][1], 'lib/python2.7/site-packages')
         self.assertEqual(eb['sanity_check_paths']['dirs'][0], 'libfoo.%s' % get_shared_lib_ext())
-        self.assertEqual(eb['homepage'], "http://example.com/P/p")
+        self.assertEqual(eb['homepage'], "http://example.com/P/p/v3/")
         self.assertEqual(eb['modloadmsg'], "Java: 1.7.80, 1.7; Python: 2.7.10, 2.7; Perl: 5.22.0, 5.22; R: 3.2.3, 3.2")
         self.assertEqual(eb['license_file'], os.path.join(os.environ['HOME'], 'licenses', 'PI', 'license.txt'))
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -47,7 +47,7 @@ from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig
 from easybuild.framework.easyconfig.easyconfig import create_paths, copy_easyconfigs, get_easyblock_class
 from easybuild.framework.easyconfig.licenses import License, LicenseGPLv3
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
-from easybuild.framework.easyconfig.templates import to_template_str
+from easybuild.framework.easyconfig.templates import template_constant_dict, to_template_str
 from easybuild.framework.easyconfig.tools import dep_graph, find_related_easyconfigs
 from easybuild.framework.easyconfig.tools import parse_easyconfigs
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak_one
@@ -1704,6 +1704,43 @@ class EasyConfigTest(EnhancedTestCase):
             copied_ec = os.path.join(ecs_target_dir, orig_ec[0].lower(), orig_ec.split('-')[0], orig_ec)
             self.assertTrue(os.path.exists(copied_ec), "File %s exists" % copied_ec)
             self.assertEqual(read_file(copied_ec), read_file(os.path.join(self.test_prefix, src_ec)))
+
+    def test_template_constant_dict(self):
+        """Test template_constant_dict function."""
+        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs')
+        ec = EasyConfig(os.path.join(test_ecs_dir, 'gzip-1.5-goolf-1.4.10.eb'))
+
+        expected = {
+            'name': 'gzip',
+            'nameletter': 'g',
+            'toolchain_name': 'goolf',
+            'toolchain_version': '1.4.10',
+            'version': '1.5',
+            'version_major': '1',
+            'version_major_minor': '1.5',
+            'version_minor': '5',
+            'versionprefix': '',
+            'versionsuffix': '',
+        }
+        self.assertEqual(template_constant_dict(ec._config), expected)
+
+        ec = EasyConfig(os.path.join(test_ecs_dir, 'toy-0.0-deps.eb'))
+        # fiddle with version to check version_minor template ('0' should be retained)
+        ec['version'] = '0.01'
+
+        expected = {
+            'name': 'toy',
+            'nameletter': 't',
+            'toolchain_name': 'dummy',
+            'toolchain_version': 'dummy',
+            'version': '0.01',
+            'version_major': '0',
+            'version_major_minor': '0.01',
+            'version_minor': '01',
+            'versionprefix': '',
+            'versionsuffix': '-deps',
+        }
+        self.assertEqual(template_constant_dict(ec._config), expected)
 
 
 def suite():


### PR DESCRIPTION
don't use `LooseVersion` to define `version_major` and especially `version_minor` template values, since a verson like `4.09` isn't handled correctly in that case; we expect `version_minor` to be `09` rather than `9`

cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/3141