### PR TITLE
add support for blas_family() and lapack_family() methods in Toolchain instances

### DIFF
--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -38,6 +38,9 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
+TC_CONSTANT_ACML = 'ACML'
+
+
 class Acml(LinAlg):
     """
     Provides ACML BLAS/LAPACK support.
@@ -46,12 +49,14 @@ class Acml(LinAlg):
     # full list of libraries is highly dependent on ACML version and toolchain compiler (ifort, gfortran, ...)
     BLAS_LIB = ['acml']
     BLAS_LIB_MT = ['acml_mp']
+    BLAS_FAMILY = TC_CONSTANT_ACML
 
     # is completed in _set_blas_variables, depends on compiler used
     BLAS_LIB_DIR = []
 
     LAPACK_MODULE_NAME = ['ACML']
     LAPACK_IS_BLAS = True
+    LAPACK_FAMILY = TC_CONSTANT_ACML
 
     ACML_SUBDIRS_MAP = {
         TC_CONSTANT_INTELCOMP: ['ifort64', 'ifort64_mp'],

--- a/easybuild/toolchains/linalg/atlas.py
+++ b/easybuild/toolchains/linalg/atlas.py
@@ -32,6 +32,9 @@ Support for ATLAS as toolchain linear algebra library.
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
+TC_CONSTANT_ATLAS = 'ATLAS'
+
+
 class Atlas(LinAlg):
     """
     Provides ATLAS BLAS/LAPACK support.
@@ -40,6 +43,8 @@ class Atlas(LinAlg):
     BLAS_MODULE_NAME = ['ATLAS']
     BLAS_LIB = ["cblas", "f77blas", "atlas"]
     BLAS_LIB_MT = ["ptcblas", "ptf77blas", "atlas"]
+    BLAS_FAMILY = TC_CONSTANT_ATLAS
 
     LAPACK_MODULE_NAME = ['ATLAS']
     LAPACK_LIB = ['lapack']
+    LAPACK_FAMILY = TC_CONSTANT_ATLAS

--- a/easybuild/toolchains/linalg/flame.py
+++ b/easybuild/toolchains/linalg/flame.py
@@ -32,8 +32,11 @@ Support for FLAME as toolchain linear algebra library.
 from easybuild.toolchains.linalg.lapack import Lapack
 
 
+TC_CONSTANT_OPENBLAS = 'FLAME'
+
+
 class Flame(Lapack):
     """Less trivial module, provides FLAME support."""
     LAPACK_MODULE_NAME = ['FLAME'] + Lapack.LAPACK_MODULE_NAME  # no super()
     LAPACK_LIB = ['lapack2flame', 'flame'] + Lapack.LAPACK_LIB  # no super()
-
+    LAPACK_FAMILY = TC_CONSTANT_FLAME

--- a/easybuild/toolchains/linalg/gotoblas.py
+++ b/easybuild/toolchains/linalg/gotoblas.py
@@ -32,9 +32,13 @@ Support for GotoBLAS as toolchain linear algebra library.
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
+TC_CONSTANT_GOTOBLAS = 'GotoBLAS'
+
+
 class GotoBLAS(LinAlg):
     """
     Trivial class, provides GotoBLAS support.
     """
     BLAS_MODULE_NAME = ['GotoBLAS']
     BLAS_LIB = ['goto']
+    BLAS_FAMILY = TC_CONSTANT_GOTOBLAS

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -42,6 +42,9 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
+TC_CONSTANT_INTELMKL = 'IntelMKL'
+
+
 class IntelMKL(LinAlg):
     """Support for Intel MKL."""
 
@@ -56,9 +59,11 @@ class IntelMKL(LinAlg):
     BLAS_LIB_MT = ["mkl_%(interface)s%(lp64)s" , "mkl_%(interface_mt)s_thread", "mkl_core"]
     BLAS_LIB_GROUP = True
     BLAS_LIB_STATIC = True
+    BLAS_FAMILY = TC_CONSTANT_INTELMKL
 
     LAPACK_MODULE_NAME = ['imkl']
     LAPACK_IS_BLAS = True
+    LAPACK_FAMILY = TC_CONSTANT_INTELMKL
 
     BLACS_MODULE_NAME = ['imkl']
     BLACS_LIB = ["mkl_blacs%(mpi)s%(lp64)s"]

--- a/easybuild/toolchains/linalg/lapack.py
+++ b/easybuild/toolchains/linalg/lapack.py
@@ -32,7 +32,11 @@ Support for LAPACK as toolchain linear algebra library.
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
+TC_CONSTANT_LAPACK = 'LAPACK'
+
+
 class Lapack(LinAlg):
     """Trivial class, provides LAPACK support."""
     LAPACK_MODULE_NAME = ['LAPACK']
     LAPACK_LIB = ['lapack']
+    LAPACK_FAMILY = TC_CONSTANT_LAPACK

--- a/easybuild/toolchains/linalg/libsci.py
+++ b/easybuild/toolchains/linalg/libsci.py
@@ -36,6 +36,7 @@ from easybuild.tools.toolchain.linalg import LinAlg
 
 
 CRAY_LIBSCI_MODULE_NAME = 'cray-libsci'
+TC_CONSTANT_CRAY_LIBSCI = 'CrayLibSci'
 
 
 class LibSci(LinAlg):
@@ -49,9 +50,11 @@ class LibSci(LinAlg):
     # FIXME: need to revisit this, on numpy we ended up with a serial BLAS through the wrapper.
     BLAS_LIB = []
     BLAS_LIB_MT = []
