### PR TITLE
add support for --disable-mpi-tests

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -160,6 +160,7 @@ BUILD_OPTIONS_CMDLINE = {
         'cleanup_builddir',
         'cleanup_tmpdir',
         'extended_dry_run_ignore_errors',
+        'mpi_tests',
     ],
     'warn': [
         'strict',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -325,6 +325,7 @@ class EasyBuildOptions(GeneralOption):
             'minimal-toolchains': ("Use minimal toolchain when resolving dependencies", None, 'store_true', False),
             'module-only': ("Only generate module file(s); skip all steps except for %s" % ', '.join(MODULE_ONLY_STEPS),
                             None, 'store_true', False),
+            'mpi-tests': ("Run MPI tests (when relevant)", None, 'store_true', True),
             'optarch': ("Set architecture optimization, overriding native architecture optimizations",
                         None, 'store', None),
             'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_TXT, FORMAT_RST]),


### PR DESCRIPTION
cfr. feature request #1906 by @jhein32

this only adds a new build option named `mpi_tests`, easyblocks where MPI tests are being run need to be made aware of the `mpi_tests` build option (see https://github.com/hpcugent/easybuild-easyblocks/pull/993)

disabling MPI tests can then be done using `--disable-mpi-tests`