### PR TITLE
include suggestion on how to change configuration w.r.t. modules tool/syntax

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -253,7 +253,10 @@ class ModulesTool(object):
             self.log.info("Full path for module command is %s, so using it" % self.cmd)
         else:
             mod_tool = self.__class__.__name__
-            raise EasyBuildError("%s modules tool can not be used, '%s' command is not available.", mod_tool, self.cmd)
+            mod_tools = avail_modules_tools().keys()
+            error_msg = "%s modules tool can not be used, '%s' command is not available" % (mod_tool, self.cmd)
+            error_msg += "; use --modules-tool to specify a different modules tool to use (%s)" % ', '.join(mod_tools)
+            raise EasyBuildError(error_msg)
 
     def check_module_function(self, allow_mismatch=False, regex=None):
         """Check whether selected module tool matches 'module' function definition."""

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -689,7 +689,10 @@ class EasyBuildOptions(GeneralOption):
                 raise EasyBuildError("Required support for using GitHub API is not available (see warnings).")
 
         if self.options.module_syntax == ModuleGeneratorLua.SYNTAX and self.options.modules_tool != Lmod.__name__:
-            raise EasyBuildError("Generating Lua module files requires Lmod as modules tool.")
+            error_msg = "Generating Lua module files requires Lmod as modules tool; "
+            mod_syntaxes = ', '.join(sorted(avail_module_generators().keys()))
+            error_msg += "use --module-syntax to specify a different module syntax to use (%s)" % mod_syntaxes
+            raise EasyBuildError(error_msg)
 
         # make sure a GitHub token is available when it's required
         if self.options.upload_test_report:


### PR DESCRIPTION
implementation of suggestion made in #1927

Output now looks like this with a wrong configuration:

```
$ eb ...
ERROR: EnvironmentModulesC modules tool can not be used, 'modulecmd' command is not available; use --modules-tool to specify a different modules to use (Lmod, EnvironmentModulesTcl, EnvironmentModulesC)
```

some idea applied to `--module-syntax`:

```
$ eb ...
ERROR: Failed to parse configuration options: 'Generating Lua module files requires Lmod as modules tool; use --module-syntax to specify a different module syntax to use (Lua, Tcl)'
```

```
```

This is very relevant now since we just switched to Lmod/Lua in #1985.

@fgeorgatos please review?