### PR TITLE
disable cleanupoldbuild if buildininstalldir is specified, since it's enabled by default

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -761,10 +761,12 @@ class EasyBlock(object):
             self.log.info("Overriding 'cleanupoldinstall' (to False), 'cleanupoldbuild' (to True) "
                           "and 'keeppreviousinstall' because we're building in the installation directory.")
             # force cleanup before installation
-            if not build_option('module_only'):
-                self.cfg['cleanupoldbuild'] = True
+            if build_option('module_only'):
+                self.log.debug("Disabling cleanupoldbuild because we run as module-only")
+                self.cfg['cleanupoldbuild'] = False
             else:
-                self.log.debug("Not setting cleanupoldbuild because we run as module-only")
+                self.cfg['cleanupoldbuild'] = True
+
             self.cfg['keeppreviousinstall'] = False
             # avoid cleanup after installation
             self.cfg['cleanupoldinstall'] = False


### PR DESCRIPTION
this completes the fix for `--modules-only` in #1919 for builds that have `buildininstalldir` enabled