### PR TITLE
Revert "take into account existing % chars in to_template_str"

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -242,13 +242,7 @@ def to_template_str(value, templ_const, templ_val):
         - templ_const is a dictionary of template strings (constants)
         - templ_val is an ordered dictionary of template strings specific for this easyconfig file
     """
-    orig_value, old_value = value, None
-
-    # escape any '%' characters that may occur in original value
-    if '%' in value:
-        value = value.replace('%', '%%')
-
-    templated = False
+    old_value = None
     while value != old_value:
         old_value = value
         # check for constant values
@@ -262,13 +256,6 @@ def to_template_str(value, templ_const, templ_val):
             # by another non-alphanumeric.
             if tval in value:
                 value = re.sub(r'(^|\W)' + re.escape(tval) + r'(\W|$)', r'\1%(' + tname + r')s\2', value)
-
-        if value != old_value:
-            templated = True
-
-    # if no applicable templates were found, roll back to original value (to undo potential escaping of %)
-    if not templated:
-        value = orig_value
 
     return value
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1531,19 +1531,14 @@ class EasyConfigTest(EnhancedTestCase):
             '-test':'special_char',
         }
 
-        pairs = [
-            ("template", 'TEMPLATE_VALUE'),
-            ("foo/bar/0.0.1/", "%(name)s/bar/%(version)s/"),
-            ("foo-0.0.1", 'NAME_VERSION'),
-            ("['-test', 'dontreplacenamehere']", "['%(special_char)s', 'dontreplacenamehere']"),
-            ("{'a': 'foo', 'b': 'notemplate'}", "{'a': '%(name)s', 'b': 'notemplate'}"),
-            ("('foo', '0.0.1')", "('%(name)s', '%(version)s')"),
-            ("foo %(source)s bar", "%(name)s %%(source)s bar"),
-            ("%(source)s", "%(source)s"),
-        ]
-
-        for inp, expected in pairs:
-            self.assertEqual(to_template_str(inp, templ_const, templ_val), expected)
+        self.assertEqual(to_template_str("template", templ_const, templ_val), 'TEMPLATE_VALUE')
+        self.assertEqual(to_template_str("foo/bar/0.0.1/", templ_const, templ_val), "%(name)s/bar/%(version)s/")
+        self.assertEqual(to_template_str("foo-0.0.1", templ_const, templ_val), 'NAME_VERSION')
+        templ_list = to_template_str("['-test', 'dontreplacenamehere']", templ_const, templ_val)
+        self.assertEqual(templ_list, "['%(special_char)s', 'dontreplacenamehere']")
+        templ_dict = to_template_str("{'a': 'foo', 'b': 'notemplate'}", templ_const, templ_val)
+        self.assertEqual(templ_dict, "{'a': '%(name)s', 'b': 'notemplate'}")
+        self.assertEqual(to_template_str("('foo', '0.0.1')", templ_const, templ_val), "('%(name)s', '%(version)s')")
 
     def test_dep_graph(self):
         """Test for dep_graph."""


### PR DESCRIPTION
This reverts commit 75defac801d6c0456bba5f9ba700eaee14cd155b, cfr. #1913, since it (heavily) breaks the easyconfigs test suite (e.g. https://travis-ci.org/hpcugent/easybuild-easyconfigs/jobs/160483349)

The problem is that `to_template_str` takes *raw* strings as inputs that may represent more complex values (like lists, etc.), which may cause the `%` escaping to be incorrectly applied.

Example: `to_translate_str` transforms

```python
"[('abinit-7.0.5_x86_64_linux_gnu4.5.bz2', 'tar xfj %s')]"
```

into

```python
"[('%(namelower)s-%(version)s_x86_64_linux_gnu4.5.bz2', 'tar xfj %%s')]"
```

when the latter value is properly parsed and templates are removed, this becomes:

```python
[('abinit-7.0.5_x86_64_linux_gnu4.5.bz2', 'tar xfj %%s')]
```

which does not correspond to the original value (`tar xfj %s` vs `tar xfj %%s`)

The proper fix for the broken `easybuild-easyconfigs` test suite is to avoid combining a general template like `%(name)s` with a context specific template like `%(source)s` which needs to be escaped to make it survive general templating, cfr. https://github.com/hpcugent/easybuild-easyconfigs/pull/3575.