+    BLAS_FAMILY = TC_CONSTANT_CRAY_LIBSCI
 
     LAPACK_MODULE_NAME = [CRAY_LIBSCI_MODULE_NAME]
     LAPACK_IS_BLAS = True
+    LAPACK_FAMILY = TC_CONSTANT_CRAY_LIBSCI
 
     BLACS_MODULE_NAME = []
     SCALAPACK_MODULE_NAME = []

--- a/easybuild/toolchains/linalg/openblas.py
+++ b/easybuild/toolchains/linalg/openblas.py
@@ -31,12 +31,17 @@ Support for OpenBLAS as toolchain linear algebra library.
 from easybuild.tools.toolchain.linalg import LinAlg
 
 
+TC_CONSTANT_OPENBLAS = 'OpenBLAS'
+
+
 class OpenBLAS(LinAlg):
     """
     Trivial class, provides OpenBLAS support.
     """
     BLAS_MODULE_NAME = ['OpenBLAS']
     BLAS_LIB = ['openblas']
+    BLAS_FAMILY = TC_CONSTANT_OPENBLAS
 
     LAPACK_MODULE_NAME = ['OpenBLAS']
     LAPACK_IS_BLAS = True
+    LAPACK_FAMILY = TC_CONSTANT_OPENBLAS

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -46,6 +46,7 @@ class LinAlg(Toolchain):
     BLAS_LIB_STATIC = False
     BLAS_LIB_DIR = ['lib']
     BLAS_INCLUDE_DIR = ['include']
+    BLAS_FAMILY = None
 
     LAPACK_IS_BLAS = False
     LAPACK_REQUIRES = ['LIBBLAS']
@@ -56,6 +57,7 @@ class LinAlg(Toolchain):
     LAPACK_LIB_GROUP = False
     LAPACK_LIB_DIR = ['lib']
     LAPACK_INCLUDE_DIR = ['include']
+    LAPACK_FAMILY = None
 
     BLACS_MODULE_NAME = None
     BLACS_LIB_DIR = ['lib']
@@ -298,3 +300,17 @@ class LinAlg(Toolchain):
 
         self._add_dependency_variables(self.SCALAPACK_MODULE_NAME,
                                        ld=self.SCALAPACK_LIB_DIR, cpp=self.SCALAPACK_INCLUDE_DIR)
+
+    def blas_family(self):
+        """ Return type of BLAS library used in this toolchain."""
+        if self.BLAS_FAMILY:
+            return self.BLAS_FAMILY
+        else:
+            raise EasyBuildError("blas_family: BLAS_FAMILY is undefined.")
+
+    def lapack_family(self):
+        """ Return type of LAPACK library used in this toolchain."""
+        if self.LAPACK_FAMILY:
+            return self.LAPACK_FAMILY
+        else:
+            raise EasyBuildError("lapack_family: LAPACK_FAMILY is undefined.")

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -787,8 +787,14 @@ class Toolchain(object):
         """ Return compiler family used in this toolchain (abstract method)."""
         raise NotImplementedError
 
+    def blas_family(self):
+        "Return type of BLAS library used in this toolchain, or 'None' if BLAS is not supported."
+        return None
+
+    def lapack_family(self):
+        "Return type of LAPACK library used in this toolchain, or 'None' if LAPACK is not supported."
+        return None
+
     def mpi_family(self):
-        """ Return type of MPI library used in this toolchain or 'None' if MPI is not
-            supported.
-        """
+        "Return type of MPI library used in this toolchain, or 'None' if MPI is not supported."
         return None

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -424,6 +424,37 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
         self.assertEqual(tc.mpi_family(), "IntelMPI")
 
+    def test_blas_lapack_family(self):
+        """Test determining BLAS/LAPACK family."""
+        # check compiler-only (sub)toolchain
+        tc = self.get_toolchain("GCC", version="4.7.2")
+        tc.prepare()
+        self.assertEqual(tc.blas_family(), None)
+        self.assertEqual(tc.lapack_family(), None)
+        self.modtool.purge()
+
+        # check compiler/MPI-only (sub)toolchain
+        tc = self.get_toolchain('gompi', version='1.3.12')
+        tc.prepare()
+        self.assertEqual(tc.blas_family(), None)
+        self.assertEqual(tc.lapack_family(), None)
+        self.modtool.purge()
+
+        # check full toolchain including BLAS/LAPACK
+        tc = self.get_toolchain('goolfc', version='1.3.12')
+        tc.prepare()
+        self.assertEqual(tc.blas_family(), 'OpenBLAS')
+        self.assertEqual(tc.lapack_family(), 'OpenBLAS')
+        self.modtool.purge()
+
+        # check another one
+        self.setup_sandbox_for_intel_fftw(self.test_prefix)
+        self.modtool.prepend_module_path(self.test_prefix)
+        tc = self.get_toolchain('ictce', version='4.1.13')
+        tc.prepare()
+        self.assertEqual(tc.blas_family(), 'IntelMKL')
+        self.assertEqual(tc.lapack_family(), 'IntelMKL')
+
     def test_goolfc(self):
         """Test whether goolfc is handled properly."""
         tc = self.get_toolchain("goolfc", version="1.3.12")


### PR DESCRIPTION
This is required to get rid of some deprecated blocks of code in easyblocks like ScaLAPACK which currently use a hardcoded list of BLAS/LAPACK libraries.