### PR TITLE
use '0' as letter dir for funky software names that don't start with a letter

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -52,8 +52,8 @@ from vsc.utils.missing import get_class_for
 import easybuild.tools.environment as env
 from easybuild.tools import config, filetools
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
-from easybuild.framework.easyconfig.easyconfig import ITERATE_OPTIONS, EasyConfig, ActiveMNS
-from easybuild.framework.easyconfig.easyconfig import get_easyblock_class, get_module_path, resolve_template
+from easybuild.framework.easyconfig.easyconfig import ITERATE_OPTIONS, EasyConfig, ActiveMNS, get_easyblock_class
+from easybuild.framework.easyconfig.easyconfig import get_module_path, letter_dir_for, resolve_template
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP
@@ -519,7 +519,7 @@ class EasyBlock(object):
             filename = url.split('/')[-1]
 
             # figure out where to download the file to
-            filepath = os.path.join(srcpaths[0], self.name[0].lower(), self.name)
+            filepath = os.path.join(srcpaths[0], letter_dir_for(self.name), self.name)
             if extension:
                 filepath = os.path.join(filepath, "extensions")
             self.log.info("Creating path %s to download file to" % filepath)
@@ -557,7 +557,7 @@ class EasyBlock(object):
             for path in ebpath + common_filepaths + srcpaths:
                 # create list of candidate filepaths
                 namepath = os.path.join(path, self.name)
-                letterpath = os.path.join(path, self.name.lower()[0], self.name)
+                letterpath = os.path.join(path, letter_dir_for(self.name), self.name)
 
                 # most likely paths
                 candidate_filepaths = [

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1285,6 +1285,19 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
     return easyconfigs
 
 
+def letter_dir_for(name):
+    """
+    Determine 'letter' directory for specified software name.
+    This usually just the 1st letter of the software name (in lowercase),
+    except for funky software names, e.g. ones starting with a digit.
+    """
+    letter = name.lower()[0]
+    if letter < 'a' or letter > 'z':
+        letter = '0'
+
+    return letter
+
+
 def create_paths(path, name, version):
     """
     Returns all the paths where easyconfig could be located
@@ -1294,11 +1307,11 @@ def create_paths(path, name, version):
     """
     cand_paths = [
         (name, version),  # e.g. <path>/GCC/4.8.2.eb
-        (name, "%s-%s" % (name, version)),  # e.g. <path>/GCC/GCC-4.8.2.eb
-        (name.lower()[0], name, "%s-%s" % (name, version)),  # e.g. <path>/g/GCC/GCC-4.8.2.eb
-        ("%s-%s" % (name, version),),  # e.g. <path>/GCC-4.8.2.eb
+        (name, '%s-%s' % (name, version)),  # e.g. <path>/GCC/GCC-4.8.2.eb
+        (letter_dir_for(name), name, '%s-%s' % (name, version)),  # e.g. <path>/g/GCC/GCC-4.8.2.eb
+        ('%s-%s' % (name, version),),  # e.g. <path>/GCC-4.8.2.eb
     ]
-    return ["%s.eb" % os.path.join(path, *cand_path) for cand_path in cand_paths]
+    return ['%s.eb' % os.path.join(path, *cand_path) for cand_path in cand_paths]
 
 
 def robot_find_easyconfig(name, version):
@@ -1398,11 +1411,7 @@ def det_location_for(path, target_dir, soft_name, target_file):
     subdir = os.path.join('easybuild', 'easyconfigs')
 
     if os.path.exists(os.path.join(target_dir, subdir)):
-        letter = soft_name.lower()[0]
-        if letter not in [chr(i) for i in range(ord('a'), ord('z') + 1)]:
-            raise EasyBuildError("Don't know which letter subdir to use for software name %s", soft_name)
-
-        target_path = os.path.join('easybuild', 'easyconfigs', letter, soft_name, target_file)
+        target_path = os.path.join('easybuild', 'easyconfigs', letter_dir_for(soft_name), soft_name, target_file)
         _log.debug("Target path for %s: %s", path, target_path)
 
         target_path = os.path.join(target_dir, target_path)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -44,7 +44,7 @@ import easybuild.tools.build_log
 import easybuild.framework.easyconfig as easyconfig
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.constants import EXTERNAL_MODULE_MARKER
-from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig, create_paths
+from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig, create_paths, letter_dir_for
 from easybuild.framework.easyconfig.easyconfig import copy_easyconfigs, get_easyblock_class, resolve_template
 from easybuild.framework.easyconfig.licenses import License, LicenseGPLv3
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
@@ -987,14 +987,37 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, "Failed to import EB_TOY", get_easyblock_class, None, name='TOY')
         self.assertEqual(get_easyblock_class(None, name='TOY', error_on_failed_import=False), None)
 
+    def test_letter_dir(self):
+        """Test letter_dir_for function."""
+        test_cases = {
+            'foo': 'f',
+            'Bar': 'b',
+            'CAPS': 'c',
+            'R': 'r',
+            '3to2': '0',
+            '7zip': '0',
+            '_bleh_': '0',
+        }
+        for name, letter in test_cases.items():
+            self.assertEqual(letter_dir_for(name), letter)
+
     def test_easyconfig_paths(self):
         """Test create_paths function."""
-        cand_paths = create_paths("/some/path", "Foo", "1.2.3")
+        cand_paths = create_paths('/some/path', 'Foo', '1.2.3')
         expected_paths = [
-            "/some/path/Foo/1.2.3.eb",
-            "/some/path/Foo/Foo-1.2.3.eb",
-            "/some/path/f/Foo/Foo-1.2.3.eb",
-            "/some/path/Foo-1.2.3.eb",
+            '/some/path/Foo/1.2.3.eb',
+            '/some/path/Foo/Foo-1.2.3.eb',
+            '/some/path/f/Foo/Foo-1.2.3.eb',
+            '/some/path/Foo-1.2.3.eb',
+        ]
+        self.assertEqual(cand_paths, expected_paths)
+
+        cand_paths = create_paths('foobar', '3to2', '1.1.1')
+        expected_paths = [
+            'foobar/3to2/1.1.1.eb',
+            'foobar/3to2/3to2-1.1.1.eb',
+            'foobar/0/3to2/3to2-1.1.1.eb',
+            'foobar/3to2-1.1.1.eb',
         ]
         self.assertEqual(cand_paths, expected_paths)
 


### PR DESCRIPTION
I noticed this when looking into an easyconfig file to `3to2` (required for https://github.com/hpcugent/easybuild-easyconfigs/pull/3655)...