### PR TITLE
make tests more robust against running headless

### DIFF
--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -433,8 +433,8 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(lines[1], "=====")
 
         # different versionsuffix
-        self.assertEqual(lines[2], "3 %s- versionsuffix = '-test'%s (1/2) toy-0.0-gompi-1.3.12-test.eb" % (red, endcol))
-        self.assertEqual(lines[3], "3 %s- versionsuffix = '-deps'%s (1/2) toy-0.0-deps.eb" % (red, endcol))
+        self.assertTrue(lines[2].startswith("3 %s- versionsuffix = '-test'%s (1/2) toy-0.0-" % (red, endcol)))
+        self.assertTrue(lines[3].startswith("3 %s- versionsuffix = '-deps'%s (1/2) toy-0.0-" % (red, endcol)))
 
         # different toolchain in toy-0.0-gompi-1.3.12-test: '+' line (removed chars in toolchain name/version, in red)
         expected = "7 %(endcol)s-%(endcol)s toolchain = {"
@@ -450,7 +450,8 @@ class FileToolsTest(EnhancedTestCase):
         # no postinstallcmds in toy-0.0-deps.eb
         expected = "28 %s+ postinstallcmds = " % green
         self.assertTrue(any([line.startswith(expected) for line in lines]))
-        self.assertTrue("29 %s+%s (1/2) toy-0.0-deps.eb" % (green, endcol) in lines)
+        expected = "29 %s+%s (1/2) toy-0.0" % (green, endcol)
+        self.assertTrue(any(l.startswith(expected) for l in lines), "Found '%s' in: %s" % (expected, lines))
         self.assertEqual(lines[-1], "=====")
 
         lines = multidiff(toy_ec, other_toy_ecs, colored=False).split('\n')
@@ -458,24 +459,25 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(lines[1], "=====")
 
         # different versionsuffix
-        self.assertEqual(lines[2], "3 - versionsuffix = '-test' (1/2) toy-0.0-gompi-1.3.12-test.eb")
-        self.assertEqual(lines[3], "3 - versionsuffix = '-deps' (1/2) toy-0.0-deps.eb")
+        self.assertTrue(lines[2].startswith("3 - versionsuffix = '-test' (1/2) toy-0.0-"))
+        self.assertTrue(lines[3].startswith("3 - versionsuffix = '-deps' (1/2) toy-0.0-"))
 
         # different toolchain in toy-0.0-gompi-1.3.12-test: '+' line with squigly line underneath to mark removed chars
         expected = "7 - toolchain = {'name': 'gompi', 'version': '1.3.12'} (1/2) toy"
         self.assertTrue(lines[7].startswith(expected))
-        expected = "  ?                       ^^ ^^               ^^^^^^"
-        self.assertEqual(lines[8], expected)
+        expected = "  ?                       ^^ ^^ "
+        self.assertTrue(lines[8].startswith(expected))
         # different toolchain in toy-0.0-gompi-1.3.12-test: '-' line with squigly line underneath to mark added chars
         expected = "7 + toolchain = {'name': 'dummy', 'version': 'dummy'} (1/2) toy"
         self.assertTrue(lines[9].startswith(expected))
-        expected = "  ?                       ^^ ^^               ^^^^^"
-        self.assertEqual(lines[10], expected)
+        expected = "  ?                       ^^ ^^ "
+        self.assertTrue(lines[10].startswith(expected))
 
         # no postinstallcmds in toy-0.0-deps.eb
         expected = "28 + postinstallcmds = "
-        self.assertTrue(any([line.startswith(expected) for line in lines]))
-        self.assertTrue("29 + (1/2) toy-0.0-deps.eb" in lines)
+        self.assertTrue(any(l.startswith(expected) for l in lines), "Found '%s' in: %s" % (expected, lines))
+        expected = "29 + (1/2) toy-0.0-"
+        self.assertTrue(any(l.startswith(expected) for l in lines), "Found '%s' in: %s" % (expected, lines))
 
         self.assertEqual(lines[-1], "=====")
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -514,7 +514,7 @@ class ModulesTest(EnhancedTestCase):
 
         if isinstance(self.modtool, Lmod):
             # GCC/4.6.3 is nowhere to be found (in $MODULEPATH)
-            load_err_msg = r"The following module\(s\) are unknown"
+            load_err_msg = r"The[\s\n]*following[\s\n]*module\(s\)[\s\n]*are[\s\n]*unknown"
         else:
             load_err_msg = "Unable to locate a modulefile"
 
@@ -547,7 +547,10 @@ class ModulesTest(EnhancedTestCase):
         if isinstance(self.modtool, Lmod):
             # OpenMPI/1.6.4 exists, but is not available for load;
             # exact error message depends on Lmod version
-            load_err_msg = r"These module\(s\) exist but cannot be|The following module\(s\) are unknown"
+            load_err_msg = '|'.join([
+                r'These[\s\sn]*module\(s\)[\s\sn]*exist[\s\sn]*but[\s\sn]*cannot[\s\sn]*be',
+                'The[\s\sn]*following[\s\sn]*module\(s\)[\s\sn]*are[\s\sn]*unknown',
+            ])
         else:
             load_err_msg = "Unable to locate a modulefile"
 

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -684,8 +684,8 @@ class SystemToolsTest(EnhancedTestCase):
     def test_det_terminal_size(self):
         """Test det_terminal_size function."""
         (height, width) = st.det_terminal_size()
-        self.assertTrue(isinstance(height, int) and height > 0)
-        self.assertTrue(isinstance(width, int) and width > 0)
+        self.assertTrue(isinstance(height, int) and height >= 0)
+        self.assertTrue(isinstance(width, int) and width >= 0)
 
 
 def suite():


### PR DESCRIPTION
For some reason unclear to me, a couple of the EasyBuild framework tests have been failing when running from my fork (https://github.com/boegel/easybuild-framework), with errors like this:

```
FAIL: Test multidiff function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/boegel/easybuild-framework/test/framework/filetools.py", line 436, in test_multidiff
    self.assertEqual(lines[2], "3 %s- versionsuffix = '-test'%s (1/2) toy-0.0-gompi-1.3.12-test.eb" % (red, endcol))
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/vsc_install-0.10.19-py2.6.egg/vsc/install/testing.py", line 79, in assertEqual
    raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
AssertionError: "3 \x1b[0;41m- versionsuffix = '-test'\x1b[0m (1/2) toy-0.0-gompi-1.3.12-test\x1b[0m..." != "3 \x1b[0;41m- versionsuffix = '-test'\x1b[0m (1/2) toy-0.0-gompi-1.3.12-test.eb":
DIFF:
- 3 - versionsuffix = '-test' (1/2) toy-0.0-gompi-1.3.12-test...?                                                                       ---- ^^
+ 3 - versionsuffix = '-test' (1/2) toy-0.0-gompi-1.3.12-test.eb
```
```
FAIL: Test det_terminal_size function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/boegel/easybuild-framework/test/framework/systemtools.py", line 687, in test_det_terminal_size
    self.assertTrue(isinstance(height, int) and height > 0)
AssertionError
```

I'm not sure why they only fail for my fork and not the central repos, since the test setup is exactly the same. My best guess is that Travis is gradually rolling out some changes which have not yet hit all test environments.

This change makes the affected tests more robust against running headless. For the `multidiff` test, it makes some of the test cases slightly less strict, but that shouldn't affect the capability to catch regression (since the test is quite extensively).