### PR TITLE
Add support for github organizations 

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -104,6 +104,7 @@ BUILD_OPTIONS_CMDLINE = {
         'pr_target_branch',
         'pr_target_repo',
         'github_user',
+        'github_org',
         'group',
         'ignore_dirs',
         'job_backend_config',

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -214,14 +214,6 @@ class GithubError(Exception):
     pass
 
 
-def get_github_account():
-    """
-    Helper method, for retrieving the GitHub account for creating PR.
-    @return: github account name
-    """
-    if build_option('github_org'):
-        return build_option('github_org')
-    return build_option('github_user')
 
 def github_api_get_request(request_f, github_user=None, token=None, **kwargs):
     """
@@ -728,7 +720,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, target
     git_repo.index.commit(commit_msg)
 
     # push to GitHub
-    github_account =  get_github_account()
+    github_account =  build_option('github_org') or build_option('github_user')
     github_url = 'git@github.com:%s/%s.git' % (github_account, pr_target_repo)
     salt = ''.join(random.choice(string.letters) for _ in range(5))
     remote_name = 'github_%s_%s' % (github_account, salt)
@@ -859,10 +851,10 @@ def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
     # collect GitHub info we'll need
     # * GitHub username to push branch to repo
     # * GitHub token to open PR
-    github_user = github_account = build_option('github_user')
+    github_user = build_option('github_user')
     if github_user is None:
         raise EasyBuildError("GitHub user must be specified to use --new-pr")
-    github_account = get_github_account()
+    github_account = build_option('github_org') or build_option('github_user')
 
     github_token = fetch_github_token(github_user)
     if github_token is None:
@@ -1010,7 +1002,7 @@ def check_github():
     # GitHub user
     print_msg("* GitHub user...", log=_log, prefix=False, newline=False)
     github_user = build_option('github_user')
-    github_account = get_github_account()
+    github_account = build_option('github_org') or build_option('github_user')
 
     if github_user is None:
         check_res = "(none available) => FAIL"

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -214,6 +214,15 @@ class GithubError(Exception):
     pass
 
 
+def get_github_account():
+    """
+    Helper method, for retrieving the GitHub account for creating PR.
+    @return: github account name
+    """
+    if build_option('github_org'):
+        return build_option('github_org')
+    return build_option('github_user')
+
 def github_api_get_request(request_f, github_user=None, token=None, **kwargs):
     """
     Helper method, for performing get requests to GitHub API.
@@ -719,9 +728,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, target
     git_repo.index.commit(commit_msg)
 
     # push to GitHub
-    github_user = github_account =  build_option('github_user')
-    if build_option('github_org'):
-        github_account = build_option('github_org')
+    github_account =  get_github_account()
     github_url = 'git@github.com:%s/%s.git' % (github_account, pr_target_repo)
     salt = ''.join(random.choice(string.letters) for _ in range(5))
     remote_name = 'github_%s_%s' % (github_account, salt)
@@ -855,8 +862,7 @@ def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
     github_user = github_account = build_option('github_user')
     if github_user is None:
         raise EasyBuildError("GitHub user must be specified to use --new-pr")
-    if build_option('github_org'):
-        github_account = build_option('github_org')
+    github_account = get_github_account()
 
     github_token = fetch_github_token(github_user)
     if github_token is None:
@@ -1003,9 +1009,9 @@ def check_github():
 
     # GitHub user
     print_msg("* GitHub user...", log=_log, prefix=False, newline=False)
-    github_user = github_account = build_option('github_user')
-    if build_option('github_org'):
-        github_account = build_option('github_org')
+    github_user = build_option('github_user')
+    github_account = get_github_account()
+
     if github_user is None:
         check_res = "(none available) => FAIL"
         status['--new-pr'] = status['--update-pr'] = status['--upload-test-report'] = False

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -450,6 +450,7 @@ class EasyBuildOptions(GeneralOption):
             'from-pr': ("Obtain easyconfigs from specified PR", int, 'store', None, {'metavar': 'PR#'}),
             'git-working-dirs-path': ("Path to Git working directories for EasyBuild repositories", str, 'store', None),
             'github-user': ("GitHub username", str, 'store', None),
+            'github-org': ("GitHub organization", str, 'store', None),
             'install-github-token': ("Install GitHub token (requires --github-user)", None, 'store_true', False),
             'new-pr': ("Open a new pull request", None, 'store_true', False),
             'pr-branch-name': ("Branch name to use for new PRs; '<timestamp>_new_pr_<name><version>' if unspecified",

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2297,8 +2297,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"^\* title: \"\{tools\}\[gompi/1.3.12\] toy v0.0\"",
             r"\(created using `eb --new-pr`\)",  # description
             r"^\* overview of changes:",
-            r".*/toy-0.0-gompi-1.3.12-test.eb\s+\|\s+[0-9]+\s+\++",
-            r".*/toy-0.0_typo.patch\s+\|\s+[0-9]+\s+\++",
+            r".*/toy-0.0-gompi-1.3.12-test.eb\s*\|",
+            r".*/toy-0.0_typo.patch\s*\|",
             r"^\s*2 files changed",
         ]
         for regex in regexs:
@@ -2337,8 +2337,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"moar letters foar teh lettre box",  # also description (see --pr-descr)
             r"^\* title: \"test-1-2-3\"",
             r"^\* overview of changes:",
-            r".*/toy-0.0-gompi-1.3.12-test.eb\s+\|\s+[0-9]+\s+\++",
-            r".*/toy-0.0_typo.patch\s+\|\s+[0-9]+\s+\++",
+            r".*/toy-0.0-gompi-1.3.12-test.eb\s*\|",
+            r".*/toy-0.0_typo.patch\s*\|",
             r"^\s*2 files changed",
         ]
         for regex in regexs:
@@ -2364,7 +2364,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regexs = [
             r"^== Determined branch name corresponding to hpcugent/easybuild-easyconfigs PR #2237: develop",
             r"^== fetching branch 'develop' from https://github.com/hpcugent/easybuild-easyconfigs.git...",
-            r".*/toy-0.0-gompi-1.3.12-test.eb\s+\|\s+[0-9]+\s+\++",
+            r".*/toy-0.0-gompi-1.3.12-test.eb\s*\|",
             r"^\s*1 file changed",
             r"^Updated hpcugent/easybuild-easyconfigs PR #2237 by pushing to branch hpcugent/develop \[DRY RUN\]",
         ]
@@ -2448,8 +2448,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         regexs = [
             r"^\* overview of changes:",
-            r".*/foo-1\.0\.eb\s+\|\s+[0-9]+\s+\++",
-            r".*/bar-2\.0\.eb\s+\|\s+[0-9]+\s+\++",
+            r".*/foo-1\.0\.eb\s*\|",
+            r".*/bar-2\.0\.eb\s*\|",
             r"^\s*2 files changed",
         ]
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2312,7 +2312,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         else:
             self.assertTrue(False, "Failed to find temporary git working dir: %s" % dirs)
 
-        GITHUB_TEST_ORG = 'test-ogranization'
+        GITHUB_TEST_ORG = 'test-organization'
         args.extend([
             '--git-working-dirs-path=%s' % git_working_dir,
             '--pr-branch-name=branch_name_for_new_pr_test',

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2312,12 +2312,14 @@ class CommandLineOptionsTest(EnhancedTestCase):
         else:
             self.assertTrue(False, "Failed to find temporary git working dir: %s" % dirs)
 
+        GITHUB_TEST_ORG = 'test-ogranization'
         args.extend([
             '--git-working-dirs-path=%s' % git_working_dir,
             '--pr-branch-name=branch_name_for_new_pr_test',
             '--pr-commit-msg="this is a commit message. really!"',
             '--pr-descr="moar letters foar teh lettre box"',
             '--pr-target-branch=master',
+            '--github-org=%s' % GITHUB_TEST_ORG,
             '--pr-target-account=boegel',  # we need to be able to 'clone' from here (via https)
             '--pr-title=test-1-2-3',
         ])
@@ -2330,7 +2332,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"^== fetching branch 'master' from https://github.com/boegel/easybuild-easyconfigs.git...",
             r"^Opening pull request \[DRY RUN\]",
             r"^\* target: boegel/easybuild-easyconfigs:master",
-            r"^\* from: %s/easybuild-easyconfigs:branch_name_for_new_pr_test" % GITHUB_TEST_ACCOUNT,
+            r"^\* from: %s/easybuild-easyconfigs:branch_name_for_new_pr_test" % GITHUB_TEST_ORG,
             r"\(created using `eb --new-pr`\)",  # description
             r"moar letters foar teh lettre box",  # also description (see --pr-descr)
             r"^\* title: \"test-1-2-3\"",


### PR DESCRIPTION
An additional options build/command-line option `github-org` was added,
to allow users to create pull requests from an
github organization instead of a user github account (#1890).
The check_github function was modified to properly check if the user has access
to the repo in the github organization.