### PR TITLE
Handle multi-flag compiler options on all types of options.

### DIFF
--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -137,7 +137,6 @@ class CrayPEGCC(CrayPECompiler):
     def __init__(self, *args, **kwargs):
         """CrayPEGCC constructor."""
         super(CrayPEGCC, self).__init__(*args, **kwargs)
-        self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = 'fopenmp'
         for precflag in self.COMPILER_PREC_FLAGS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = Gcc.COMPILER_UNIQUE_OPTION_MAP[precflag]
 
@@ -150,7 +149,6 @@ class CrayPEIntel(CrayPECompiler):
     def __init__(self, *args, **kwargs):
         """CrayPEIntel constructor."""
         super(CrayPEIntel, self).__init__(*args, **kwargs)
-        self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = 'fopenmp'
         for precflag in self.COMPILER_PREC_FLAGS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = IntelIccIfort.COMPILER_UNIQUE_OPTION_MAP[precflag]
 

--- a/easybuild/toolchains/compiler/cuda.py
+++ b/easybuild/toolchains/compiler/cuda.py
@@ -92,8 +92,8 @@ class Cuda(Compiler):
             'Xcompiler="%s"' % str(self.variables['CXXFLAGS']),
             'Xlinker="%s %s"' % (str(self.variables['LDFLAGS']), str(self.variables['LIBS'])),
         ]
-        self.variables.nappend('CUDA_CFLAGS', cuda_flags)
-        self.variables.nappend('CUDA_CXXFLAGS', cuda_flags)
+        self.variables.nextend('CUDA_CFLAGS', cuda_flags)
+        self.variables.nextend('CUDA_CXXFLAGS', cuda_flags)
 
         # add gencode compiler flags to list of flags for compiler variables
         for gencode_val in self.options.get('cuda_gencode', []):

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -56,7 +56,6 @@ class Gcc(Compiler):
         'f2c': 'ff2c',
         'loop': ['ftree-switch-conversion', 'floop-interchange', 'floop-strip-mine', 'floop-block'],
         'lto': 'flto',
-        'openmp': 'fopenmp',
         'strict': ['mieee-fp', 'mno-recip'],
         'precise':['mno-recip'],
         'defaultprec':[],

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -58,7 +58,6 @@ class IntelIccIfort(Compiler):
         'i8': 'i8',
         'r8': 'r8',
         'optarch': 'xHost',
-        'openmp': 'fopenmp',  # both -qopenmp/-fopenmp are valid for enabling OpenMP (-openmp is deprecated)
         'strict': ['fp-speculation=strict', 'fp-model strict'],
         'precise': ['fp-model precise'],
         'defaultprec': ['ftz', 'fp-speculation=safe', 'fp-model source'],

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -88,18 +88,19 @@ class Compiler(Toolchain):
 
     COMPILER_UNIQUE_OPTION_MAP = None
     COMPILER_SHARED_OPTION_MAP = {
-        'pic': 'fPIC',
-        'verbose': 'v',
-        'debug': 'g',
-        'unroll': 'unroll',
-        'static': 'static',
-        'shared': 'shared',
-        'noopt': 'O0',
-        'lowopt': 'O1',
         DEFAULT_OPT_LEVEL: 'O2',
-        'opt': 'O3',
         '32bit' : 'm32',
         'cstd': 'std=%(value)s',
+        'debug': 'g',
+        'lowopt': 'O1',
+        'noopt': 'O0',
+        'openmp': 'fopenmp',
+        'opt': 'O3',
+        'pic': 'fPIC',
+        'shared': 'shared',
+        'static': 'static',
+        'unroll': 'unroll',
+        'verbose': 'v',
     }
 
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = None

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -259,13 +259,13 @@ class Compiler(Toolchain):
 
         # precflags last
         for var in ['CFLAGS', 'CXXFLAGS']:
-            self.variables.nappend(var, flags)
-            self.variables.nappend(var, cflags)
+            self.variables.nextend(var, flags)
+            self.variables.nextend(var, cflags)
             self.variables.join(var, 'OPTFLAGS', 'PRECFLAGS')
 
         for var in ['FCFLAGS', 'FFLAGS', 'F90FLAGS']:
-            self.variables.nappend(var, flags)
-            self.variables.nappend(var, fflags)
+            self.variables.nextend(var, flags)
+            self.variables.nextend(var, fflags)
             self.variables.join(var, 'OPTFLAGS', 'PRECFLAGS')
 
     def _set_optimal_architecture(self):

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -310,6 +310,9 @@ class ListOfLists(list):
             raise EasyBuildError("extend_el with None value unimplemented")
         else:
             for el in value:
+		if isinstance(el, (bool,)):
+                    self.log.debug("nextend: ignoring el %s from value %s (bool)" % (el, value.__repr__()))
+                    continue
                 if not self._str_ok(el):
                     self.log.debug("nextend: ignoring el %s from value %s (not _str_ok)" % (el, value.__repr__()))
                     continue

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -310,9 +310,6 @@ class ListOfLists(list):
             raise EasyBuildError("extend_el with None value unimplemented")
         else:
             for el in value:
