### PR TITLE
add support for --consider-archived-easyconfigs

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -79,6 +79,9 @@ MANDATORY_PARAMS = ['name', 'version', 'homepage', 'description', 'toolchain']
 # set of configure/build/install options that can be provided as lists for an iterated build
 ITERATE_OPTIONS = ['preconfigopts', 'configopts', 'prebuildopts', 'buildopts', 'preinstallopts', 'installopts']
 
+# name of easyconfigs archive subdirectory
+EASYCONFIGS_ARCHIVE_DIR = '__archive__'
+
 
 try:
     import autopep8
@@ -1333,6 +1336,10 @@ def robot_find_easyconfig(name, version):
         paths = []
     elif not isinstance(paths, (list, tuple)):
         paths = [paths]
+
+    # if we should also consider archived easyconfigs, duplicate paths list with archived equivalents
+    if build_option('consider_archived_easyconfigs'):
+        paths = paths + [os.path.join(p, EASYCONFIGS_ARCHIVE_DIR) for p in paths]
 
     res = None
     for path in paths:

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -46,7 +46,7 @@ from distutils.version import LooseVersion
 from vsc.utils import fancylogger
 
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
-from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig
+from easybuild.framework.easyconfig.easyconfig import EASYCONFIGS_ARCHIVE_DIR, ActiveMNS, EasyConfig
 from easybuild.framework.easyconfig.easyconfig import create_paths, get_easyblock_class, process_easyconfig
 from easybuild.framework.easyconfig.format.yeb import quote_yaml_special_chars
 from easybuild.tools.build_log import EasyBuildError, print_msg
@@ -343,6 +343,10 @@ def det_easyconfig_paths(orig_paths):
 
                 # ignore subdirs specified to be ignored by replacing items in dirnames list used by os.walk
                 dirnames[:] = [d for d in dirnames if d not in build_option('ignore_dirs')]
+
+                # ignore archived easyconfigs, unless specified otherwise
+                if not build_option('consider_archived_easyconfigs'):
+                    dirnames[:] = [d for d in dirnames if d != EASYCONFIGS_ARCHIVE_DIR]
 
             # stop os.walk insanity as soon as we have all we need (outer loop)
             if not ecs_to_find:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -178,10 +178,12 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # set by option parsers via set_tmpdir
     eb_tmpdir = tempfile.gettempdir()
 
+    search_query = options.search or options.search_filename or options.search_short
+
     # initialise logging for main
     global _log
     _log, logfile = init_logging(logfile, logtostdout=options.logtostdout,
-                                 silent=(testing or options.terse), colorize=options.color)
+                                 silent=(testing or options.terse or search_query), colorize=options.color)
 
     # disallow running EasyBuild as root
     if os.getuid() == 0:
@@ -198,8 +200,6 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # process software build specifications (if any), i.e.
     # software name/version, toolchain name/version, extra patches, ...
     (try_to_generate, build_specs) = process_software_build_specs(options)
