### PR TITLE
add --avail-toolchain-opts

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -188,7 +188,7 @@ def dep_graph(filename, specs):
         all_nodes.add(spec['module'])
         spec['ec'].all_dependencies = [mk_node_name(s) for s in spec['ec'].all_dependencies]
         all_nodes.update(spec['ec'].all_dependencies)
-        
+
         # Get the build dependencies for each spec so we can distinguish them later
         spec['ec'].build_dependencies = [mk_node_name(s) for s in spec['ec']['builddependencies']]
         all_nodes.update(spec['ec'].build_dependencies)

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -579,10 +579,11 @@ def avail_toolchain_opts_rst(name, tc_dict):
 
     table_titles = ['option', 'description', 'default']
 
+    tc_items = sorted(tc_dict.items())
     table_values = [
-        ['``%s``' % opt_name for opt_name in tc_dict.keys()],
-        ['%s' % val[1] for val in tc_dict.values()],
-        ['``%s``' % val[0] for val in tc_dict.values()],
+        ['``%s``' % val[0] for val in tc_items],
+        ['%s' % val[1][1] for val in tc_items],
+        ['``%s``' % val[1][0] for val in tc_items],
     ]
 
     doc = rst_title_and_table(title, table_titles, table_values)

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -53,6 +53,7 @@ from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_LOWER, TEMPL
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP, TEMPLATE_CONSTANTS
 from easybuild.framework.easyconfig.templates import TEMPLATE_SOFTWARE_VERSIONS
 from easybuild.framework.extension import Extension
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file
 from easybuild.tools.ordereddict import OrderedDict
 from easybuild.tools.toolchain.utilities import get_toolchain, search_toolchain
@@ -560,7 +561,7 @@ def avail_toolchain_opts(name, output_format=FORMAT_TXT):
     """Show list of known options for given toolchain."""
     tc_class, _ = search_toolchain(name)
     if not tc_class:
-        return "Couldn't find toolchain: '%s'. To see available toolchains, use --list-toolchains" % name
+        raise EasyBuildError("Couldn't find toolchain: '%s'. To see available toolchains, use --list-toolchains" % name)
     tc = tc_class(version='1.0') # version doesn't matter here, but needs to be defined
 
     options = [tc.COMPILER_SHARED_OPTS, tc.COMPILER_UNIQUE_OPTS, tc.MPI_SHARED_OPTS, tc.MPI_UNIQUE_OPTS]

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -46,7 +46,7 @@ from vsc.utils.missing import nub
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG, HIDDEN, sorted_categories
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
-from easybuild.framework.easyconfig.easyconfig import get_easyblock_class, ActiveMNS
+from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_CONFIG, TEMPLATE_NAMES_EASYCONFIG
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_LOWER, TEMPLATE_NAMES_LOWER_TEMPLATE

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -557,32 +557,33 @@ def list_toolchains_txt(tcs):
 
 
 def avail_toolchain_opts(name, output_format=FORMAT_TXT):
-    """Show list of known toolchains."""
+    """Show list of known options for given toolchain."""
     tc_class, _ = search_toolchain(name)
     if not tc_class:
         return "Couldn't find toolchain: '%s'. To see available toolchains, use --list-toolchains" % name
-    tc = tc_class(version='1.0')
+    tc = tc_class(version='1.0') # version doesn't matter here, but needs to be defined
 
-    options = [tc.COMPILER_UNIQUE_OPTS, tc.COMPILER_SHARED_OPTS, tc.MPI_UNIQUE_OPTS, tc.MPI_SHARED_OPTS]
+    options = [tc.COMPILER_SHARED_OPTS, tc.COMPILER_UNIQUE_OPTS, tc.MPI_SHARED_OPTS, tc.MPI_UNIQUE_OPTS]
 
     tc_dict = {}
     for opt in options:
-        if opt: # can be None
+        if opt is not None:
             tc_dict.update(opt)
 
     return generate_doc('avail_toolchain_opts_%s' % output_format, [name, tc_dict])
 
 
 def avail_toolchain_opts_rst(name, tc_dict):
-    """ Returns overview of all toolchains in rst format """
+    """ Returns overview of toolchain options in rst format """
     title = "Available options for %s toolchain:" % name
 
     table_titles = ['option', 'description', 'default']
 
