### PR TITLE
Fix issue #1887

### DIFF
--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -356,7 +356,10 @@ def stage1(tmpdir, sourcepath, distribute_egg_dir):
 
     # clear the Python search path, we only want the individual eggs dirs to be in the PYTHONPATH (see below)
     # this is needed to avoid easy-install.pth controlling what Python packages are actually used
-    os.environ['PYTHONPATH'] = distribute_egg_dir
+    if distribute_egg_dir is not None:
+        os.environ['PYTHONPATH'] = distribute_egg_dir
+    else:
+        del os.environ['PYTHONPATH']
 
     # template string to inject in template easyconfig
     templates = {}


### PR DESCRIPTION
Fix "TypeError: putenv() argument 2 must be string" when skipping stage 0.

See comments on issue #1887 for more details.