-
-    search_query = options.search or options.search_filename or options.search_short
 
     # determine robot path
     # --try-X, --dep-graph, --search use robot path for searching, so enable it with path of installed easyconfigs

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -132,6 +132,7 @@ BUILD_OPTIONS_CMDLINE = {
     False: [
         'add_dummy_to_minimal_toolchains',
         'allow_modules_tool_mismatch',
+        'consider_archived_easyconfigs',
         'debug',
         'debug_lmod',
         'dump_autopep8',

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -384,7 +384,15 @@ def find_easyconfigs(path, ignore_dirs=None):
 
 def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filename_only=False, terse=False):
     """
-    Search for a particular file (only prints)
+    Search for files using in specified paths using specified search query (regular expression)
+
+    :param paths: list of paths to search in
+    :param query: search query to use (regular expression); will be used case-insensitive
+    :param short: figure out common prefix of hits, use variable to factor it out
+    :param ignore_dirs: list of directories to ignore (default: ['.git', '.svn'])
+    :param silent: whether or not to remain silent (don't print anything)
+    :param filename_only: only return filenames, not file paths
+    :param terse: stick to terse (machine-readable) output, as opposed to pretty-printing
     """
     if ignore_dirs is None:
         ignore_dirs = ['.git', '.svn']
@@ -395,27 +403,25 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
     # compile regex, case-insensitive
     query = re.compile(query, re.I)
 
-    var_lines = []
-    hit_lines = []
+    var_defs = []
+    hits = []
     var_index = 1
     var = None
     for path in paths:
-        hits = []
-        hit_in_path = False
+        path_hits = []
         if not terse:
             print_msg("Searching (case-insensitive) for '%s' in %s " % (query.pattern, path), log=_log, silent=silent)
 
         for (dirpath, dirnames, filenames) in os.walk(path, topdown=True):
             for filename in filenames:
                 if query.search(filename):
-                    if not hit_in_path:
+                    if not path_hits:
                         var = "CFGS%d" % var_index
                         var_index += 1
-                        hit_in_path = True
                     if filename_only:
-                        hits.append(filename)
+                        path_hits.append(filename)
                     else:
-                        hits.append(os.path.join(dirpath, filename))
+                        path_hits.append(os.path.join(dirpath, filename))
 
             # do not consider (certain) hidden directories
             # note: we still need to consider e.g., .local !
@@ -423,22 +429,17 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
             # see http://stackoverflow.com/questions/13454164/os-walk-without-hidden-folders
             dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
 
-        hits = sorted(hits)
+        path_hits = sorted(path_hits)
 
-        if hits and not terse:
-            common_prefix = det_common_path_prefix(hits)
-            if short and common_prefix is not None and len(common_prefix) > len(var) * 2:
-                var_lines.append("%s=%s" % (var, common_prefix))
-                hit_lines.extend([" * %s" % os.path.join('$%s' % var, fn[len(common_prefix) + 1:]) for fn in hits])
+        if path_hits:
+            common_prefix = det_common_path_prefix(path_hits)
+            if not terse and short and common_prefix is not None and len(common_prefix) > len(var) * 2:
+                var_defs.append((var, common_prefix))
+                hits.extend([os.path.join('$%s' % var, fn[len(common_prefix) + 1:]) for fn in path_hits])
             else:
-                hit_lines.extend([" * %s" % fn for fn in hits])
+                hits.extend(path_hits)
 
-    if terse:
-        for line in hits:
-            print(line)
-    else:
-        for line in var_lines + hit_lines:
-            print_msg(line, log=_log, silent=silent, prefix=False)
+    return var_defs, hits
 
 
 def compute_checksum(path, checksum_type=DEFAULT_CHECKSUM):

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -310,6 +310,7 @@ class EasyBuildOptions(GeneralOption):
             'cleanup-tmpdir': ("Cleanup tmp dir after successful run.", None, 'store_true', True),
             'color': ("Colorize output", 'choice', 'store', fancylogger.Colorize.AUTO, fancylogger.Colorize,
                       {'metavar':'WHEN'}),
+            'consider-archived-easyconfigs': ("Also consider archived easyconfigs", None, 'store_true', False),
             'debug-lmod': ("Run Lmod modules tool commands in debug module", None, 'store_true', False),
             'default-opt-level': ("Specify default optimisation level", 'choice', 'store', DEFAULT_OPT_LEVEL,
                                   Compiler.COMPILER_OPT_FLAGS),

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -397,7 +397,7 @@ def search_easyconfigs(query, short=False, filename_only=False, terse=False):
             cnt = len(archived_hits)
             lines.extend([
                 '',
-                "Note: %d matching archived were found, use --consider-archived-easyconfigs to see them." % cnt,
+                "Note: %d matching archived easyconfig(s) found, use --consider-archived-easyconfigs to see them" % cnt,
             ])
 
     print '\n'.join(lines)

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -360,7 +360,7 @@ def search_easyconfigs(query, short=False, filename_only=False, terse=False):
 
     ignore_dirs = build_option('ignore_dirs')
 
-    # note: don't parse down 'filename_only' here, we need the full path to filter out archived easyconfigs
+    # note: don't pass down 'filename_only' here, we need the full path to filter out archived easyconfigs
     var_defs, _hits = search_file(search_path, query, short=short, ignore_dirs=ignore_dirs, terse=terse,
                                   silent=True, filename_only=False)
 

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -353,12 +353,21 @@ def resolve_dependencies(easyconfigs, modtool, retain_all_deps=False):
 
 def search_easyconfigs(query, short=False, filename_only=False, terse=False):
     """Search for easyconfigs, if a query is provided."""
-    robot_path = build_option('robot_path')
-    if robot_path:
-        search_path = robot_path
-    else:
+    search_path = build_option('robot_path')
+    if not search_path:
         search_path = [os.getcwd()]
+
     ignore_dirs = build_option('ignore_dirs')
-    silent = build_option('silent')
-    search_file(search_path, query, short=short, ignore_dirs=ignore_dirs, silent=silent, filename_only=filename_only,
-                terse=terse)
+
+    var_defs, hits = search_file(search_path, query, short=short, ignore_dirs=ignore_dirs,
+                                 silent=build_option('silent'), filename_only=filename_only, terse=terse)
+
+    if terse:
+        lines, tmpl = [], '%s'
+    else:
+        lines = ['%s=%s' % var_def for var_def in var_defs]
+        tmpl = ' * %s'
+
+    lines.extend(tmpl % x for x in hits)
+
+    print '\n'.join(lines)

--- a/test/framework/easyconfigs/test_ecs/__archive__/i/ictce/ictce-3.2.2.u3.eb
+++ b/test/framework/easyconfigs/test_ecs/__archive__/i/ictce/ictce-3.2.2.u3.eb
@@ -1,0 +1,19 @@
+easyblock = "Toolchain"
+
+name = 'ictce'
+version = '3.2.2.u3'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolchain-compiler/'
+description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI & Intel MKL."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+# fake/empty ictce/3.2.2.u3 toolchain, just for testing purposes
+dependencies = [
+#    ('icc', '11.1.073'),
+#    ('ifort', '11.1.073'),
+#    ('impi', '4.0.0.028', '', ('iccifort', compver)),
+#    ('imkl', '10.2.6.038', '', ('iimpi', version)),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -890,6 +890,11 @@ class FileToolsTest(EnhancedTestCase):
         ]
         self.assertEqual(hits, expected)
 
+        # check combo of terse and filename-only
+        var_defs, hits = ft.search_file([test_ecs], 'HWLOC', terse=True, filename_only=True)
+        self.assertEqual(var_defs, [])
+        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.6.4.eb', 'hwloc-1.6.2-GCC-4.7.2.eb'])
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -855,6 +855,41 @@ class FileToolsTest(EnhancedTestCase):
         regex = re.compile("^file [^ ]* removed$")
         self.assertTrue(regex.match(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
+    def test_search_file(self):
+        """Test search_file function."""
+        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+
+        # check for default semantics, test case-insensitivity
+        var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True)
+        self.assertEqual(var_defs, [])
+        self.assertEqual(len(hits), 2)
+        self.assertTrue(all(os.path.exists(p) for p in hits))
+        self.assertTrue(hits[0].endswith('/hwloc-1.6.2-GCC-4.6.4.eb'))
+        self.assertTrue(hits[1].endswith('/hwloc-1.6.2-GCC-4.7.2.eb'))
+
+        # check filename-only mode
+        var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, filename_only=True)
+        self.assertEqual(var_defs, [])
+        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.6.4.eb', 'hwloc-1.6.2-GCC-4.7.2.eb'])
+
+        # check specifying of ignored dirs
+        var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, ignore_dirs=['hwloc'])
+        self.assertEqual(var_defs + hits, [])
+
+        # check short mode
+        var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, short=True)
+        self.assertEqual(var_defs, [('CFGS1', os.path.join(test_ecs, 'h', 'hwloc'))])
+        self.assertEqual(hits, ['$CFGS1/hwloc-1.6.2-GCC-4.6.4.eb', '$CFGS1/hwloc-1.6.2-GCC-4.7.2.eb'])
+
+        # check terse mode (implies 'silent', overrides 'short')
+        var_defs, hits = ft.search_file([test_ecs], 'HWLOC', terse=True, short=True)
+        self.assertEqual(var_defs, [])
+        expected = [
+            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.6.2-GCC-4.6.4.eb'),
+            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.6.2-GCC-4.7.2.eb'),
+        ]
+        self.assertEqual(hits, expected)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -689,7 +689,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         expected = '\n'.join([
             ' * ictce-4.1.13.eb',
             '',
-            "Note: 1 matching archived were found, use --consider-archived-easyconfigs to see them.",
+            "Note: 1 matching archived easyconfig(s) found, use --consider-archived-easyconfigs to see them",
         ])
         self.assertEqual(txt, expected)
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -593,8 +593,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
 
