### PR TITLE
fix type conversion for checksums

### DIFF
--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -400,13 +400,24 @@ def to_dependencies(dep_list):
     """
     return [to_dependency(dep) for dep in dep_list]
 
+
 def to_checksums(checksums):
     """Ensure correct element types for list of checksums: convert list elements to tuples."""
-    if all(isinstance(cs, (list, tuple)) for cs in checksums):
-        # if all elements are lists/tuples, we convert each individual element to a string/tuple list
-        res = [to_list_of_strings_and_tuples(cs) for cs in checksums]
-    else:
-        res = to_list_of_strings_and_tuples(checksums)
+    res = []
+    for checksum in checksums:
+        # each list entry can be:
+        # * a string (MD5 checksum)
+        # * a tuple with 2 elements: checksum type + checksum value
+        # * a list of checksums (i.e. multiple checksums for a single file)
+        if isinstance(checksum, basestring):
+            res.append(checksum)
+        elif isinstance(checksum, (list, tuple)):
+            # 2 elements + only string/int values => a checksum tuple
+            if len(checksum) == 2 and all(isinstance(x, (basestring, int)) for x in checksum):
+                res.append(tuple(checksum))
+            else:
+                res.append(to_checksums(checksum))
+
     return res
 
 

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -531,7 +531,11 @@ class TypeCheckingTest(EnhancedTestCase):
         test_inputs = [
             ['be662daa971a640e40be5c804d9d7d10'],
             ['be662daa971a640e40be5c804d9d7d10', ('md5', 'be662daa971a640e40be5c804d9d7d10')],
+            [['be662daa971a640e40be5c804d9d7d10', ('md5', 'be662daa971a640e40be5c804d9d7d10')]],
             [('md5', 'be662daa971a640e40be5c804d9d7d10')],
+            ['be662daa971a640e40be5c804d9d7d10', ('adler32', '0x998410035'), ('crc32', '0x1553842328'),
+             ('md5', 'be662daa971a640e40be5c804d9d7d10'), ('sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'),
+             ('size', 273)],
         ]
         for checksums in test_inputs:
             self.assertEqual(to_checksums(checksums), checksums)

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -35,8 +35,9 @@ from easybuild.framework.easyconfig.types import as_hashable, check_element_type
 from easybuild.framework.easyconfig.types import check_required_keys, check_type_of_param_value, convert_value_type
 from easybuild.framework.easyconfig.types import DEPENDENCIES, DEPENDENCY_DICT, NAME_VERSION_DICT
 from easybuild.framework.easyconfig.types import SANITY_CHECK_PATHS_DICT, STRING_OR_TUPLE_LIST
-from easybuild.framework.easyconfig.types import is_value_of_type, to_name_version_dict, to_dependencies, to_dependency
-from easybuild.framework.easyconfig.types import to_list_of_strings_and_tuples, to_sanity_check_paths_dict
+from easybuild.framework.easyconfig.types import is_value_of_type, to_checksums, to_dependencies, to_dependency
+from easybuild.framework.easyconfig.types import to_list_of_strings_and_tuples, to_name_version_dict
+from easybuild.framework.easyconfig.types import to_sanity_check_paths_dict
 from easybuild.tools.build_log import EasyBuildError
 
 
@@ -524,6 +525,16 @@ class TypeCheckingTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_msg, to_sanity_check_paths_dict, {'files': 'foo', 'dirs': []})
         error_msg = "Expected elements to be of type string, tuple or list"
         self.assertErrorRegex(EasyBuildError, error_msg, to_sanity_check_paths_dict, {'files': [], 'dirs': [1]})
+
+    def test_to_checksums(self):
+        """Test to_checksums function."""
+        test_inputs = [
+            ['be662daa971a640e40be5c804d9d7d10'],
+            ['be662daa971a640e40be5c804d9d7d10', ('md5', 'be662daa971a640e40be5c804d9d7d10')],
+            [('md5', 'be662daa971a640e40be5c804d9d7d10')],
+        ]
+        for checksums in test_inputs:
+            self.assertEqual(to_checksums(checksums), checksums)
 
 
 def suite():


### PR DESCRIPTION
@Caylo I noticed that the case of a single checksum being listed as `[('md5', '...')]` got broken with #1826, we'll need to fix that since this introduces a regression and breaks a handful of existing easyconfigs, e.g. https://github.com/hpcugent/easybuild-easyconfigs/blob/master/easybuild/easyconfigs/c/CUDA/CUDA-6.5.14.eb and https://github.com/hpcugent/easybuild-easyconfigs/blob/master/easybuild/easyconfigs/c/CAP3/CAP3-20071221-intel-x86_64.eb, resulting in errors like:

```
== 2016-07-09 22:09:04,289 easyblock.py:2519 INFO Running source_checksum_step step
== 2016-07-09 22:09:04,289 filetools.py:463 DEBUG Using blocksize 16777216 for calculating the checksum
== 2016-07-09 22:09:06,276 filetools.py:502 DEBUG Computed md5 checksum for /user/data/gent/vsc400/vsc40023/EasyBuild/sources/c/CUDA/cuda_6.5.14_linux_64.run: 90b1b8f77313600cc294d9271741f4da (correct checksum: md5)
== 2016-07-09 22:09:06,361 build_log.py:152 ERROR Checksum verification for /user/data/gent/vsc400/vsc40023/EasyBuild/sources/c/CUDA/cuda_6.5.14_linux_64.run using ['md5', '90b1b8f77313600cc294d9271741f4da'] failed. (at easybuild/framework/easyblock.py:1489 in checksum_step)
```

please fix? :)