### PR TITLE
make --check-conflicts report source of conflicts

### DIFF
--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -85,7 +85,7 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
         return (spec['name'], det_full_ec_version(spec))
 
     # construct a dictionary: (name, installver) tuple to (build) dependencies
-    deps_for = {}
+    deps_for, dep_of = {}, {}
     for node in ordered_ecs:
         node_key = mk_key(node)
 
@@ -98,13 +98,14 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
 
         deps_for[node_key] = (build_deps, runtime_deps)
 
+        # keep track of reverse deps too
+        for dep in deps:
+            dep_of.setdefault(dep, set()).add(node_key)
+
     if check_inter_ec_conflicts:
         # add ghost entry that depends on each of the specified easyconfigs,
         # since we want to check for conflicts between specified easyconfigs too
         deps_for[(None, None)] = ([], [mk_key(e) for e in easyconfigs])
-
-    import pprint
-    #pprint.PrettyPrinter(indent=4).pprint(deps_for)
 
     # iteratively expand list of dependencies
     last_deps_for = None
@@ -124,16 +125,22 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
 
             deps_for[key] = (sorted(nub(deps_for[key][0])), sorted(nub(deps_for[key][1])))
 
-        import pprint
-        #pprint.PrettyPrinter(indent=4).pprint(deps_for)
+            # also track reverse deps (except for ghost entry)
+            if key != (None, None):
+                for dep in build_deps + runtime_deps:
+                    dep_of.setdefault(dep, set()).add(key)
 
-    def is_conflict((name, installver), (name1, installver1), (name2, installver2)):
+    def check_conflict((name, installver), dep1, dep2):
         """Check whether dependencies with given name/(install) version conflict with each other."""
         # dependencies with the same name should have the exact same install version
         # if not => CONFLICT!
-        conflict = name1 == name2 and installver1 != installver2
+        conflict = dep1[0] == dep2[0] and dep1[1] != dep2[1]
         if conflict:
-            vs_msg = "%s-%s vs %s-%s" % (name1, installver1, name2, installver2)
+            vs_msg = "%s-%s vs %s-%s " % (dep1 + dep2)
+            for dep in [dep1, dep2]:
+                if dep in dep_of:
+                    vs_msg += "\n\t%s-%s as dep of: " % dep + ', '.join('%s-%s' % d for d in sorted(dep_of[dep]))
+
             if name is None:
                 sys.stderr.write("Conflict between (dependencies of) easyconfigs: %s\n" % vs_msg)
             else:
@@ -150,7 +157,7 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
             for dep2 in (build_deps + runtime_deps)[i+1:]:
                 # don't worry about conflicts between module itself and any of its build deps
                 if dep1 != key or dep2 not in build_deps:
-                    res |= is_conflict(key, dep1, dep2)
+                    res |= check_conflict(key, dep1, dep2)
 
     return res
 

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -81,11 +81,14 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
         """Create key for dictionary with all dependencies."""
         if 'ec' in spec:
             spec = spec['ec']
+
         return (spec['name'], det_full_ec_version(spec))
 
     # construct a dictionary: (name, installver) tuple to (build) dependencies
     deps_for = {}
     for node in ordered_ecs:
+        node_key = mk_key(node)
+
         # exclude external modules, since we can't check conflicts on them (we don't even know the software name)
         build_deps = [mk_key(d) for d in node['builddependencies'] if not d.get('external_module', False)]
         deps = [mk_key(d) for d in node['ec'].all_dependencies if not d.get('external_module', False)]
@@ -93,12 +96,15 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
         # separate runtime deps from build deps
         runtime_deps = [d for d in deps if d not in build_deps]
 
-        deps_for[mk_key(node)] = [build_deps, runtime_deps]
+        deps_for[(node_key[0], node_key[1])] = (build_deps, runtime_deps)
 
     if check_inter_ec_conflicts:
         # add ghost entry that depends on each of the specified easyconfigs,
         # since we want to check for conflicts between specified easyconfigs too
-        deps_for[(None, None)] = [[], [mk_key(e) for e in easyconfigs]]
+        deps_for[(None, None)] = ([], [mk_key(e) for e in easyconfigs])
+
+    import pprint
+    pprint.PrettyPrinter(indent=4).pprint(deps_for)
 
     # iteratively expand list of dependencies
     last_deps_for = None
@@ -108,11 +114,15 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
             # extend runtime dependencies with non-build dependencies of own runtime dependencies
             for dep in runtime_deps:
                 deps_for[key][1].extend([d for d in deps_for[dep][1] if d not in deps_for[dep][0]])
