### PR TITLE
Protect hierarchical modules from MODULEPATH reordering

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -388,9 +388,8 @@ class ModulesTool(object):
             eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
             shufflepaths = \
                 (mod_path for mod_path in self.mod_paths[::-1] if
-                 (os.path.commonprefix([os.path.realpath(mod_path), os.path.realpath(eb_modpath)]) != eb_modpath)
-                 and (os.path.realpath(mod_path) != os.path.realpath(eb_modpath))
-                 )
+                 (os.path.realpath(mod_path) == os.path.realpath(eb_modpath)) or
+                 (os.path.commonprefix([os.path.realpath(mod_path), os.path.realpath(eb_modpath)]) != eb_modpath))
             for mod_path in shufflepaths:
                 self.prepend_module_path(mod_path)
             self.log.info("$MODULEPATH set via list of module paths (w/ 'module use'): %s" % os.environ['MODULEPATH'])

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -383,8 +383,8 @@ class ModulesTool(object):
         if curr_module_paths() == self.mod_paths:
             self.log.debug("Current value of $MODULEPATH already matches list of module path %s", self.mod_paths)
         else:
-            # Don't include subdirs of the module installation target (hierarchical schemes, for example, rely on their
-            # placement)
+            # Don't include subdirs of the module installation target when we shuffle (hierarchical schemes, for
+            # example, rely on their relative location in MODULEPATH)
             eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
             shufflepaths = \
                 (mod_path for mod_path in self.mod_paths[::-1] if

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -383,7 +383,10 @@ class ModulesTool(object):
         if curr_module_paths() == self.mod_paths:
             self.log.debug("Current value of $MODULEPATH already matches list of module path %s", self.mod_paths)
         else:
-            for mod_path in self.mod_paths[::-1]:
+            # Don't include subdirs of the module installation target (hierarchical schemes, for example, rely on their placement)
+            eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
+            shufflepaths = (mod_path for mod_path in self.mod_paths[::-1] if os.path.commonprefix([os.path.realpath(mod_path), os.path.realpath(eb_modpath)]) != eb_modpath)
+            for mod_path in shufflepaths:
                 self.prepend_module_path(mod_path)
             self.log.info("$MODULEPATH set via list of module paths (w/ 'module use'): %s" % os.environ['MODULEPATH'])
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -384,7 +384,7 @@ class ModulesTool(object):
             self.log.debug("Current value of $MODULEPATH already matches list of module path %s", self.mod_paths)
         else:
             # Don't include subdirs of the module installation target when we shuffle (hierarchical schemes, for
-            # example, rely on their relative location in MODULEPATH)
+            # example, rely on the relative location of directories in MODULEPATH)
             eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
             shufflepaths = \
                 (mod_path for mod_path in self.mod_paths[::-1] if

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -383,9 +383,14 @@ class ModulesTool(object):
         if curr_module_paths() == self.mod_paths:
             self.log.debug("Current value of $MODULEPATH already matches list of module path %s", self.mod_paths)
         else:
-            # Don't include subdirs of the module installation target (hierarchical schemes, for example, rely on their placement)
+            # Don't include subdirs of the module installation target (hierarchical schemes, for example, rely on their
+            # placement)
             eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
-            shufflepaths = (mod_path for mod_path in self.mod_paths[::-1] if os.path.commonprefix([os.path.realpath(mod_path), os.path.realpath(eb_modpath)]) != eb_modpath)
+            shufflepaths = \
+                (mod_path for mod_path in self.mod_paths[::-1] if
+                 (os.path.commonprefix([os.path.realpath(mod_path), os.path.realpath(eb_modpath)]) != eb_modpath)
+                 and (os.path.realpath(mod_path) != os.path.realpath(eb_modpath))
+                 )
             for mod_path in shufflepaths:
                 self.prepend_module_path(mod_path)
             self.log.info("$MODULEPATH set via list of module paths (w/ 'module use'): %s" % os.environ['MODULEPATH'])


### PR DESCRIPTION
Addresses #1787 

Don't allow subdirs of the target space for module files to be moved around, hierarchical schemes rely on their placement.

