### PR TITLE
make sure 'modules_tool' attribute is also defined for extensions

### DIFF
--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -78,6 +78,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             self.cfg['version'] = self.ext.get('version', None)
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir
+            self.modules_tool = self.master.modules_tool
             self.is_extension = True
             self.unpack_options = None
 

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -43,6 +43,7 @@ class Toy_Extension(ExtensionEasyBlock):
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for toy extensions."""
+        self.log.info("Loaded modules: %s", self.modules_tool.list())
         custom_paths = {
             'files': ['bin/%s' % self.name, 'lib/lib%s.a' % self.name],
             'dirs': [],


### PR DESCRIPTION
fix for #2009

This is kind of a silly bug, since `self.modules_tool` is used in the `sanity_check_rpath` method, but it gets only run for extensions for which custom paths/commands are specified in the corresponding easyblock (like `numpy`).

Making sure that `modules_tool` is always defined makes sense, since that requirement may get introduced in other places as well at some point...