### PR TITLE
bump vsc-base requirement to 2.5.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ implement support for installing particular (groups of) software packages.""",
     install_requires=[
         'setuptools >= 0.6',
         "vsc-install >= 0.9.19",
-        "vsc-base >= 2.5.3",
+        "vsc-base >= 2.5.4",
     ],
     extras_require = {
         'yeb': ["PyYAML >= 3.11"],


### PR DESCRIPTION
required since `vsc-base` 2.5.4 includes a critical bug fix compared to 2.5.3, cfr. https://github.com/hpcugent/vsc-base/pull/238/files