### PR TITLE
skip dependencies of toolchain marked as external modules when determining module hierarchy

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -171,6 +171,10 @@ def get_toolchain_hierarchy(parent_toolchain):
         # consider both version and versionsuffix for dependencies
         cands = []
         for dep in parsed_ec['ec'].dependencies():
+            # skip dependencies that are marked as external modules
+            if dep['external_module']:
+                continue
+
             # include dep and toolchain of dep as candidates
             cands.extend([
                 {'name': dep['name'], 'version': dep['version'] + dep['versionsuffix']},

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -704,6 +704,19 @@ class RobotTest(EnhancedTestCase):
             {'name': 'iccifort', 'version': '2016.1.150-GCC-4.9.3-2.25'},
         ])
 
+        get_toolchain_hierarchy.clear()
+        build_options = {
+            'add_dummy_to_minimal_toolchains': True,
+            'external_modules_metadata': ConfigObj(),
+            'robot_path': test_easyconfigs,
+        }
+        init_config(build_options=build_options)
+        craycce_hierarchy = get_toolchain_hierarchy({'name': 'CrayCCE', 'version': '5.1.29'})
+        self.assertEqual(craycce_hierarchy, [
+            {'name': 'dummy', 'version': ''},
+            {'name': 'CrayCCE', 'version': '5.1.29'},
+        ])
+
     def test_find_resolved_modules(self):
         """Test find_resolved_modules function."""
         nodeps = {


### PR DESCRIPTION
parsing of easyconfigs using a `Cray*` toolchain is broken without this fix:

```
======================================================================
ERROR: test_get_toolchain_hierarchy (__main__.RobotTest)
Test get_toolchain_hierarchy function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/test/framework/robot.py", line 714, in test_get_toolchain_hierarchy
    craycce_hierarchy = get_toolchain_hierarchy({'name': 'CrayCCE', 'version': '5.1.29'})
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 128, in cache_aware_func
    toolchain_hierarchy = func(toolchain)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 176, in get_toolchain_hierarchy
    {'name': dep['name'], 'version': dep['version'] + dep['versionsuffix']},
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

----------------------------------------------------------------------
Ran 1 test in 1.561s

FAILED (errors=1)
```

(see also https://travis-ci.org/hpcugent/easybuild-easyconfigs/jobs/173480807)

cc @gppezzi