-    table_values = [[] for i in range(len(table_titles))]
-    table_values[0] = ['``%s``' % opt_name for opt_name in tc_dict.keys()]
-    table_values[1] = ['%s' % val[1] for val in tc_dict.values()]
-    table_values[2] = ['``%s``' % val[0] for val in tc_dict.values()]
+    table_values = [
+        ['``%s``' % opt_name for opt_name in tc_dict.keys()],
+        ['%s' % val[1] for val in tc_dict.values()],
+        ['``%s``' % val[0] for val in tc_dict.values()],
+    ]
 
     doc = rst_title_and_table(title, table_titles, table_values)
 
@@ -590,7 +591,7 @@ def avail_toolchain_opts_rst(name, tc_dict):
 
 
 def avail_toolchain_opts_txt(name, tc_dict):
-    """ Returns overview of all toolchains in txt format """
+    """ Returns overview of toolchain options in txt format """
     doc = ["Available options for %s toolchain:" % name]
     for opt_name in sorted(tc_dict.keys()):
         doc.append("%s%s: %s (default: %s)" % (INDENT_4SPACES, opt_name, tc_dict[opt_name][1], tc_dict[opt_name][0]))

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -57,7 +57,7 @@ from easybuild.tools.config import DEFAULT_REPOSITORY
 from easybuild.tools.config import get_pretend_installpath, mk_full_default_path
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
 from easybuild.tools.docs import FORMAT_TXT, FORMAT_RST
-from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses
+from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses, avail_toolchain_opts
 from easybuild.tools.docs import avail_easyconfig_params, avail_easyconfig_templates, list_easyblocks, list_toolchains
 from easybuild.tools.environment import restore_env, unset_env_vars
 from easybuild.tools.filetools import mkdir
@@ -407,6 +407,8 @@ class EasyBuildOptions(GeneralOption):
             'avail-easyconfig-templates': (("Show all template names and template constants "
                                             "that can be used in easyconfigs."),
                                            None, 'store_true', False),
+            'avail-toolchain-opts': (("Show options for toolchain",
+                                       'str', 'store', None)),
             'check-conflicts': ("Check for version conflicts in dependency graphs", None, 'store_true', False),
             'dep-graph': ("Create dependency graph", None, 'store', None, {'metavar': 'depgraph.<ext>'}),
             'dump-env-script': ("Dump source script to set up build environment based on toolchain/dependencies",
@@ -602,7 +604,7 @@ class EasyBuildOptions(GeneralOption):
                 self.options.avail_easyconfig_constants, self.options.avail_easyconfig_licenses,
                 self.options.avail_repositories, self.options.show_default_moduleclasses,
                 self.options.avail_modules_tools, self.options.avail_module_naming_schemes,
-                self.options.show_default_configfiles,
+                self.options.show_default_configfiles, self.options.avail_toolchain_opts,
                 ]):
             build_easyconfig_constants_dict()  # runs the easyconfig constants sanity check
             self._postprocess_list_avail()
@@ -712,6 +714,10 @@ class EasyBuildOptions(GeneralOption):
         # dump known toolchains
         if self.options.list_toolchains:
             msg += list_toolchains(self.options.output_format)
+
+        # dump known toolchain options
+        if self.options.avail_toolchain_opts:
+            msg += avail_toolchain_opts(str(self.options.avail_toolchain_opts), self.options.output_format)
 
         # dump known repository types
         if self.options.avail_repositories:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -407,8 +407,7 @@ class EasyBuildOptions(GeneralOption):
             'avail-easyconfig-templates': (("Show all template names and template constants "
                                             "that can be used in easyconfigs."),
                                            None, 'store_true', False),
