### PR TITLE
fix --list-software by making letter_dir_for aware of '*' wildcard name

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1291,9 +1291,14 @@ def letter_dir_for(name):
     This usually just the 1st letter of the software name (in lowercase),
     except for funky software names, e.g. ones starting with a digit.
     """
-    letter = name.lower()[0]
-    if letter < 'a' or letter > 'z':
-        letter = '0'
+    # wildcard name should result in wildcard letter
+    if name == '*':
+        letter = '*'
+    else:
+        letter = name.lower()[0]
+        # outside of a-z range, use '0'
+        if letter < 'a' or letter > 'z':
+            letter = '0'
 
     return letter
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -997,6 +997,7 @@ class EasyConfigTest(EnhancedTestCase):
             '3to2': '0',
             '7zip': '0',
             '_bleh_': '0',
+            '*': '*',
         }
         for name, letter in test_cases.items():
             self.assertEqual(letter_dir_for(name), letter)


### PR DESCRIPTION
`--list-software` is broken in `develop` without this, only easyconfig files in the `0` subdir are taken into account.

The tests didn't notice this because the easyconfig files in `test/framework/easyconfigs` are organised differently than the ones in the `easybuild-easyconfigs` repository. I'll look into how much of a PITA it is to reorganise the easyconfigs there to match the directory structure we have in the easybuild-easyconfigs repository.

This was introduced in #1954.