### PR TITLE
convert all_dependencies to a property in EasyConfig class

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -321,10 +321,7 @@ class EasyConfig(object):
         # filter hidden dependencies from list of dependencies
         self.filter_hidden_deps()
 
-        # list of *all* dependencies, including hidden/build deps & toolchain, but excluding filtered deps
-        self.all_dependencies = copy.deepcopy(self.dependencies())
-        if self['toolchain']['name'] != DUMMY_TOOLCHAIN_NAME:
-            self.all_dependencies.append(self.toolchain.as_dict())
+        self._all_dependencies = None
 
         # keep track of whether the generated module file should be hidden
         if hidden is None:
@@ -658,6 +655,17 @@ class EasyConfig(object):
             tc_dict = self._toolchain.as_dict()
             self.log.debug("Initialized toolchain: %s (opts: %s)" % (tc_dict, self['toolchainopts']))
         return self._toolchain
+
+    @property
+    def all_dependencies(self):
+        """Return list of all dependencies, incl. hidden/build deps & toolchain, but excluding filtered deps."""
+        if self._all_dependencies is None:
+            self.log.debug("Composing list of all dependencies (incl. toolchain)")
+            self._all_dependencies = copy.deepcopy(self.dependencies())
+            if self['toolchain']['name'] != DUMMY_TOOLCHAIN_NAME:
+                self._all_dependencies.append(self.toolchain.as_dict())
+
+        return self._all_dependencies
 
     def dump(self, fp):
         """

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -191,7 +191,7 @@ def dep_graph(filename, specs):
     for spec in specs:
         spec['module'] = mk_node_name(spec['ec'])
         all_nodes.add(spec['module'])
-        spec['ec'].all_dependencies = [mk_node_name(s) for s in spec['ec'].all_dependencies]
+        spec['ec']._all_dependencies = [mk_node_name(s) for s in spec['ec'].all_dependencies]
         all_nodes.update(spec['ec'].all_dependencies)
 
         # Get the build dependencies for each spec so we can distinguish them later


### PR DESCRIPTION
This is mainly to avoid that the `toolchain` property is being accessed when an `EasyConfig` instance is created, since that i) is time-consuming, ii) can cause problems with 'special' toolchains like the `Cray*` toolchains, where a `craype-<optarch>` module *must* be available when the toolchain is instantiated (which is rather silly to do when just parsing the easyconfig file).

`all_dependencies` is only used in specific situations, i.e. when using `--dep-graph`, with `--job --robot`, and in `--check-conflicts`.

The proposed change ensures that `all_dependencies` is correctly defined when it's first accessed.

This will help speed up parsing of easyconfig files a little bit too.