### PR TITLE
fix 'colored' argument for review_pr, bump vsc-base requirement, define COLOR_* constants in options.py

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -251,7 +251,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         install_github_token(options.github_user, silent=build_option('silent'))
 
     elif options.review_pr:
-        print review_pr(options.review_pr, colored=options.color)
+        print review_pr(options.review_pr, colored=use_color(options.color))
 
     # non-verbose cleanup after handling GitHub integration stuff or printing terse info
     if options.check_github or options.install_github_token or options.review_pr or options.terse:

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -41,6 +41,7 @@ from vsc.utils.exceptions import LoggedException
 
 from easybuild.tools.version import VERSION
 
+
 # EasyBuild message prefix
 EB_MSG_PREFIX = "=="
 

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -56,12 +56,6 @@ DRY_RUN_BUILD_DIR = None
 DRY_RUN_SOFTWARE_INSTALL_DIR = None
 DRY_RUN_MODULES_INSTALL_DIR = None
 
-try:
-    from vsc.utils.fancylogger import Colorize
-    COLOR_AUTO = Colorize.AUTO
-except ImportError:
-    COLOR_AUTO = 'auto'
-
 
 class EasyBuildError(LoggedException):
     """
@@ -203,13 +197,10 @@ fancylogger.logToFile(filename=os.devnull)
 _init_easybuildlog = fancylogger.getLogger(fname=False)
 
 
-def init_logging(logfile, logtostdout=False, silent=False, colorize=COLOR_AUTO):
+def init_logging(logfile, logtostdout=False, silent=False, colorize=fancylogger.Colorize.AUTO):
     """Initialize logging."""
     if logtostdout:
-        try:
-            fancylogger.logToScreen(enable=True, stdout=True, colorize=colorize)
-        except TypeError:
-            fancylogger.logToScreen(enable=True, stdout=True)
+        fancylogger.logToScreen(enable=True, stdout=True, colorize=colorize)
     else:
         if logfile is None:
             # mkstemp returns (fd,filename), fd is from os.open, not regular open!

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -41,7 +41,6 @@ from vsc.utils.exceptions import LoggedException
 
 from easybuild.tools.version import VERSION
 
-
 # EasyBuild message prefix
 EB_MSG_PREFIX = "=="
 
@@ -56,6 +55,12 @@ DEPRECATED_DOC_URL = 'http://easybuild.readthedocs.org/en/latest/Deprecated-func
 DRY_RUN_BUILD_DIR = None
 DRY_RUN_SOFTWARE_INSTALL_DIR = None
 DRY_RUN_MODULES_INSTALL_DIR = None
+
+try:
+    from vsc.utils.fancylogger import Colorize
+    COLOR_AUTO = Colorize.AUTO
+except ImportError:
+    COLOR_AUTO = 'auto'
 
 
 class EasyBuildError(LoggedException):
@@ -198,10 +203,13 @@ fancylogger.logToFile(filename=os.devnull)
 _init_easybuildlog = fancylogger.getLogger(fname=False)
 
 
-def init_logging(logfile, logtostdout=False, silent=False, colorize=fancylogger.Colorize.AUTO):
+def init_logging(logfile, logtostdout=False, silent=False, colorize=COLOR_AUTO):
     """Initialize logging."""
     if logtostdout:
-        fancylogger.logToScreen(enable=True, stdout=True, colorize=colorize)
+        try:
+            fancylogger.logToScreen(enable=True, stdout=True, colorize=colorize)
+        except TypeError:
+            fancylogger.logToScreen(enable=True, stdout=True)
     else:
         if logfile is None:
             # mkstemp returns (fd,filename), fd is from os.open, not regular open!

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -100,8 +100,6 @@ XDG_CONFIG_DIRS = os.environ.get('XDG_CONFIG_DIRS', '/etc').split(os.pathsep)
 DEFAULT_SYS_CFGFILES = [f for d in XDG_CONFIG_DIRS for f in sorted(glob.glob(os.path.join(d, 'easybuild.d', '*.cfg')))]
 DEFAULT_USER_CFGFILE = os.path.join(XDG_CONFIG_HOME, 'easybuild', 'config.cfg')
 
-(COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER) = fancylogger.Colorize
-
 
 _log = fancylogger.getLogger('options', fname=False)
 
@@ -166,12 +164,13 @@ def use_color(colorize, stream=sys.stdout):
     see the ``--color`` option for their meaning.
     """
     # turn color=auto/yes/no into a boolean value
-    if colorize == COLOR_AUTO:
+    if colorize == fancylogger.Colorize.AUTO:
         return terminal_supports_colors(stream)
-    elif colorize == COLOR_ALWAYS:
+    elif colorize == fancylogger.Colorize.ALWAYS:
         return True
     else:
-        assert colorize == COLOR_NEVER, "Argument `colorize` must be one of: %s" % ', '.join(fancylogger.Colorize)
+        assert colorize == fancylogger.Colorize.NEVER, \
+            "Argument `colorize` must be one of: %s" % ', '.join(fancylogger.Colorize)
         return False
 
 
