### PR TITLE
add support for --zip-logs

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2479,7 +2479,9 @@ def build_and_install_one(ecdict, init_env):
             dry_run_msg("(no ignored errors during dry run)\n", silent=silent)
 
     if application_log:
-        print_msg("Results of the build can be found in the log file %s" % application_log, log=_log, silent=silent)
+        # there may be multiple log files, or the file name may be different due to zipping
+        logs = glob.glob('%s*' % application_log)
+        print_msg("Results of the build can be found in the log file(s) %s" % ', '.join(logs), log=_log, silent=silent)
 
     del app
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -122,6 +122,7 @@ BUILD_OPTIONS_CMDLINE = {
         'test_report_env_filter',
         'testoutput',
         'umask',
+        'zip_logs',
     ],
     False: [
         'add_dummy_to_minimal_toolchains',

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1012,6 +1012,9 @@ def rmtree2(path, n=3):
 
 def move_logs(src_logfile, target_logfile):
     """Move log file(s)."""
+
+    zip_log_cmd = build_option('zip_logs')
+
     mkdir(os.path.dirname(target_logfile), parents=True)
     src_logfile_len = len(src_logfile)
     try:
@@ -1035,6 +1038,10 @@ def move_logs(src_logfile, target_logfile):
             # move log to target path
             shutil.move(app_log, new_log_path)
             _log.info("Moved log file %s to %s" % (src_logfile, new_log_path))
+
+            if zip_log_cmd:
+                run.run_cmd("%s %s" % (zip_log_cmd, new_log_path))
+                _log.info("Zipped log %s using '%s'", new_log_path, zip_log_cmd)
 
     except (IOError, OSError), err:
         raise EasyBuildError("Failed to move log file(s) %s* to new log file %s*: %s",

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -306,6 +306,8 @@ class EasyBuildOptions(GeneralOption):
                                           None, 'store_true', False),
             'use-existing-modules': ("Use existing modules when resolving dependencies with minimal toolchains",
                                      None, 'store_true', False),
+            'zip-logs': ("Zip logs that are copied to install directory, using specified command",
+                         None, 'store_or_None', 'gzip'),
         })
 
         self.log.debug("override_options: descr %s opts %s" % (descr, opts))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2564,6 +2564,31 @@ class CommandLineOptionsTest(EnhancedTestCase):
         err_msg = "Different length for lists of names/versions in metadata for external module"
         self.assertErrorRegex(EasyBuildError, err_msg, parse_external_modules_metadata, [testcfg])
 
+    def test_zip_logs(self):
+        """Test use of --zip-logs"""
+
+        toy_eb_install_dir = os.path.join(self.test_installpath, 'software', 'toy', '0.0', 'easybuild')
+        for zip_logs in ['', '--zip-logs', '--zip-logs=gzip', '--zip-logs=bzip2']:
+
+            out = self.eb_main(['toy-0.0.eb', '--force', zip_logs], do_build=True)
+            print out
+
+            print os.listdir(os.path.join(self.test_installpath))
+            print os.listdir(os.path.dirname(toy_eb_install_dir))
+            print os.listdir(toy_eb_install_dir)
+            logs = glob.glob(os.path.join(toy_eb_install_dir, 'easybuild-toy-0.0*log*'))
+            self.assertEqual(len(logs), 1, "Found exactly 1 log file in %s: %s" % (toy_eb_install_dir, logs))
+
+            zip_logs_arg = zip_logs.split('=')[-1]
+            if zip_logs == '--zip-logs' or zip_logs_arg == 'gzip':
+                ext = 'log.gz'
+            elif zip_logs_arg == 'bzip2':
+                ext = 'log.bz2xx'
+            else:
+                ext = 'log'
+
+            self.assertTrue(logs[0].endswith(ext), "%s has correct '%s' extension for %s" % (logs[0], ext, zip_logs))
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2570,12 +2570,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
         toy_eb_install_dir = os.path.join(self.test_installpath, 'software', 'toy', '0.0', 'easybuild')
         for zip_logs in ['', '--zip-logs', '--zip-logs=gzip', '--zip-logs=bzip2']:
 
-            out = self.eb_main(['toy-0.0.eb', '--force', zip_logs], do_build=True)
-            print out
+            shutil.rmtree(self.test_installpath)
 
-            print os.listdir(os.path.join(self.test_installpath))
-            print os.listdir(os.path.dirname(toy_eb_install_dir))
-            print os.listdir(toy_eb_install_dir)
+            args = ['toy-0.0.eb', '--force', '--debug']
+            if zip_logs:
+                args.append(zip_logs)
+            out = self.eb_main(args, do_build=True)
+
             logs = glob.glob(os.path.join(toy_eb_install_dir, 'easybuild-toy-0.0*log*'))
             self.assertEqual(len(logs), 1, "Found exactly 1 log file in %s: %s" % (toy_eb_install_dir, logs))
 
@@ -2583,7 +2584,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             if zip_logs == '--zip-logs' or zip_logs_arg == 'gzip':
                 ext = 'log.gz'
             elif zip_logs_arg == 'bzip2':
-                ext = 'log.bz2xx'
+                ext = 'log.bz2'
             else:
                 ext = 'log'
 


### PR DESCRIPTION
Log files can be quite big, especially with debugging enabled and lots of extensions.

Adding support for zipping the installed logs can make a big difference.