### PR TITLE
Prepare module_naming_scheme/hierarchical_mns for Intel+CUDA toolchain

### DIFF
--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -170,7 +170,8 @@ class HierarchicalMNS(ModuleNamingScheme):
                         if ec['name'] == 'ifort':
                             # 'icc' key should be provided since it's the only one used in the template
                             comp_versions.update({'icc': self.det_full_version(ec)})
-                        if tc_comp_info is not None:
+
+                        if tc_comp_info is not None and tc_comp_info[0] in key.split(','):
                             # also provide toolchain version for non-dummy toolchains
                             comp_versions.update({tc_comp_info[0]: tc_comp_info[1]})
 


### PR DESCRIPTION
Must not indiscriminately add tc_comp_info to comp_versions, only
add parts that comes from the list.

This is a prerequisite for PR #1976, which will be changed accordingly.