### PR TITLE
Don't pass '--try-*' command-line options to EB instance running within job script

### DIFF
--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -127,7 +127,9 @@ def submit_jobs(ordered_ecs, cmd_line_opts, testing=False, prepare_first=True):
     curdir = os.getcwd()
 
     # the options to ignore (help options can't reach here)
-    ignore_opts = ['robot', 'job']
+    ignore_opts = ['robot', 'job', 'try-amend',
+                   'try-software', 'try-software-name', 'try-software-version',
+                   'try-toolchain', 'try-toolchain-name', 'try-toolchain-version']
 
     # generate_cmd_line returns the options in form --longopt=value
     opts = [x for x in cmd_line_opts if not x.split('=')[0] in ['--%s' % y for y in ignore_opts]]

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -307,7 +307,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # options passed are reordered, so order here matters to make tests pass
         check_args(['--debug'])
-        check_args(['--debug', '--stop=configure', '--try-software-name=foo'])
+        # --try-* options are not passed down
+        check_args(['--debug', '--stop=configure', '--try-software-name=foo'],
+                   passed_args=['--debug', '--stop=configure'])
         check_args(['--debug', '--robot-paths=/tmp/foo:/tmp/bar'])
         # --robot has preference over --robot-paths, --robot is not passed down
         check_args(['--debug', '--robot-paths=/tmp/foo', '--robot=/tmp/bar'],


### PR DESCRIPTION
As tweaking the easyconfigs is already done by the driver `eb` instance on the head node, `--try-*` command-line options don't need to be passed to the build instances running within the job scripts.  Thus, filter them out.  This should ~~fix~~ address https://github.com/hpcugent/easybuild-framework/issues/1475 (a shared `--tmpdir` is still needed as mentioned in https://github.com/hpcugent/easybuild-framework/issues/1355).

Tested with `eb --try-toolchain=gompi,2016a LAPACK-3.4.2-gompi-1.5.12.eb --job`; fails w/o the fix, succeeds with it.