-        info_msg = r"Searching \(case-insensitive\) for 'gzip' in"
-        self.assertTrue(re.search(info_msg, txt), "Info message when searching for easyconfigs in '%s'" % txt)
         for ec in ["gzip-1.4.eb", "gzip-1.4-GCC-4.6.3.eb"]:
             regex = re.compile(r" \* \S*%s$" % ec, re.M)
             self.assertTrue(regex.search(txt), "Found pattern '%s' in: %s" % (regex.pattern, txt))
@@ -609,8 +607,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
 
-        info_msg = r"Searching \(case-insensitive\) for '\^gcc.\*2.eb' in"
-        self.assertTrue(re.search(info_msg, txt), "Info message when searching for easyconfigs in '%s'" % txt)
         for ec in ['GCC-4.7.2.eb', 'GCC-4.8.2.eb', 'GCC-4.9.2.eb']:
             regex = re.compile(r" \* \S*%s$" % ec, re.M)
             self.assertTrue(regex.search(txt), "Found pattern '%s' in: %s" % (regex.pattern, txt))
@@ -666,8 +662,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             txt = self.get_stdout()
             self.mock_stdout(False)
 
-            info_msg = r"Searching \(case-insensitive\) for 'toy-0.0' in"
-            self.assertTrue(re.search(info_msg, txt), "Info message when searching for easyconfigs in '%s'" % txt)
             self.assertTrue(re.search('^CFGS\d+=', txt, re.M), "CFGS line message found in '%s'" % txt)
             for ec in ["toy-0.0.eb", "toy-0.0-multiple.eb"]:
                 regex = re.compile(r" \* \$CFGS\d+/*%s" % ec, re.M)
