### PR TITLE
fix installation of Lua in install_eb_dep.sh script

### DIFF
--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -12,6 +12,9 @@ PREFIX=$2
 PKG_NAME=`echo $PKG | sed 's/-[^-]*$//g'`
 PKG_VERSION=`echo $PKG | sed 's/.*-//g'`
 
+CONFIG_OPTIONS=
+PRECONFIG_CMD=
+
 if [ x$PKG_NAME == 'xmodules' ]; then
     PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
     export PATH=$PREFIX/Modules/$PKG_VERSION/bin:$PATH

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -44,5 +44,5 @@ wget ${PKG_URL} && tar xfz *${PKG_VERSION}.tar.gz
 if [ x$PKG_NAME == 'xmodules-tcl' ]; then
     mv modules $PREFIX/${PKG}
 else
-    cd ${PKG} && touch config.log && make clean && ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
+    cd ${PKG} && PATH=$PWD:$PATH make clean && ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
 fi

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -44,5 +44,5 @@ wget ${PKG_URL} && tar xfz *${PKG_VERSION}.tar.gz
 if [ x$PKG_NAME == 'xmodules-tcl' ]; then
     mv modules $PREFIX/${PKG}
 else
-    cd ${PKG} && ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
+    cd ${PKG} && ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make clean && make && make install
 fi

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -19,9 +19,9 @@ if [ x$PKG_NAME == 'xmodules' ]; then
 
 elif [ x$PKG_NAME == 'xlua' ]; then
     PKG_URL="http://downloads.sourceforge.net/project/lmod/${PKG}.tar.gz"
-    PRECONFIG_CMD="PATH=$PKG:$PATH make clean && "
+    PRECONFIG_CMD="make clean"
     CONFIG_OPTIONS='--with-static=yes'
-    export PATH=$PREFIX/bin:$PATH
+    export PATH=$PWD/$PKG:$PREFIX/bin:$PATH
 
 elif [ x$PKG_NAME == 'xLmod' ]; then
     PKG_URL="https://github.com/TACC/Lmod/archive/${PKG_VERSION}.tar.gz"
@@ -45,5 +45,9 @@ wget ${PKG_URL} && tar xfz *${PKG_VERSION}.tar.gz
 if [ x$PKG_NAME == 'xmodules-tcl' ]; then
     mv modules $PREFIX/${PKG}
 else
-    cd ${PKG} && ${PRECONFIG_CMD} ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
+    cd ${PKG}
+    if [ ! -z $PRECONFIG_CMD ]; then
+        eval ${PRECONFIG_CMD}
+    fi
+    ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
 fi

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -46,7 +46,7 @@ if [ x$PKG_NAME == 'xmodules-tcl' ]; then
     mv modules $PREFIX/${PKG}
 else
     cd ${PKG}
-    if [ ! -z $PRECONFIG_CMD ]; then
+    if [[ ! -z $PRECONFIG_CMD ]]; then
         eval ${PRECONFIG_CMD}
     fi
     ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -19,6 +19,7 @@ if [ x$PKG_NAME == 'xmodules' ]; then
 
 elif [ x$PKG_NAME == 'xlua' ]; then
     PKG_URL="http://downloads.sourceforge.net/project/lmod/${PKG}.tar.gz"
+    PRECONFIG_CMD="PATH=$PKG:$PATH make clean && "
     CONFIG_OPTIONS='--with-static=yes'
     export PATH=$PREFIX/bin:$PATH
 
@@ -44,5 +45,5 @@ wget ${PKG_URL} && tar xfz *${PKG_VERSION}.tar.gz
 if [ x$PKG_NAME == 'xmodules-tcl' ]; then
     mv modules $PREFIX/${PKG}
 else
-    cd ${PKG} && PATH=$PWD:$PATH make clean && ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
+    cd ${PKG} && ${PRECONFIG_CMD} ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
 fi

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -44,5 +44,5 @@ wget ${PKG_URL} && tar xfz *${PKG_VERSION}.tar.gz
 if [ x$PKG_NAME == 'xmodules-tcl' ]; then
     mv modules $PREFIX/${PKG}
 else
-    cd ${PKG} && ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make clean && make && make install
+    cd ${PKG} && touch config.log && make clean && ./configure $CONFIG_OPTIONS --prefix=$PREFIX && make && make install
 fi


### PR DESCRIPTION
The `lua-5.1.4.8.tar.gz` at https://sourceforge.net/projects/lmod/files was updated (to also support `make uninstall`, cfr. https://sourceforge.net/p/lmod/mailman/message/35128697/).

However, the new version of the tarball is 'dirty', i.e. it ships `.so` files etc., which turns out to be an issue on Travis: `posix.so` for example doesn't get rebuilt, but then Lmod fails to pick it up because it's probably incompatible with the system it's being used on.

This is fixed by running `make clean` before configuring-building-installing Lua from the tarball provided in the Lmod repo. Doing this also requires to add the current working directory to `$PATH`, such that the `config.status` script is found.

We need to take care that `make clean` is only run for Lua (it fails hard to Lmod & other tools because of a missing target).