-            deps_for[key][1] = sorted(nub(deps_for[key][1]))
+
             # extend build dependencies with non-build dependencies of own build dependencies
             for dep in build_deps:
                 deps_for[key][0].extend([d for d in deps_for[dep][1] if d not in deps_for[dep][0]])
-            deps_for[key][0] = sorted(nub(deps_for[key][0]))
+
+            deps_for[key] = (sorted(nub(deps_for[key][0])), sorted(nub(deps_for[key][1])))
+
+        import pprint
+        pprint.PrettyPrinter(indent=4).pprint(deps_for)
 
     def is_conflict((name, installver), (name1, installver1), (name2, installver2)):
         """Check whether dependencies with given name/(install) version conflict with each other."""
@@ -120,7 +130,7 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
         # if not => CONFLICT!
         conflict = name1 == name2 and installver1 != installver2
         if conflict:
-            vs_msg = "%s-%s vs %s-%s" % (name1, installver1, name2, installver2)
+            vs_msg = "%s-%s => %s-%s vs %s-%s" % (name, installver, name1, installver1, name2, installver2)
             if name is None:
                 sys.stderr.write("Conflict between (dependencies of) easyconfigs: %s\n" % vs_msg)
             else:

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -130,8 +130,14 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
                 for dep in build_deps + runtime_deps:
                     dep_of.setdefault(dep, set()).add(key)
 
-    def check_conflict((name, installver), dep1, dep2):
-        """Check whether dependencies with given name/(install) version conflict with each other."""
+    def check_conflict(parent, dep1, dep2):
+        """
+        Check whether dependencies with given name/(install) version conflict with each other.
+
+        @param parent: name & install version of 'parent' software
+        @param dep1: name & install version of 1st dependency
+        @param dep2: name & install version of 2nd dependency
+        """
         # dependencies with the same name should have the exact same install version
         # if not => CONFLICT!
         conflict = dep1[0] == dep2[0] and dep1[1] != dep2[1]
@@ -141,10 +147,10 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
                 if dep in dep_of:
                     vs_msg += "\n\t%s-%s as dep of: " % dep + ', '.join('%s-%s' % d for d in sorted(dep_of[dep]))
 
-            if name is None:
+            if parent[0] is None:
                 sys.stderr.write("Conflict between (dependencies of) easyconfigs: %s\n" % vs_msg)
             else:
-                specname = '%s-%s' % (name, installver)
+                specname = '%s-%s' % parent
                 sys.stderr.write("Conflict found for dependencies of %s: %s\n" % (specname, vs_msg))
 
         return conflict


### PR DESCRIPTION
fix for #1816

@verdurin: how does this look?

```
$ eb --check-conflicts sympy-0.7.2-goolf-1.4.10-Python-2.7.3.eb Seaborn-0.6.0-goolf-1.4.10-Python-2.7.5.eb Python-2.7.6-goolf-1.4.10.eb
== temporary log file in case of crash /var/folders/xl/p7lmsxcs0bsg5_zv9y9lzk5c0000gn/T/eb-9gdqhJ/easybuild-3aUchF.log
Conflict between (dependencies of) easyconfigs: Python-2.7.3-goolf-1.4.10 vs Python-2.7.5-goolf-1.4.10 
	Python-2.7.3-goolf-1.4.10 as dep of: sympy-0.7.2-goolf-1.4.10-Python-2.7.3
	Python-2.7.5-goolf-1.4.10 as dep of: Seaborn-0.6.0-goolf-1.4.10-Python-2.7.5
Conflict between (dependencies of) easyconfigs: Python-2.7.3-goolf-1.4.10 vs Python-2.7.6-goolf-1.4.10 
	Python-2.7.3-goolf-1.4.10 as dep of: sympy-0.7.2-goolf-1.4.10-Python-2.7.3
Conflict between (dependencies of) easyconfigs: Python-2.7.5-goolf-1.4.10 vs Python-2.7.6-goolf-1.4.10 
	Python-2.7.5-goolf-1.4.10 as dep of: Seaborn-0.6.0-goolf-1.4.10-Python-2.7.5
Conflict between (dependencies of) easyconfigs: zlib-1.2.7-goolf-1.4.10 vs zlib-1.2.8-goolf-1.4.10 
	zlib-1.2.7-goolf-1.4.10 as dep of: Python-2.7.3-goolf-1.4.10, Python-2.7.6-goolf-1.4.10, sympy-0.7.2-goolf-1.4.10-Python-2.7.3
	zlib-1.2.8-goolf-1.4.10 as dep of: Python-2.7.5-goolf-1.4.10, SQLite-3.8.5-goolf-1.4.10, Seaborn-0.6.0-goolf-1.4.10-Python-2.7.5, Tcl-8.6.4-goolf-1.4.10
ERROR: One or more conflicts detected!
```