-            'avail-toolchain-opts': (("Show options for toolchain",
-                                       'str', 'store', None)),
+            'avail-toolchain-opts': ("Show options for toolchain", 'str', 'store', None),
             'check-conflicts': ("Check for version conflicts in dependency graphs", None, 'store_true', False),
             'dep-graph': ("Create dependency graph", None, 'store', None, {'metavar': 'depgraph.<ext>'}),
             'dump-env-script': ("Dump source script to set up build environment based on toolchain/dependencies",
@@ -717,7 +716,7 @@ class EasyBuildOptions(GeneralOption):
 
         # dump known toolchain options
         if self.options.avail_toolchain_opts:
-            msg += avail_toolchain_opts(str(self.options.avail_toolchain_opts), self.options.output_format)
+            msg += avail_toolchain_opts(self.options.avail_toolchain_opts, self.options.output_format)
 
         # dump known repository types
         if self.options.avail_repositories:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -57,8 +57,9 @@ from easybuild.tools.config import DEFAULT_REPOSITORY
 from easybuild.tools.config import get_pretend_installpath, mk_full_default_path
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
 from easybuild.tools.docs import FORMAT_TXT, FORMAT_RST
-from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses, avail_toolchain_opts
-from easybuild.tools.docs import avail_easyconfig_params, avail_easyconfig_templates, list_easyblocks, list_toolchains
+from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses
+from easybuild.tools.docs import avail_toolchain_opts, avail_easyconfig_params, avail_easyconfig_templates
+from easybuild.tools.docs import list_easyblocks, list_toolchains
 from easybuild.tools.environment import restore_env, unset_env_vars
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.github import GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, HAVE_GITHUB_API, HAVE_KEYRING


### PR DESCRIPTION
see https://github.com/hpcugent/easybuild/issues/66

**eb --avail-toolchain opts intel**
```
Available options for intel toolchain:
    32bit: Compile 32bit target (default: False)
    cciscxx: Use CC as CXX (default: False)
    cstd: Specify C standard (default: None)
    debug: Enable debug (default: False)
    defaultopt: Default compiler optimizations (default: False)
    defaultprec: Default precision (default: False)
    error-unknown-option: Error instead of warning for unknown options (default: False)
    i8: Integers are 8 byte integers (default: False)
    intel-static: Link Intel provided libraries statically (default: False)
    loose: Loose precision (default: False)
    lowopt: Low compiler optimizations (default: False)
    no-icc: Don't set Intel specific macros (default: False)
    noopt: Disable compiler optimizations (default: False)
    openmp: Enable OpenMP (default: False)
    opt: High compiler optimizations (default: False)
    optarch: Enable architecture optimizations (default: True)
    packed-linker-options: Pack the linker options as comma separated list (default: False)
    pic: Use PIC (default: False)
    precise: High precision (default: False)
    r8: Real is 8 byte real (default: False)
    shared: Build shared library (default: False)
    static: Build static library (default: False)
    strict: Strict (highest) precision (default: False)
    unroll: Unroll loops (default: False)
    usempi: Use MPI compiler as default compiler (default: False)
    verbose: Verbose output (default: False)
    veryloose: Very loose precision (default: False)
```

**eb --avail-toolchain opts intel --output-format=rst**
```
Available options for intel toolchain:
--------------------------------------

=========================    ===============================================    =========
option                       description                                        default  
=========================    ===============================================    =========
``32bit``                    Compile 32bit target                               ``False``
``cciscxx``                  Use CC as CXX                                      ``False``
``cstd``                     Specify C standard                                 ``None`` 
``debug``                    Enable debug                                       ``False``
``defaultopt``               Default compiler optimizations                     ``False``
``defaultprec``              Default precision                                  ``False``
``error-unknown-option``     Error instead of warning for unknown options       ``False``
``i8``                       Integers are 8 byte integers                       ``False``
``intel-static``             Link Intel provided libraries statically           ``False``
``loose``                    Loose precision                                    ``False``
``lowopt``                   Low compiler optimizations                         ``False``
``no-icc``                   Don't set Intel specific macros                    ``False``
``noopt``                    Disable compiler optimizations                     ``False``
``openmp``                   Enable OpenMP                                      ``False``
``opt``                      High compiler optimizations                        ``False``
``optarch``                  Enable architecture optimizations                  ``True`` 
``packed-linker-options``    Pack the linker options as comma separated list    ``False``
``pic``                      Use PIC                                            ``False``
``precise``                  High precision                                     ``False``
``r8``                       Real is 8 byte real                                ``False``
``shared``                   Build shared library                               ``False``
``static``                   Build static library                               ``False``
``strict``                   Strict (highest) precision                         ``False``
``unroll``                   Unroll loops                                       ``False``
``usempi``                   Use MPI compiler as default compiler               ``False``
``verbose``                  Verbose output                                     ``False``
``veryloose``                Very loose precision                               ``False``
=========================    ===============================================    =========

```

