### PR TITLE
use correct module syntax in bootstrap script if Lmod is not used (i.e. Tcl)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,13 +74,10 @@ script:
       fi
     # run test suite
     - python -O -m test.framework.suite
-    # configure EasyBuild before running bootstrap (modules tool/syntax to use)
-    - if [ ! -z $TEST_EASYBUILD_MODULES_TOOL ]; then export EASYBUILD_MODULES_TOOL=$TEST_EASYBUILD_MODULES_TOOL; fi
-    - if [ ! -z $TEST_EASYBUILD_MODULE_SYNTAX ]; then export EASYBUILD_MODULE_SYNTAX=$TEST_EASYBUILD_MODULE_SYNTAX; fi
     # move outside of checkout of easybuild-framework repository, weird place to run bootstrap
     - cd $HOME
     # test bootstrap script
-    - EASYBUILD_BOOTSTRAP_DEBUG=1 python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID
+    - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID
     # unset $PYTHONPATH to avoid mixing two EasyBuild 'installations' when testing bootstrapped EasyBuild module
     - unset PYTHONPATH
     # simply sanity check on bootstrapped EasyBuild module

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
     # move outside of checkout of easybuild-framework repository, weird place to run bootstrap
     - cd $HOME
     # test bootstrap script
-    - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID
+    - EASYBUILD_BOOTSTRAP_DEBUG=1 python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID
     # unset $PYTHONPATH to avoid mixing two EasyBuild 'installations' when testing bootstrapped EasyBuild module
     - unset PYTHONPATH
     # simply sanity check on bootstrapped EasyBuild module

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -205,11 +205,12 @@ def prep(path):
     if easybuild_module_syntax:
         # if module syntax is specified, use it
         os.environ['EASYBUILD_MODULE_SYNTAX'] = easybuild_module_syntax
+        debug("Using specified module syntax: %s" % os.environ['EASYBUILD_MODULE_SYNTAX'])
     elif easybuild_modules_tool != 'Lmod':
         # Lua is the default module syntax, but that requires Lmod
         # if Lmod is not being used, use Tcl module syntax
         os.environ['EASYBUILD_MODULE_SYNTAX'] = 'Tcl'
-    debug("$EASYBUILD_MODULE_SYNTAX set to %s" % os.environ['EASYBUILD_MODULE_SYNTAX'])
+        debug("$EASYBUILD_MODULE_SYNTAX set to %s" % os.environ['EASYBUILD_MODULE_SYNTAX'])
 
 
 

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -90,6 +90,7 @@ orig_os_environ = copy.deepcopy(os.environ)
 
 # If the modules tool is specified, use it
 easybuild_modules_tool = os.environ.get('EASYBUILD_MODULES_TOOL', None)
+easybuild_module_syntax = os.environ.get('EASYBUILD_MODULE_SYNTAX', None)
 
 
 #
@@ -200,6 +201,16 @@ def prep(path):
 
     os.environ['EASYBUILD_MODULES_TOOL'] = easybuild_modules_tool
     debug("$EASYBUILD_MODULES_TOOL set to %s" % os.environ['EASYBUILD_MODULES_TOOL'])
+
+    if easybuild_module_syntax:
+        # if module syntax is specified, use it
+        os.environ['EASYBUILD_MODULE_SYNTAX'] = easybuild_module_syntax
+    elif easybuild_modules_tool != 'Lmod':
+        # Lua is the default module syntax, but that requires Lmod
+        # if Lmod is not being used, use Tcl module syntax
+        os.environ['EASYBUILD_MODULE_SYNTAX'] = 'Tcl'
+    debug("$EASYBUILD_MODULE_SYNTAX set to %s" % os.environ['EASYBUILD_MODULE_SYNTAX'])
+
 
 
 def check_module_command(tmpdir):


### PR DESCRIPTION
This is some fallout of the switch to `Lua` as default module syntax in #1985.