### PR TITLE
add check for module output, empty stdout is a sign of trouble with Lmod

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -929,10 +929,11 @@ class Lmod(ModulesTool):
 
     def check_module_output(self, cmd, stdout, stderr):
         """Check output of 'module' command, see if if is potentially invalid."""
+        fail_regex = re.compile('^stack traceback:', re.M)
         if stdout:
             self.log.debug("Output found in stdout, seems like '%s' ran fine", cmd)
-        else:
-            raise EasyBuildError("No output found in stdout, seems like '%s' failed", cmd)
+        elif fail_regex.search(stderr):
+            raise EasyBuildError("Empty stdout, '%s' found in stderr, seems like '%s' failed", fail_regex.pattern, cmd)
 
     def available(self, mod_name=None):
         """

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -565,6 +565,10 @@ class ModulesTool(object):
         """Set path environment variable to the given list of paths."""
         os.environ[key] = os.pathsep.join(paths)
 
+    def check_module_output(self, cmd, stdout, stderr):
+        """Check output of 'module' command, see if if is potentially invalid."""
+        self.log.debug("No checking of module output implemented for %s", self.__class__.__name__)
+
     def run_module(self, *args, **kwargs):
         """
         Run module command.
@@ -611,6 +615,8 @@ class ModulesTool(object):
         # stderr will contain text (just like the normal module command)
         (stdout, stderr) = proc.communicate()
         self.log.debug("Output of module command '%s': stdout: %s; stderr: %s" % (full_cmd, stdout, stderr))
+
+        self.check_module_output(full_cmd, stdout, stderr)
 
         if kwargs.get('return_output', False):
             return stdout + stderr
@@ -920,6 +926,13 @@ class Lmod(ModulesTool):
         if not 'regex' in kwargs:
             kwargs['regex'] = r".*(%s|%s)" % (self.COMMAND, self.COMMAND_ENVIRONMENT)
         super(Lmod, self).check_module_function(*args, **kwargs)
+
+    def check_module_output(self, cmd, stdout, stderr):
+        """Check output of 'module' command, see if if is potentially invalid."""
+        if stdout:
+            self.log.debug("Output found in stdout, seems like '%s' ran fine", cmd)
+        else:
+            raise EasyBuildError("No output found in stdout, seems like '%s' failed", cmd)
 
     def available(self, mod_name=None):
         """

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -213,7 +213,7 @@ class ModulesTool(object):
             raise EasyBuildError("No VERSION_REGEXP defined")
 
         try:
-            txt = self.run_module(self.VERSION_OPTION, return_output=True)
+            txt = self.run_module(self.VERSION_OPTION, return_output=True, check_output=False)
 
             ver_re = re.compile(self.VERSION_REGEXP, re.M)
             res = ver_re.search(txt)
@@ -616,7 +616,8 @@ class ModulesTool(object):
         (stdout, stderr) = proc.communicate()
         self.log.debug("Output of module command '%s': stdout: %s; stderr: %s" % (full_cmd, stdout, stderr))
 
-        self.check_module_output(full_cmd, stdout, stderr)
+        if kwargs.get('check_output', True):
+            self.check_module_output(full_cmd, stdout, stderr)
 
         if kwargs.get('return_output', False):
             return stdout + stderr
@@ -929,11 +930,10 @@ class Lmod(ModulesTool):
 
     def check_module_output(self, cmd, stdout, stderr):
         """Check output of 'module' command, see if if is potentially invalid."""
-        fail_regex = re.compile('^stack traceback:', re.M)
         if stdout:
             self.log.debug("Output found in stdout, seems like '%s' ran fine", cmd)
-        elif fail_regex.search(stderr):
-            raise EasyBuildError("Empty stdout, '%s' found in stderr, seems like '%s' failed", fail_regex.pattern, cmd)
+        else:
+            raise EasyBuildError("Found empty stdout, seems like '%s' failed: %s", cmd, stderr)
 
     def available(self, mod_name=None):
         """

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -249,7 +249,7 @@ class ModulesTool(object):
         """Check whether modules tool command is available."""
         cmd_path = which(self.cmd)
         if cmd_path is not None:
-            self.cmd = cmd_path
+            self.cmd = os.path.realpath(cmd_path)
             self.log.info("Full path for module command is %s, so using it" % self.cmd)
         else:
             mod_tool = self.__class__.__name__

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -160,7 +160,7 @@ class ModulesToolTest(EnhancedTestCase):
             init_config(build_options=build_options)
 
             lmod = Lmod(testing=True)
-            self.assertEqual(lmod.cmd, lmod_abspath)
+            self.assertEqual(lmod.cmd, os.path.realpath(lmod_abspath))
 
             # drop any location where 'lmod' or 'spider' can be found from $PATH
             paths = os.environ.get('PATH', '').split(os.pathsep)
@@ -177,12 +177,17 @@ class ModulesToolTest(EnhancedTestCase):
 
             # initialize Lmod modules tool, pass (fake) full path to 'lmod' via $LMOD_CMD
             fake_path = os.path.join(self.test_installpath, 'lmod')
-            write_file(fake_path, '#!/bin/bash\necho "Modules based on Lua: Version %s " >&2' % Lmod.REQ_VERSION)
+            fake_lmod_txt = '\n'.join([
+                '#!/bin/bash',
+                'echo "Modules based on Lua: Version %s " >&2' % Lmod.REQ_VERSION,
+                'echo "os.environ[\'FOO\'] = \'foo\'"',
+            ])
+            write_file(fake_path, fake_lmod_txt)
             os.chmod(fake_path, stat.S_IRUSR|stat.S_IXUSR)
             os.environ['LMOD_CMD'] = fake_path
             init_config(build_options=build_options)
             lmod = Lmod(testing=True)
-            self.assertEqual(lmod.cmd, fake_path)
+            self.assertEqual(lmod.cmd, os.path.realpath(fake_path))
 
             # use correct full path for 'lmod' via $LMOD_CMD
             os.environ['LMOD_CMD'] = lmod_abspath


### PR DESCRIPTION
motivated by https://lists.ugent.be/wws/arc/easybuild/2016-06/msg00037.html

The current implementation is too simple, but it's a starts and serves as a base for a fully fledged check.

@rtmclay any feedback on this? What would be a good way of checking whether Lmod ran correctly, based on the stdout & stderr produced by the `module` command?