### PR TITLE
change default config to use Lmod/Lua for modules tool/syntax, GC3Pie as job backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,19 @@ python: 2.6
 env:
   matrix:
     # purposely specifying slowest builds first, to gain time overall
-    - LMOD_VERSION=5.6.3 TEST_EASYBUILD_MODULES_TOOL=Lmod
-    - LMOD_VERSION=6.3.1 TEST_EASYBUILD_MODULES_TOOL=Lmod
-    - LMOD_VERSION=6.3.1 TEST_EASYBUILD_MODULES_TOOL=Lmod TEST_EASYBUILD_MODULE_SYNTAX=Lua
-    - ENV_MOD_VERSION=3.2.10
-    - ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl
+    - LMOD_VERSION=5.8
+    - LMOD_VERSION=5.8 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
+    - LMOD_VERSION=6.6.2
+    - LMOD_VERSION=6.6.2 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
+    - ENV_MOD_VERSION=3.2.10 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesC TEST_EASYBUILD_MODULE_SYNTAX=Tcl
+    - ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl TEST_EASYBUILD_MODULE_SYNTAX=Tcl
 matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true
   include:
     # also test default configuration with Python 2.7
     - python: 2.7
-      env: ENV_MOD_VERSION=3.2.10
+      env: LMOD_VERSION=5.8
 addons:
   apt:
     packages:
@@ -54,6 +55,8 @@ install:
     - if [ ! -z $LMOD_VERSION ]; then source $INSTALL_DEP Lmod-${LMOD_VERSION} $HOME; fi
     - if [ ! -z $ENV_MOD_TCL_VERSION ]; then source $INSTALL_DEP modules-tcl-${ENV_MOD_TCL_VERSION} $HOME; fi
 script:
+    # make sure 'ml' alias is defined, otherwise sourcing the init script fails (silently) for Lmod (< 5.9.3)
+    - if [ ! -z $MOD_INIT ] && [ ! -z $LMOD_VERSION ]; then alias ml=foobar; fi
     # set up environment for modules tool (if $MOD_INIT is defined)
     - if [ ! -z $MOD_INIT ]; then source $MOD_INIT; fi
     # set up environment for EasyBuild framework tests

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -55,11 +55,11 @@ PKG_TOOL_FPM = 'fpm'
 PKG_TYPE_RPM = 'rpm'
 
 
-DEFAULT_JOB_BACKEND = 'PbsPython'
+DEFAULT_JOB_BACKEND = 'GC3Pie'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
 DEFAULT_MNS = 'EasyBuildMNS'
