### PR TITLE
revert #1832, it introduces a regression for --from-pr

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -327,18 +327,17 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
 
     develop = download_repo(repo=GITHUB_EASYCONFIGS_REPO, branch='develop', path=path)
     if not os.path.isdir(develop):
-        raise EasyBuildError("Downloading of develop branch failed: not found in %s", develop)
+        raise EasyBuildError('Downloading of develop branch failed: not found in %s', develop)
 
     patch_name = 'patch%s' % pr
-    patch_url = URL_SEPARATOR.join([GITHUB_URL, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, GITHUB_PR, '%s.patch' % pr])
-    patch_path = os.path.join(patch_url, patch_name)
-    patch = download_file(patch_name, patch_url, patch_path)
+    patch_url = URL_SEPARATOR.join([GITHUB_URL, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, GITHUB_PR, str(pr)])
+    patch = download_file(patch_name, patch_url + '.patch', path + '/' + patch_name)
     if patch is None:
-        raise EasyBuildError("Failed to download file %s to %s", patch_url, patch_path)
+        raise EasyBuildError('Failed to download file %s to %s', patch_url + '.patch', path + '/' + patch_name)
 
     result = apply_patch(patch, develop, level=1)
     if not result:
-        raise EasyBuildError("Patch of develop branch with pr %s fails", pr)
+        raise EasyBuildError('Patch of develop branch with pr %s fails', pr)
 
     _log.debug("Fetching easyconfigs from PR #%s into %s" % (pr, path))
     pr_url = lambda g: g.repos[GITHUB_EB_MAIN][GITHUB_EASYCONFIGS_REPO].pulls[pr]

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -327,17 +327,19 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
 
     develop = download_repo(repo=GITHUB_EASYCONFIGS_REPO, branch='develop', path=path)
     if not os.path.isdir(develop):
-        raise EasyBuildError('Downloading of develop branch failed: not found in %s', develop)
+        raise EasyBuildError("Downloading of develop branch failed: not found in %s" % develop)
+    try:
+        os.chdir(develop)
+    except OSError:
+        _log.debug('Failed to change into directory %s: %s' % develop)
 
     patch_name = 'patch%s' % pr
     patch_url = URL_SEPARATOR.join([GITHUB_URL, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, GITHUB_PR, str(pr)])
     patch = download_file(patch_name, patch_url + '.patch', path + '/' + patch_name)
-    if patch is None:
-        raise EasyBuildError('Failed to download file %s to %s', patch_url + '.patch', path + '/' + patch_name)
 
     result = apply_patch(patch, develop, level=1)
     if not result:
-        raise EasyBuildError('Patch of develop branch with pr %s fails', pr)
+        raise EasyBuildError("Patch of develop branch with pr %s failed" % pr)
 
     _log.debug("Fetching easyconfigs from PR #%s into %s" % (pr, path))
     pr_url = lambda g: g.repos[GITHUB_EB_MAIN][GITHUB_EASYCONFIGS_REPO].pulls[pr]
@@ -391,7 +393,7 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
         if os.path.exists(os.path.join(develop, f)):
             ec_files.append(os.path.join(develop, f))
         else:
-            raise EasyBuildError("Coudln't find path to patched file %s", os.path.join(develop, f))
+            raise EasyBuildError("Coudln't find path to patched file %s" % os.path.join(develop, f))
 
     return ec_files
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -82,6 +82,7 @@ GITHUB_API_URL = 'https://api.github.com'
 GITHUB_DIR_TYPE = u'dir'
 GITHUB_EB_MAIN = 'hpcugent'
 GITHUB_EASYCONFIGS_REPO = 'easybuild-easyconfigs'
+GITHUB_EASYCONFIGS_REPO_DEV = 'easybuild-easyconfigs-develop'
 GITHUB_FILE_TYPE = u'file'
 GITHUB_MAX_PER_PAGE = 100
 GITHUB_MERGEABLE_STATE_CLEAN = 'clean'
@@ -326,20 +327,12 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
         mkdir(path, parents=True)
 
     develop = download_repo(repo=GITHUB_EASYCONFIGS_REPO, branch='develop', path=path)
-    if not os.path.isdir(develop):
-        raise EasyBuildError("Downloading of develop branch failed: not found in %s" % develop)
-    try:
-        os.chdir(develop)
-    except OSError:
-        _log.debug('Failed to change into directory %s: %s' % develop)
-
+    os.chdir(develop)
     patch_name = 'patch%s' % pr
     patch_url = URL_SEPARATOR.join([GITHUB_URL, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, GITHUB_PR, str(pr)])
     patch = download_file(patch_name, patch_url + '.patch', path + '/' + patch_name)
 
     result = apply_patch(patch, develop, level=1)
-    if not result:
-        raise EasyBuildError("Patch of develop branch with pr %s failed" % pr)
 
     _log.debug("Fetching easyconfigs from PR #%s into %s" % (pr, path))
     pr_url = lambda g: g.repos[GITHUB_EB_MAIN][GITHUB_EASYCONFIGS_REPO].pulls[pr]