@@ -293,7 +292,8 @@ class EasyBuildOptions(GeneralOption):
                                             None, 'store_true', False),
             'cleanup-builddir': ("Cleanup build dir after successful installation.", None, 'store_true', True),
             'cleanup-tmpdir': ("Cleanup tmp dir after successful run.", None, 'store_true', True),
-            'color': ("Colorize output", 'choice', 'store', COLOR_AUTO, fancylogger.Colorize, {'metavar':'WHEN'}),
+            'color': ("Colorize output", 'choice', 'store', fancylogger.Colorize.AUTO, fancylogger.Colorize,
+                      {'metavar':'WHEN'}),
             'debug-lmod': ("Run Lmod modules tool commands in debug module", None, 'store_true', False),
             'default-opt-level': ("Specify default optimisation level", 'choice', 'store', DEFAULT_OPT_LEVEL,
                                   Compiler.COMPILER_OPT_FLAGS),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -100,6 +100,13 @@ XDG_CONFIG_DIRS = os.environ.get('XDG_CONFIG_DIRS', '/etc').split(os.pathsep)
 DEFAULT_SYS_CFGFILES = [f for d in XDG_CONFIG_DIRS for f in sorted(glob.glob(os.path.join(d, 'easybuild.d', '*.cfg')))]
 DEFAULT_USER_CFGFILE = os.path.join(XDG_CONFIG_HOME, 'easybuild', 'config.cfg')
 
+try:
+    from vsc.utils.fancylogger import Colorize
+    (COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER) = Colorize
+except ImportError:
+    (COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER) = ('auto', 'always', 'never')
+COLOR_OPTIONS = [COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER]
+
 
 _log = fancylogger.getLogger('options', fname=False)
 
@@ -164,13 +171,12 @@ def use_color(colorize, stream=sys.stdout):
     see the ``--color`` option for their meaning.
     """
     # turn color=auto/yes/no into a boolean value
-    if colorize == fancylogger.Colorize.AUTO:
+    if colorize == COLOR_AUTO:
         return terminal_supports_colors(stream)
-    elif colorize == fancylogger.Colorize.ALWAYS:
+    elif colorize == COLOR_ALWAYS:
         return True
     else:
-        assert colorize == fancylogger.Colorize.NEVER, \
-            "Argument `colorize` must be one of 'auto', 'always', or 'never'."
+        assert colorize == COLOR_NEVER, "Argument `colorize` must be one of: %s" % ', '.join(COLOR_OPTIONS)
         return False
 
 
@@ -292,9 +298,7 @@ class EasyBuildOptions(GeneralOption):
                                             None, 'store_true', False),
             'cleanup-builddir': ("Cleanup build dir after successful installation.", None, 'store_true', True),
             'cleanup-tmpdir': ("Cleanup tmp dir after successful run.", None, 'store_true', True),
-            'color': ("Colorize output", 'choice', 'store', fancylogger.Colorize.AUTO,
-                      [fancylogger.Colorize.AUTO, fancylogger.Colorize.ALWAYS, fancylogger.Colorize.NEVER],
-                      {'metavar':'WHEN'}),
+            'color': ("Colorize output", 'choice', 'store', COLOR_AUTO, COLOR_OPTIONS, {'metavar':'WHEN'}),
             'debug-lmod': ("Run Lmod modules tool commands in debug module", None, 'store_true', False),
             'default-opt-level': ("Specify default optimisation level", 'choice', 'store', DEFAULT_OPT_LEVEL,
                                   Compiler.COMPILER_OPT_FLAGS),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -100,12 +100,7 @@ XDG_CONFIG_DIRS = os.environ.get('XDG_CONFIG_DIRS', '/etc').split(os.pathsep)
 DEFAULT_SYS_CFGFILES = [f for d in XDG_CONFIG_DIRS for f in sorted(glob.glob(os.path.join(d, 'easybuild.d', '*.cfg')))]
 DEFAULT_USER_CFGFILE = os.path.join(XDG_CONFIG_HOME, 'easybuild', 'config.cfg')
 
-try:
-    from vsc.utils.fancylogger import Colorize
-    (COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER) = Colorize
-except ImportError:
-    (COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER) = ('auto', 'always', 'never')
-COLOR_OPTIONS = [COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER]
+(COLOR_AUTO, COLOR_ALWAYS, COLOR_NEVER) = fancylogger.Colorize
 
 
 _log = fancylogger.getLogger('options', fname=False)
@@ -176,7 +171,7 @@ def use_color(colorize, stream=sys.stdout):
     elif colorize == COLOR_ALWAYS:
         return True
     else:
-        assert colorize == COLOR_NEVER, "Argument `colorize` must be one of: %s" % ', '.join(COLOR_OPTIONS)
+        assert colorize == COLOR_NEVER, "Argument `colorize` must be one of: %s" % ', '.join(fancylogger.Colorize)
         return False
 
 
@@ -298,7 +293,7 @@ class EasyBuildOptions(GeneralOption):
                                             None, 'store_true', False),
             'cleanup-builddir': ("Cleanup build dir after successful installation.", None, 'store_true', True),
             'cleanup-tmpdir': ("Cleanup tmp dir after successful run.", None, 'store_true', True),
-            'color': ("Colorize output", 'choice', 'store', COLOR_AUTO, COLOR_OPTIONS, {'metavar':'WHEN'}),
+            'color': ("Colorize output", 'choice', 'store', COLOR_AUTO, fancylogger.Colorize, {'metavar':'WHEN'}),
             'debug-lmod': ("Run Lmod modules tool commands in debug module", None, 'store_true', False),
             'default-opt-level': ("Specify default optimisation level", 'choice', 'store', DEFAULT_OPT_LEVEL,
                                   Compiler.COMPILER_OPT_FLAGS),

--- a/setup.py
+++ b/setup.py
@@ -122,12 +122,11 @@ implement support for installing particular (groups of) software packages.""",
     install_requires=[
         'setuptools >= 0.6',
         "vsc-install >= 0.9.19",
-        "vsc-base >= 2.4.18",
+        "vsc-base >= 2.5.3",
     ],
     extras_require = {
         'yeb': ["PyYAML >= 3.11"],
         'coloredlogs': [
-            'vsc-base[coloredlogs] >= 2.5.3',
             'coloredlogs',
             'humanfriendly',  # determine whether terminal supports ANSI color
         ],

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -51,7 +51,7 @@ from easybuild.tools.filetools import download_file, mkdir, read_file, write_fil
 from easybuild.tools.github import GITHUB_RAW, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, URL_SEPARATOR
 from easybuild.tools.github import fetch_github_token
 from easybuild.tools.modules import Lmod
-from easybuild.tools.options import EasyBuildOptions, parse_external_modules_metadata, set_tmpdir
+from easybuild.tools.options import EasyBuildOptions, parse_external_modules_metadata, set_tmpdir, use_color
 from easybuild.tools.toolchain.utilities import TC_CONST_PREFIX
 from easybuild.tools.run import run_cmd
 from easybuild.tools.version import VERSION
@@ -91,6 +91,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
         """Set up test."""
         super(CommandLineOptionsTest, self).setUp()
         self.github_token = fetch_github_token(GITHUB_TEST_ACCOUNT)
+
+        self.orig_terminal_supports_colors = easybuild.tools.options.terminal_supports_colors
+
+    def tearDown(self):
+        """Clean up after test."""
+        easybuild.tools.options.terminal_supports_colors = self.orig_terminal_supports_colors
+        super(CommandLineOptionsTest, self).tearDown()
 
     def purge_environment(self):
         """Remove any leftover easybuild variables"""
@@ -2742,6 +2749,15 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))
         else:
             print "Skipping test_debug_lmod, required Lmod as modules tool"
