### PR TITLE
take into account existing % chars in to_template_str

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -242,7 +242,13 @@ def to_template_str(value, templ_const, templ_val):
         - templ_const is a dictionary of template strings (constants)
         - templ_val is an ordered dictionary of template strings specific for this easyconfig file
     """
-    old_value = None
+    orig_value, old_value = value, None
+
+    # escape any '%' characters that may occur in original value
+    if '%' in value:
+        value = value.replace('%', '%%')
+
+    templated = False
     while value != old_value:
         old_value = value
         # check for constant values
@@ -256,6 +262,13 @@ def to_template_str(value, templ_const, templ_val):
             # by another non-alphanumeric.
             if tval in value:
                 value = re.sub(r'(^|\W)' + re.escape(tval) + r'(\W|$)', r'\1%(' + tname + r')s\2', value)
+
+        if value != old_value:
+            templated = True
+
+    # if no applicable templates were found, roll back to original value (to undo potential escaping of %)
+    if not templated:
+        value = orig_value
 
     return value
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1531,14 +1531,19 @@ class EasyConfigTest(EnhancedTestCase):
             '-test':'special_char',
         }
 
-        self.assertEqual(to_template_str("template", templ_const, templ_val), 'TEMPLATE_VALUE')
-        self.assertEqual(to_template_str("foo/bar/0.0.1/", templ_const, templ_val), "%(name)s/bar/%(version)s/")
-        self.assertEqual(to_template_str("foo-0.0.1", templ_const, templ_val), 'NAME_VERSION')
-        templ_list = to_template_str("['-test', 'dontreplacenamehere']", templ_const, templ_val)
-        self.assertEqual(templ_list, "['%(special_char)s', 'dontreplacenamehere']")
-        templ_dict = to_template_str("{'a': 'foo', 'b': 'notemplate'}", templ_const, templ_val)
-        self.assertEqual(templ_dict, "{'a': '%(name)s', 'b': 'notemplate'}")
-        self.assertEqual(to_template_str("('foo', '0.0.1')", templ_const, templ_val), "('%(name)s', '%(version)s')")
+        pairs = [
+            ("template", 'TEMPLATE_VALUE'),
+            ("foo/bar/0.0.1/", "%(name)s/bar/%(version)s/"),
+            ("foo-0.0.1", 'NAME_VERSION'),
+            ("['-test', 'dontreplacenamehere']", "['%(special_char)s', 'dontreplacenamehere']"),
+            ("{'a': 'foo', 'b': 'notemplate'}", "{'a': '%(name)s', 'b': 'notemplate'}"),
+            ("('foo', '0.0.1')", "('%(name)s', '%(version)s')"),
+            ("foo %(source)s bar", "%(name)s %%(source)s bar"),
+            ("%(source)s", "%(source)s"),
+        ]
+
+        for inp, expected in pairs:
+            self.assertEqual(to_template_str(inp, templ_const, templ_val), expected)
 
     def test_dep_graph(self):
         """Test for dep_graph."""


### PR DESCRIPTION
@wpoely86 easyconfig test suite is currently broken because of this (because of `cmds_map` in the `FastTree` easyconfigs), as a side-effect of the templating-related changes in #1883 

It was wrong all along though, we should've been taking into account `%` already...