### PR TITLE
cache $PATH & $PYTHONPATH in test setUp, restore them in tests where 'eb' is used

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1899,6 +1899,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_include_module_naming_schemes(self):
         """Test --include-module-naming-schemes."""
+        # make sure that calling out to 'eb' will work by restoring $PATH & $PYTHONPATH
+        self.restore_env_path_pythonpath()
+
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -1970,6 +1973,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_include_toolchains(self):
         """Test --include-toolchains."""
+        # make sure that calling out to 'eb' will work by restoring $PATH & $PYTHONPATH
+        self.restore_env_path_pythonpath()
+
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -175,6 +175,13 @@ class EnhancedTestCase(_EnhancedTestCase):
         test_easyblocks_path = os.path.join(test_easyblocks_path, 'generic')
         easybuild.easyblocks.generic.__path__.insert(0, test_easyblocks_path)
 
+        # save values of $PATH & $PYTHONPATH, so they can be restored later
+        # this is important in case EasyBuild was installed as a module, since that module may be unloaded,
+        # for example due to changes to $MODULEPATH in case EasyBuild was installed in a module hierarchy
+        # cfr. https://github.com/hpcugent/easybuild-framework/issues/1685
+        self.env_path = os.environ['PATH']
+        self.env_pythonpath = os.environ['PYTHONPATH']
+
         self.modtool = modules_tool()
         self.reset_modulepath([os.path.join(testdir, 'modules')])
         reset_module_caches()
@@ -217,6 +224,13 @@ class EnhancedTestCase(_EnhancedTestCase):
 
         # reset to make sure tempfile picks up new temporary directory to use
         tempfile.tempdir = None
+
+    def restore_env_path_pythonpath(self):
+        """
+        Restore $PATH & $PYTHONPATH in environment using saved values.
+        """
+        os.environ['PATH'] = self.env_path
+        os.environ['PYTHONPATH'] = self.env_pythonpath
 
     def reset_modulepath(self, modpaths):
         """Reset $MODULEPATH with specified paths."""


### PR DESCRIPTION
(verified) fix for #1685