-DEFAULT_MODULE_SYNTAX = 'Tcl'
-DEFAULT_MODULES_TOOL = 'EnvironmentModulesC'
+DEFAULT_MODULE_SYNTAX = 'Lua'
+DEFAULT_MODULES_TOOL = 'Lmod'
 DEFAULT_PATH_SUBDIRS = {
     'buildpath': 'build',
     'installpath': '',

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -36,7 +36,6 @@ import os
 import re
 import sys
 import tempfile
-from distutils.version import StrictVersion
 from vsc.utils import fancylogger
 from vsc.utils.missing import get_subclasses
 
@@ -676,14 +675,8 @@ class ModuleGeneratorLua(ModuleGenerator):
         """
         Add a message that should be printed when loading the module.
         """
-        if '\n' in msg:
-            if StrictVersion(modules_tool().version) >= StrictVersion('5.8'):
-                stmt_tmpl = 'io.stderr:write([==[%s]==])'
-            else:
-                raise EasyBuildError("Lmod 5.8 (or more recent) is required for multiline load messages in Lua modules")
-        else:
-            stmt_tmpl = 'io.stderr:write("%s")'
-
+        # take into account possible newlines in messages by using [==...==] (requires Lmod 5.8)
+        stmt_tmpl = 'io.stderr:write([==[%s]==])'
         return '\n'.join(['', self.conditional_statement('mode() == "load"', stmt_tmpl % msg)])
 
     def set_alias(self, key, value):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -223,7 +223,7 @@ class ModulesTool(object):
 
                 # make sure version is a valid StrictVersion (e.g., 5.7.3.1 is invalid),
                 # and replace 'rc' by 'b', to make StrictVersion treat it as a beta-release
-                self.version = self.version.replace('rc', 'b')
+                self.version = self.version.replace('rc', 'b').replace('-beta', 'b1')
                 if len(self.version.split('.')) > 3:
                     self.version = '.'.join(self.version.split('.')[:3])
 
@@ -936,13 +936,11 @@ class Lmod(ModulesTool):
     """Interface to Lmod."""
     COMMAND = 'lmod'
     COMMAND_ENVIRONMENT = 'LMOD_CMD'
-    # required and optimal version
-    # we need at least Lmod v5.6.3 (and it can't be a release candidate)
-    REQ_VERSION = '5.6.3'
+    REQ_VERSION = '5.8'
     VERSION_REGEXP = r"^Modules\s+based\s+on\s+Lua:\s+Version\s+(?P<version>\d\S*)\s"
     USER_CACHE_DIR = os.path.join(os.path.expanduser('~'), '.lmod.d', '.cache')
 
-    SHOW_HIDDEN_OPTION = '--show_hidden'
+    SHOW_HIDDEN_OPTION = '--show-hidden'
 
     def __init__(self, *args, **kwargs):
         """Constructor, set lmod-specific class variable values."""
@@ -996,10 +994,8 @@ class Lmod(ModulesTool):
 
         :param name: a (partial) module name for filtering (default: None)
         """
-        extra_args = []
-        if StrictVersion(self.version) >= StrictVersion('5.7.5'):
-            # make hidden modules visible for recent version of Lmod
-            extra_args = [self.SHOW_HIDDEN_OPTION]
+        # make hidden modules visible (requires Lmod 5.7.5)
+        extra_args = [self.SHOW_HIDDEN_OPTION]
 
         mods = super(Lmod, self).available(mod_name=mod_name, extra_args=extra_args)
 

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -438,19 +438,18 @@ class ModuleGeneratorTest(EnhancedTestCase):
             self.assertEqual(tcl_load_msg, self.modgen.msg_on_load('test $test \\$test\ntest $foo \\$bar'))
 
         else:
-            expected = '\nif mode() == "load" then\n    io.stderr:write("test")\nend\n'
+            expected = '\nif mode() == "load" then\n    io.stderr:write([==[test]==])\nend\n'
             self.assertEqual(expected, self.modgen.msg_on_load('test'))
 
-            if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('5.8'):
-                lua_load_msg = '\n'.join([
-                    '',
-                    'if mode() == "load" then',
-                    '    io.stderr:write([==[test $test \\$test',
-                    '    test $foo \\$bar]==])',
-                    'end',
-                    '',
-                ])
-                self.assertEqual(lua_load_msg, self.modgen.msg_on_load('test $test \\$test\ntest $foo \\$bar'))
+            lua_load_msg = '\n'.join([
+                '',
+                'if mode() == "load" then',
+                '    io.stderr:write([==[test $test \\$test',
+                '    test $foo \\$bar]==])',
+                'end',
+                '',
+            ])
+            self.assertEqual(lua_load_msg, self.modgen.msg_on_load('test $test \\$test\ntest $foo \\$bar'))
 
     def test_module_naming_scheme(self):
         """Test using default module naming scheme."""

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -338,8 +338,11 @@ class ModulesTest(EnhancedTestCase):
     def test_path_to_top_of_module_tree_lua(self):
         """Test path_to_top_of_module_tree function on modules in Lua syntax."""
         if isinstance(self.modtool, Lmod):
+            orig_modulepath = os.environ.get('MODULEPATH')
             self.modtool.unuse(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules'))
-            self.assertEqual(os.environ.get('MODULEPATH'), None)
+            curr_modulepath = os.environ.get('MODULEPATH')
+            error_msg = "Incorrect $MODULEPATH value after unuse: %s (orig: %s)" % (curr_modulepath, orig_modulepath)
+            self.assertEqual(curr_modulepath, None, error_msg)
 
             top_moddir = os.path.join(self.test_prefix, 'test_modules')
             core_dir = os.path.join(top_moddir, 'Core')

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2677,7 +2677,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # output of --show-full-config includes additional lines for options with default values
         expected_lines.extend([
             r"force\s* \(D\) = False",
-            r"module-syntax\s* \(D\) = Tcl",
+            r"modules-tool\s* \(D\) = Lmod",
+            r"module-syntax\s* \(D\) = Lua",
             r"umask\s* \(D\) = None",
         ])
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -35,7 +35,6 @@ import shutil
 import stat
 import sys
 import tempfile
-from distutils.version import StrictVersion
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from test.framework.package import mock_fpm
 from unittest import TextTestRunner
@@ -211,14 +210,9 @@ class ToyBuildTest(EnhancedTestCase):
         ec_file = os.path.join(self.test_buildpath, 'toy-0.0-tweaked.eb')
         shutil.copy2(os.path.join(test_ecs_dir, 'test_ecs', 't', 'toy', 'toy-0.0.eb'), ec_file)
 
-        if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) < StrictVersion('5.8'):
-            modloadmsg = 'THANKS FOR LOADING ME, I AM %(name)s v%(version)s'
-            modloadmsg_regex_tcl = 'THANKS.*, I AM toy v0.0"'
-            modloadmsg_regex_lua = '"THANKS., I AM toy v0.0"'
-        else:
-            modloadmsg = 'THANKS FOR LOADING ME\\nI AM %(name)s v%(version)s'
-            modloadmsg_regex_tcl = 'THANKS.*\n\s*I AM toy v0.0"'
-            modloadmsg_regex_lua = '\[==\[THANKS.*\n\s*I AM toy v0.0\]==\]'
+        modloadmsg = 'THANKS FOR LOADING ME\\nI AM %(name)s v%(version)s'
+        modloadmsg_regex_tcl = 'THANKS.*\n\s*I AM toy v0.0"'
+        modloadmsg_regex_lua = '\[==\[THANKS.*\n\s*I AM toy v0.0\]==\]'
 
         # tweak easyconfig by appending to it
         ec_extra = '\n'.join([
@@ -260,8 +254,8 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertTrue(re.search(r'^prepend_path\("SOMEPATH", pathJoin\(root, "baz"\)\)$', toy_module_txt, re.M))
             self.assertTrue(re.search(r'^prepend_path\("SOMEPATH", root\)$', toy_module_txt, re.M))
             mod_load_msg = r'^if mode\(\) == "load" then\n\s*io.stderr:write\(%s\)$' % modloadmsg_regex_lua
-            self.assertTrue(re.search(mod_load_msg, toy_module_txt, re.M))
-            self.assertTrue(re.search(r'^io.stderr:write\("oh hai!"\)$', toy_module_txt, re.M))
+            regex = re.compile(mod_load_msg, re.M)
+            self.assertTrue(regex.search(toy_module_txt), "Pattern '%s' found in: %s" % (regex.pattern, toy_module_txt))
         else:
             self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
 
@@ -831,22 +825,14 @@ class ToyBuildTest(EnhancedTestCase):
             toy_module += '.lua'
         toy_mod_txt = read_file(toy_module)
 
-        if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) < StrictVersion('5.8'):
-            modloadmsg_tcl = [
-                r'    puts stderr "THANKS FOR LOADING ME, I AM toy v0.0"',
-            ]
-            modloadmsg_lua = [
-                r'    io.stderr:write\("THANKS FOR LOADING ME, I AM toy v0.0"\)',
-            ]
-        else:
-            modloadmsg_tcl = [
-                r'    puts stderr "THANKS FOR LOADING ME',
-                r'    I AM toy v0.0"',
-            ]
-            modloadmsg_lua = [
-                r'    io.stderr:write\(\[==\[THANKS FOR LOADING ME',
-                r'    I AM toy v0.0\]==\]\)',
-            ]
+        modloadmsg_tcl = [
+            r'    puts stderr "THANKS FOR LOADING ME',
+            r'    I AM toy v0.0"',
+        ]
+        modloadmsg_lua = [
+            r'    io.stderr:write\(\[==\[THANKS FOR LOADING ME',
+            r'    I AM toy v0.0\]==\]\)',
+        ]
 
         if get_module_syntax() == 'Lua':
             mod_txt_regex_pattern = '\n'.join([

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -241,7 +241,8 @@ class EnhancedTestCase(_EnhancedTestCase):
         # make very sure $MODULEPATH is totally empty
         # some paths may be left behind, e.g. when they contain environment variables
         # example: "module unuse Modules/$MODULE_VERSION/modulefiles" may not yield the desired result
-        os.environ['MODULEPATH'] = ''
+        if 'MODULEPATH' in os.environ:
+            del os.environ['MODULEPATH']
         for modpath in modpaths:
             self.modtool.add_module_path(modpath, set_mod_paths=False)
         self.modtool.set_mod_paths()


### PR DESCRIPTION
This updates the default configuration in preparation of EasyBuild v3.0.

cc @rtmclay, @riccardomurri: thanks for all your help with the support for Lmod and GC3Pie in EasyBuild! :)