### PR TITLE
avoid special characters like '[', ']' in path to temporary directory

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1177,10 +1177,10 @@ def set_tmpdir(tmpdir=None, raise_error=False):
 
     # avoid having special characters like '[' and ']' in the tmpdir pathname,
     # it is known to cause problems (e.g., with Python install tools, CUDA's nvcc, etc.);
-    # only common characteris like alphanumeric, '_', '-', '.' and '/' are retained; others are converted to '_'
+    # only common characteris like alphanumeric, '_', '-', '.' and '/' are retained; others are converted to 'X'
     special_chars_regex = r'[^\w/.-]'
     if re.search(special_chars_regex, current_tmpdir):
-        current_tmpdir = re.sub(special_chars_regex, '_', current_tmpdir)
+        current_tmpdir = re.sub(special_chars_regex, 'X', current_tmpdir)
         _log.info("Detected special characters in path to temporary directory, replacing them to avoid trouble: %s")
         try:
             os.makedirs(current_tmpdir)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2067,7 +2067,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
             mytmpdir = set_tmpdir(tmpdir=tmpdir)
 
-            parent = re.sub('[^\w/.-]', '_', parent)
+            parent = re.sub('[^\w/.-]', 'X', parent)
 
             for var in ['TMPDIR', 'TEMP', 'TMP']:
                 self.assertTrue(os.environ[var].startswith(os.path.join(parent, 'eb-')))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2059,12 +2059,15 @@ class CommandLineOptionsTest(EnhancedTestCase):
         """Test set_tmpdir config function."""
         self.purge_environment()
 
-        for tmpdir in [None, os.path.join(tempfile.gettempdir(), 'foo')]:
+        def check_tmpdir(tmpdir):
+            """Test use of specified path for temporary directory"""
             parent = tmpdir
             if parent is None:
                 parent = tempfile.gettempdir()
 
             mytmpdir = set_tmpdir(tmpdir=tmpdir)
+
+            parent = re.sub('[^\w/.-]', '_', parent)
 
             for var in ['TMPDIR', 'TEMP', 'TMP']:
                 self.assertTrue(os.environ[var].startswith(os.path.join(parent, 'eb-')))
@@ -2083,6 +2086,17 @@ class CommandLineOptionsTest(EnhancedTestCase):
             shutil.rmtree(mytmpdir)
             modify_env(os.environ, self.orig_environ)
             tempfile.tempdir = None
+
+
+        orig_tmpdir = tempfile.gettempdir()
+        cand_tmpdirs = [
+            None,
+            os.path.join(orig_tmpdir, 'foo'),
+            os.path.join(orig_tmpdir, '[1234]. bleh'),
+            os.path.join(orig_tmpdir, '[ab @cd]%/#*'),
+        ]
+        for tmpdir in cand_tmpdirs:
+            check_tmpdir(tmpdir)
 
     def test_minimal_toolchains(self):
         """End-to-end test for --minimal-toolchains."""


### PR DESCRIPTION
I've run into this a couple of times when submitting array jobs with `eb` commands on our system using Torque, since then you end up in an environment where `$TMPDIR` is set to something like:

```
`/local/12345[3200].master15.delcatty.gent.vsc`
```

Sometimes, this breaks the build/installation for no good reason. I've seen this occur primarily when installing Python packages (it seems like `setuptools` has trouble with it), and when using `nvcc` which picks up `$TMPDIR` and uses it as a 'scratch' space, cfr. https://github.com/hpcugent/easybuild-easyblocks/pull/953#issuecomment-225613062