### PR TITLE
Small bugfix for --modules-only

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1281,7 +1281,7 @@ class EasyBlock(object):
         -- else, treat it as subdir for regular procedure
         """
         start_dir = ''
-        # do not use the specifiy 'start_dir' when running as --module-only as
+        # do not use the specified 'start_dir' when running as --module-only as
         # the directory will not exist (extract_step is skipped)
         if self.cfg['start_dir'] and not build_option('module_only'):
             start_dir = self.cfg['start_dir']

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1281,7 +1281,9 @@ class EasyBlock(object):
         -- else, treat it as subdir for regular procedure
         """
         start_dir = ''
-        if self.cfg['start_dir']:
+        # do not use the specifiy 'start_dir' when running as --module-only as
+        # the directory will not exist (extract_step is skipped)
+        if self.cfg['start_dir'] and not build_option('module_only'):
             start_dir = self.cfg['start_dir']
 
         if not os.path.isabs(start_dir):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -761,7 +761,10 @@ class EasyBlock(object):
             self.log.info("Overriding 'cleanupoldinstall' (to False), 'cleanupoldbuild' (to True) "
                           "and 'keeppreviousinstall' because we're building in the installation directory.")
             # force cleanup before installation
-            self.cfg['cleanupoldbuild'] = True
+            if not build_option('module_only'):
+                self.cfg['cleanupoldbuild'] = True
+            else:
+                self.log.debug("Not setting cleanupoldbuild because we run as module-only")
             self.cfg['keeppreviousinstall'] = False
             # avoid cleanup after installation
             self.cfg['cleanupoldinstall'] = False


### PR DESCRIPTION
If the easyconfig specified a 'start_dir', the prepare step would fail
as that directory will not exist (because we skip the extract_step).

@boegel have a look