@@ -684,6 +678,34 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
         self.assertTrue(re.search('GCC-4.9.2', txt))
+
+    def test_search_archived(self):
+        "Test searching for archived easyconfigs"
+        args = ['--search-filename=^ictce']
+        self.mock_stdout(True)
+        self.eb_main(args, testing=False)
+        txt = self.get_stdout().rstrip()
+        self.mock_stdout(False)
+        expected = '\n'.join([
+            ' * ictce-4.1.13.eb',
+            '',
+            "Note: 1 matching archived were found, use --consider-archived-easyconfigs to see them.",
+        ])
+        self.assertEqual(txt, expected)
+
+        args.append('--consider-archived-easyconfigs')
+        self.mock_stdout(True)
+        self.eb_main(args, testing=False)
+        txt = self.get_stdout().rstrip()
+        self.mock_stdout(False)
+        expected = '\n'.join([
+            ' * ictce-4.1.13.eb',
+            '',
+            "Matching archived easyconfigs:",
+            '',
+            ' * ictce-3.2.2.u3.eb',
+        ])
+        self.assertEqual(txt, expected)
 
     def test_dry_run(self):
         """Test dry run (long format)."""

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -996,7 +996,8 @@ class RobotTest(EnhancedTestCase):
 
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         tc_spec = "toolchain = {'name': 'ictce', 'version': '3.2.2.u3'}"
-        test_ectxt = re.sub('^toolchain = .*', tc_spec, gzip_ectxt, flags=re.M)
+        regex = re.compile("^toolchain = .*", re.M)
+        test_ectxt = regex.sub(tc_spec, gzip_ectxt)
         write_file(test_ec, test_ectxt)
         ecs, _ = parse_easyconfigs([(test_ec, False)])
         self.assertErrorRegex(EasyBuildError, "Irresolvable dependencies encountered", resolve_dependencies,

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -41,7 +41,7 @@ import easybuild.framework.easyconfig.easyconfig as ecec
 import easybuild.framework.easyconfig.tools as ectools
 import easybuild.tools.build_log
 import easybuild.tools.robot as robot
-from easybuild.framework.easyconfig.easyconfig import process_easyconfig, EasyConfig
+from easybuild.framework.easyconfig.easyconfig import _easyconfig_files_cache, process_easyconfig, EasyConfig
 from easybuild.framework.easyconfig.tools import find_resolved_modules, parse_easyconfigs
 from easybuild.framework.easyconfig.easyconfig import get_toolchain_hierarchy
 from easybuild.framework.easyconfig.easyconfig import robot_find_minimal_toolchain_of_dependency
@@ -559,8 +559,6 @@ class RobotTest(EnhancedTestCase):
         args = [
             os.path.join(test_ecs_path, 't', 'toy', 'toy-0.0.eb'),
             test_ec,  # relative path, should be resolved via robot search path
-            # PR for foss/2015a, see https://github.com/hpcugent/easybuild-easyconfigs/pull/1239/files
-            #'--from-pr=1239',
             '--dry-run',
             '--debug',
             '--robot',
@@ -580,6 +578,21 @@ class RobotTest(EnhancedTestCase):
             ec_fn = "%s.eb" % '-'.join(module.split('/'))
             regex = re.compile(r"^ \* \[.\] %s.*%s \(module: %s\)$" % (path_prefix, ec_fn, module), re.M)
             self.assertTrue(regex.search(outtxt), "Found pattern %s in %s" % (regex.pattern, outtxt))
+
+        # test using archived easyconfigs
+        args = [
+            'ictce-3.2.2.u3.eb',
+            '--dry-run',
+            '--debug',
+            '--robot',
+            '--unittest-file=%s' % self.logfile,
+        ]
+        self.assertErrorRegex(EasyBuildError, "Can't find", self.eb_main, args, logfile=dummylogfn, raise_error=True)
+
+        args.append('--consider-archived-easyconfigs')
+        outtxt = self.eb_main(args, logfile=dummylogfn, raise_error=True)
+        regex = re.compile(r"^ \* \[.\] .*/__archive__/.*/ictce-3.2.2.u3.eb \(module: ictce/3.2.2.u3\)", re.M)
+        self.assertTrue(regex.search(outtxt), "Found pattern %s in %s" % (regex.pattern, outtxt))
 
     def test_det_easyconfig_paths_from_pr(self):
         """Test det_easyconfig_paths function, with --from-pr enabled as well."""
@@ -973,6 +986,31 @@ class RobotTest(EnhancedTestCase):
 
         # test use of check_inter_ec_conflicts
         self.assertFalse(check_conflicts(ecs, self.modtool, check_inter_ec_conflicts=False), "No conflicts found")
+
+    def test_robot_archived_easyconfigs(self):
+        """Test whether robot can pick up archived easyconfigs when asked."""
+        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+
+        gzip_ec = os.path.join(test_ecs, 'g', 'gzip', 'gzip-1.5-ictce-4.1.13.eb')
+        gzip_ectxt = read_file(gzip_ec)
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        tc_spec = "toolchain = {'name': 'ictce', 'version': '3.2.2.u3'}"
+        test_ectxt = re.sub('^toolchain = .*', tc_spec, gzip_ectxt, flags=re.M)
+        write_file(test_ec, test_ectxt)
+        ecs, _ = parse_easyconfigs([(test_ec, False)])
+        self.assertErrorRegex(EasyBuildError, "Irresolvable dependencies encountered", resolve_dependencies,
+                              ecs, self.modtool, retain_all_deps=True)
+
+        # --consider-archived-easyconfigs must be used to let robot pick up archived easyconfigs
+        init_config(build_options={
+            'consider_archived_easyconfigs': True,
+            'robot_path': [test_ecs],
+        })
+        res = resolve_dependencies(ecs, self.modtool, retain_all_deps=True)
+        self.assertEqual([ec['full_mod_name'] for ec in res], ['ictce/3.2.2.u3', 'gzip/1.5-ictce-3.2.2.u3'])
+        expected = os.path.join(test_ecs, '__archive__', 'i', 'ictce', 'ictce-3.2.2.u3.eb')
+        self.assertTrue(os.path.samefile(res[0]['spec'], expected))
 
 
 def suite():


### PR DESCRIPTION
This is required to be able to pick up archived easyconfigs (see for example https://github.com/hpcugent/easybuild-easyconfigs/pull/3731).