@@ -384,16 +377,11 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     for (dirpath, _, filenames) in os.walk(path):
         tmp_files.extend([os.path.join(os.path.basename(dirpath), f) for f in filenames])
 
-    for patched in all_files:
-        if not patched in tmp_files:
-            raise EasyBuildError("Couldn't find file in %s: %s", path, patched)
+    for file in all_files:
+        if not file in tmp_files:
+            raise EasyBuildError("Couldn't find file in %s: %s", path, file)
 
-    ec_files = []
-    for f in patched_files:
-        if os.path.exists(os.path.join(develop, f)):
-            ec_files.append(os.path.join(develop, f))
-        else:
-            raise EasyBuildError("Coudln't find path to patched file %s" % os.path.join(develop, f))
+    ec_files = [os.path.join(path, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO_DEV, f) for f in patched_files]
 
     return ec_files
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -47,8 +47,8 @@ from vsc.utils.missing import nub
 from easybuild.framework.easyconfig.easyconfig import copy_easyconfigs
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
-from easybuild.tools.filetools import apply_patch, det_patched_files, download_file, extract_file
-from easybuild.tools.filetools import mkdir, read_file, which, write_file
+from easybuild.tools.filetools import det_patched_files, download_file, extract_file, mkdir, read_file
+from easybuild.tools.filetools import which, write_file
 from easybuild.tools.systemtools import UNKNOWN, get_tool_version
 from easybuild.tools.utilities import only_if_module_is_available
 
@@ -82,11 +82,9 @@ GITHUB_API_URL = 'https://api.github.com'
 GITHUB_DIR_TYPE = u'dir'
 GITHUB_EB_MAIN = 'hpcugent'
 GITHUB_EASYCONFIGS_REPO = 'easybuild-easyconfigs'
-GITHUB_EASYCONFIGS_REPO_DEV = 'easybuild-easyconfigs-develop'
 GITHUB_FILE_TYPE = u'file'
 GITHUB_MAX_PER_PAGE = 100
 GITHUB_MERGEABLE_STATE_CLEAN = 'clean'
-GITHUB_PR = 'pull'
 GITHUB_RAW = 'https://raw.githubusercontent.com'
 GITHUB_STATE_CLOSED = 'closed'
 HTTP_STATUS_OK = 200
@@ -326,14 +324,6 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
         # make sure path exists, create it if necessary
         mkdir(path, parents=True)
 
-    develop = download_repo(repo=GITHUB_EASYCONFIGS_REPO, branch='develop', path=path)
-    os.chdir(develop)
-    patch_name = 'patch%s' % pr
-    patch_url = URL_SEPARATOR.join([GITHUB_URL, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, GITHUB_PR, str(pr)])
-    patch = download_file(patch_name, patch_url + '.patch', path + '/' + patch_name)
-
-    result = apply_patch(patch, develop, level=1)
-
     _log.debug("Fetching easyconfigs from PR #%s into %s" % (pr, path))
     pr_url = lambda g: g.repos[GITHUB_EB_MAIN][GITHUB_EASYCONFIGS_REPO].pulls[pr]
 
@@ -370,6 +360,15 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     last_commit = commits_data[-1]
     _log.debug("Commits: %s, last commit: %s" % (commits_data, last_commit['sha']))
 
+    # obtain most recent version of patched files
+    for patched_file in patched_files:
+        # path to patch file, incl. subdir it is in
+        fn = os.path.sep.join(patched_file.split(os.path.sep)[-2:])
+        sha = last_commit['sha']
+        full_url = URL_SEPARATOR.join([GITHUB_RAW, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, sha, patched_file])
+        _log.info("Downloading %s from %s" % (fn, full_url))
+        download_file(fn, full_url, path=os.path.join(path, fn), forced=True)
+
     # sanity check: make sure all patched files are downloaded
     all_files = [os.path.sep.join(f.split(os.path.sep)[-2:]) for f in patched_files]
 
@@ -377,11 +376,10 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     for (dirpath, _, filenames) in os.walk(path):
         tmp_files.extend([os.path.join(os.path.basename(dirpath), f) for f in filenames])
 
-    for file in all_files:
-        if not file in tmp_files:
-            raise EasyBuildError("Couldn't find file in %s: %s", path, file)
+    if not sorted(tmp_files) == sorted(all_files):
+        raise EasyBuildError("Not all patched files were downloaded to %s: %s vs %s", path, tmp_files, all_files)
 
-    ec_files = [os.path.join(path, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO_DEV, f) for f in patched_files]
+    ec_files = [os.path.join(path, f) for f in tmp_files]
 
     return ec_files
 


### PR DESCRIPTION
#1832 introduces a regression, i.e. that `--from-pr` can potentially no longer be used on merged PRs, especially PRs that were merged a long time ago, because the patch taken from the PR no longer applies to current `develop`

Trying to apply the patch with `--forward` enabled may help, but is likely insufficient since the patch may be broken due to further intermittent changes to `develop` since the PR has been merged.

cc @Caylo