### PR TITLE
don't resolve path to Lmod command

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -249,7 +249,7 @@ class ModulesTool(object):
         """Check whether modules tool command is available."""
         cmd_path = which(self.cmd)
         if cmd_path is not None:
-            self.cmd = os.path.realpath(cmd_path)
+            self.cmd = cmd_path
             self.log.info("Full path for module command is %s, so using it" % self.cmd)
         else:
             mod_tool = self.__class__.__name__

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -160,7 +160,7 @@ class ModulesToolTest(EnhancedTestCase):
             init_config(build_options=build_options)
 
             lmod = Lmod(testing=True)
-            self.assertEqual(lmod.cmd, os.path.realpath(lmod_abspath))
+            self.assertTrue(os.path.samefile(lmod.cmd, lmod_abspath))
 
             # drop any location where 'lmod' or 'spider' can be found from $PATH
             paths = os.environ.get('PATH', '').split(os.pathsep)
@@ -187,7 +187,7 @@ class ModulesToolTest(EnhancedTestCase):
             os.environ['LMOD_CMD'] = fake_path
             init_config(build_options=build_options)
             lmod = Lmod(testing=True)
-            self.assertEqual(lmod.cmd, os.path.realpath(fake_path))
+            self.assertTrue(os.path.samefile(lmod.cmd, fake_path))
 
             # use correct full path for 'lmod' via $LMOD_CMD
             os.environ['LMOD_CMD'] = lmod_abspath


### PR DESCRIPTION
there is no good reason to resolve the path to the Lmod command, which was added in #1793 for the sake of the tests

resolving the path may lead to problem in practice, when `eb` is being run while the Lmod installation is being upgraded

cc @wpoely86 