### PR TITLE
stick to pydot 1.1.0 for Python 2.6 in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ before_install:
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install keyring==5.7.1; else pip install 'keyring<=9.1' keyrings.alt; fi
     # GitPython 2.x may no longer be compatible with py2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'GitPython<2.0'; else pip install GitPython; fi
+    # pydot (dep for python-graph-dot) 1.2.0 and more recent doesn't work with Python 2.6
+    - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install pydot==1.1.0; else pip install pydot; fi
     # optional Python packages for EasyBuild
     - pip install autopep8 GC3Pie python-graph-dot python-hglib PyYAML
     # git config is required to make actual git commits (cfr. tests for GitRepository)


### PR DESCRIPTION
pydot 1.2.x that was released over the weekend is no longer compatible with Python 2.6