### PR TITLE
check that each glob pattern matches at least one file expand_glob_paths (important for --include-*)

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -961,7 +961,11 @@ def expand_glob_paths(glob_paths):
     """Expand specified glob paths to a list of unique non-glob paths to only files."""
     paths = []
     for glob_path in glob_paths:
-        paths.extend([f for f in glob.glob(os.path.expanduser(glob_path)) if os.path.isfile(f)])
+        add_paths = [f for f in glob.glob(os.path.expanduser(glob_path)) if os.path.isfile(f)]
+        if add_paths:
+            paths.extend(add_paths)
+        else:
+            raise EasyBuildError("No files found using glob pattern '%s'", glob_path)
 
     return nub(paths)
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -524,6 +524,10 @@ class FileToolsTest(EnhancedTestCase):
         os.environ['HOME'] = new_home
         self.assertEqual(ft.expand_glob_paths(['~/*.txt']), [os.path.join(new_home, 'test.txt')])
 
+        # check behaviour if glob that has no (file) matches is passed
+        glob_pat = os.path.join(self.test_prefix, 'test_*')
+        self.assertErrorRegex(EasyBuildError, "No files found using glob pattern", ft.expand_glob_paths, [glob_pat])
+
     def test_adjust_permissions(self):
         """Test adjust_permissions"""
         # set umask hard to run test reliably


### PR DESCRIPTION
I was bitten by `--include-easyblocks` silently not including specified easyblocks because I messed up the specified path a couple of times.

This change fixes that, by making `expand_glob_paths`, which is used (only) by the `--include-*` options, stricter to ensure at least one hit per specified glob pattern.