+
+    def test_use_color(self):
+        """Test use_color function."""
+        self.assertTrue(use_color('always'))
+        self.assertFalse(use_color('never'))
+        easybuild.tools.options.terminal_supports_colors = lambda _: True
+        self.assertTrue(use_color('auto'))
+        easybuild.tools.options.terminal_supports_colors = lambda _: False
+        self.assertFalse(use_color('auto'))
 
 
 def suite():

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2074,7 +2074,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.eb_main(['--review-pr=1484', '--color=never'], raise_error=True)
         txt = self.get_stdout()
         self.mock_stdout(False)
-        self.assertTrue(re.search(r"^Comparing zlib-1.2.8\S* with zlib-1.2.8", txt))
+        regex = re.compile(r"^Comparing zlib-1.2.8\S* with zlib-1.2.8")
+        self.assertTrue(regex.search(txt), "Pattern '%s' not found in: %s" % (regex.pattern, txt))
 
     def test_set_tmpdir(self):
         """Test set_tmpdir config function."""


### PR DESCRIPTION
~~This PR fixes the following problem with current `develop` in case the `vsc-base` version is outdated.~~

~~Since this is basically just a workaround for `vsc-base` being older than version 2.5.3 (cfr. https://github.com/hpcugent/vsc-base/pull/225), maybe we should just bump the `vsc-base` requirement instead?~~

update: this PR now basically just bumps the `vsc-base` version requirement; if you're running into the error message below, update your `vsc-base` installation

cc @riccardomurri, @wpoely86

```
Traceback (most recent call last):
  File "/usr/lib64/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/vscmnt/gent_vulpix/_/user/home/gent/vsc400/vsc40003/easybuild_easyinstalled/lib/python2.6/site-packages/easybuild_framework-2.9.0.dev0-py2.6.egg/easybuild/main.py", line 47, in <module>
    from easybuild.tools.build_log import EasyBuildError, init_logging, print_msg, print_error, stop_logging
  File "/user/home/gent/vsc400/vsc40003/easybuild_easyinstalled/lib/python2.6/site-packages/easybuild_framework-2.9.0.dev0-py2.6.egg/easybuild/tools/build_log.py", line 201, in <module>
    def init_logging(logfile, logtostdout=False, silent=False, colorize=fancylogger.Colorize.AUTO):
AttributeError: 'module' object has no attribute 'Colorize'
```
~~
