### PR TITLE
fix combining --extended-dry-run with --from-pr

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -171,7 +171,7 @@ def remove_file(path):
         raise EasyBuildError("Failed to remove %s: %s", path, err)
 
 
-def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
+def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced=False):
     """
     Given filename fn, try to extract in directory dest
     - returns the directory name in case of success
@@ -202,7 +202,7 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False):
     if extra_options:
         cmd = "%s %s" % (cmd, extra_options)
 
-    run.run_cmd(cmd, simple=True)
+    run.run_cmd(cmd, simple=True, force_in_dry_run=forced)
 
     return find_base_dir()
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -173,8 +173,14 @@ def remove_file(path):
 
 def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced=False):
     """
-    Given filename fn, try to extract in directory dest
-    - returns the directory name in case of success
+    Extract file at given path to specified directory
+    :param fn: path to file to extract
+    :param dest: location to extract to
+    :param cmd: extract command to use (derived from filename if not specified)
+    :param extra_options: extra options to pass to extract command
+    :param overwrite: overwrite existing unpacked file
+    :param forced: force extraction in (extended) dry run mode
+    :return: path to directory (in case of success)
     """
     if not os.path.isfile(fn) and not build_option('extended_dry_run'):
         raise EasyBuildError("Can't extract file %s: no such file", fn)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -303,16 +303,16 @@ def download_repo(repo=GITHUB_EASYCONFIGS_REPO, branch='master', account=GITHUB_
 
     target_path = os.path.join(path, base_name)
     _log.debug("downloading repo %s/%s as archive from %s to %s" % (account, repo, url, target_path))
-    download_file(base_name, url, target_path)
+    download_file(base_name, url, target_path, forced=True)
     _log.debug("%s downloaded to %s, extracting now" % (base_name, path))
 
-    extracted_path = os.path.join(extract_file(target_path, path), extracted_dir_name)
+    extracted_path = os.path.join(extract_file(target_path, path, forced=True), extracted_dir_name)
 
     # check if extracted_path exists
     if not os.path.isdir(extracted_path):
         raise EasyBuildError("%s should exist and contain the repo %s at branch %s", extracted_path, repo, branch)
 
-    write_file(latest_sha_path, latest_commit_sha)
+    write_file(latest_sha_path, latest_commit_sha, forced=True)
 
     _log.debug("Repo %s at branch %s extracted into %s" % (repo, branch, extracted_path))
     return extracted_path


### PR DESCRIPTION
Without this patch, combining `--from-pr` with `-x` results in an error like:

```
EasyBuildError: '/tmp/eb-96zkBo/tmpaaRyAU/hpcugent/easybuild-easyconfigs-develop
should exist and contain the repo easybuild-easyconfigs at branch develop'
```