### PR TITLE
don't hard re-enable templating while generating template values

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -933,9 +933,10 @@ class EasyConfig(object):
 
         # step 1-3 work with easyconfig.templates constants
         # disable templating with creating dict with template values to avoid looping back to here via __getitem__
+        prev_enable_templating = self.enable_templating
         self.enable_templating = False
         template_values = template_constant_dict(self, ignore=ignore, skip_lower=skip_lower)
-        self.enable_templating = True
+        self.enable_templating = prev_enable_templating
 
         # update the template_values dict
         self.template_values.update(template_values)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -779,7 +779,14 @@ class EasyConfigTest(EnhancedTestCase):
         self.prep()
         eb = EasyConfig(self.eb_file, validate=False)
         eb.validate()
+
+        # temporarily disable templating, just so we can check later whether it's *still* disabled
+        eb.enable_templating = False
+
         eb.generate_template_values()
+
+        self.assertFalse(eb.enable_templating)
+        eb.enable_templating = True
 
         self.assertEqual(eb['description'], "test easyconfig PI")
         self.assertEqual(eb['sources'][0], 'PI-3.04.tar.gz')


### PR DESCRIPTION
proper fix to broken tests in `easybuild-easyconfigs` test suite (https://travis-ci.org/hpcugent/easybuild-easyconfigs/jobs/160432935), replacement for #1913