-		if isinstance(el, (bool,)):
-                    self.log.debug("nextend: ignoring el %s from value %s (bool)" % (el, value.__repr__()))
-                    continue
                 if not self._str_ok(el):
                     self.log.debug("nextend: ignoring el %s from value %s (not _str_ok)" % (el, value.__repr__()))
                     continue

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -281,7 +281,7 @@ class ToolchainTest(EnhancedTestCase):
                 if opt == 'optarch':
                     flag = '-%s' % tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch]
                 else:
-                    flag = '-%s' % tc.COMPILER_UNIQUE_OPTION_MAP[opt]
+                    flag = '-%s' % tc.options.options_map[opt]
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:
@@ -458,12 +458,12 @@ class ToolchainTest(EnhancedTestCase):
     def test_goolfc(self):
         """Test whether goolfc is handled properly."""
         tc = self.get_toolchain("goolfc", version="1.3.12")
-        opts = {'cuda_gencode': ['arch=compute_35,code=sm_35', 'arch=compute_10,code=compute_10']}
+        opts = {'cuda_gencode': ['arch=compute_35,code=sm_35', 'arch=compute_10,code=compute_10'], 'openmp': True}
         tc.set_options(opts)
         tc.prepare()
 
         nvcc_flags = r' '.join([
-            r'-Xcompiler="-O2 -%s"' % tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch],
+            r'-Xcompiler="-fopenmp -O2 -%s"' % tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch],
             # the use of -lcudart in -Xlinker is a bit silly but hard to avoid
             r'-Xlinker=".* -lm -lrt -lcudart -lpthread"',
             r' '.join(["-gencode %s" % x for x in opts['cuda_gencode']]),
@@ -755,7 +755,7 @@ class ToolchainTest(EnhancedTestCase):
         self.modtool.purge()
 
         tc = self.get_toolchain('goolfc', version='1.3.12')
-        tc.options.update({'openmp': True})
+        tc.set_options({'openmp': True})
         tc.prepare()
         self.assertEqual(os.environ['LIBBLAS_MT'], libblas_mt_goolfc)
         self.assertEqual(os.environ['LIBFFT_MT'], libfft_mt_goolfc)
@@ -768,11 +768,11 @@ class ToolchainTest(EnhancedTestCase):
         init_config(build_options={'optarch': 'test'})
 
         tc_cflags = {
-            'CrayCCE': "-craype-verbose -O2",
-            'CrayGNU': "-craype-verbose -O2",
-            'CrayIntel': "-craype-verbose -O2 -ftz -fp-speculation=safe -fp-model source",
-            'GCC': "-O2 -test",
-            'iccifort': "-O2 -test -ftz -fp-speculation=safe -fp-model source",
+            'CrayCCE': "-craype-verbose -homp -O2",
+            'CrayGNU': "-craype-verbose -fopenmp -O2",
+            'CrayIntel': "-craype-verbose -fopenmp -O2 -ftz -fp-speculation=safe -fp-model source",
+            'GCC': "-fopenmp -O2 -test",
+            'iccifort': "-fopenmp -O2 -test -ftz -fp-speculation=safe -fp-model source",
         }
 
         toolchains = [
@@ -788,7 +788,8 @@ class ToolchainTest(EnhancedTestCase):
             for tcname, tcversion in toolchains:
                 tc = get_toolchain({'name': tcname, 'version': tcversion}, {},
                                    mns=ActiveMNS(), modtool=self.modtool)
-                tc.set_options({})
+                # also check whether correct compiler flag for OpenMP is used while we're at it
+                tc.set_options({'openmp': True})
                 tc.prepare()
                 expected_cflags = tc_cflags[tcname]
                 msg = "Expected $CFLAGS found for toolchain %s: %s" % (tcname, expected_cflags)
@@ -924,7 +925,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertTrue(os.path.samefile(which('gcc'), os.path.join(self.test_prefix, 'scripts', 'ccache')))
         self.assertTrue(os.path.samefile(which('g++'), os.path.join(self.test_prefix, 'scripts', 'ccache')))
         self.assertTrue(os.path.samefile(which('gfortran'), os.path.join(self.test_prefix, 'scripts', 'f90cache')))
-        
+
 
 
 def suite():


### PR DESCRIPTION
`tools/toolchain/compiler.py _set_compiler_flags` should use `nextend`
instead of `nappend` when setting the actual C/F FLAGS

If there is a option that isn't a simple flag but multiple flags the use of
`self.variables.nappend(var, flags)` results in things like
`-fPIC -['someflag', 'flag2']`

Using
`self.variables.nextend(var, flags)`
instead gives the expected result of
`-fPIC -someflag -flag2`
