### PR TITLE
Revert "add workaround for issue with pycparser (subdep of GC3Pie) in Travis config file"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,6 @@ before_install:
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'GitPython<2.0'; else pip install GitPython; fi
     # pydot (dep for python-graph-dot) 1.2.0 and more recent doesn't work with Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install pydot==1.1.0; else pip install pydot; fi
-    # manually install pycparser (subdep of GC3Pie) to dance around issue with uploaded wheel on PyPI
-    # cfr. https://github.com/eliben/pycparser/issues/147
-    - pip install --no-binary pycparser
     # optional Python packages for EasyBuild
     - pip install autopep8 GC3Pie python-graph-dot python-hglib PyYAML
     # git config is required to make actual git commits (cfr. tests for GitRepository)


### PR DESCRIPTION
This reverts commit 328ad21f1594b555aa6d8f0cb45d9d9bef67a3b0.

https://github.com/eliben/pycparser/issues/147 is fixed, so this workaround can be reverted.