### PR TITLE
only dump easyconfig with modified deps due to --minimal-toolchains to 'reprod' subdir of install dir

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2532,16 +2532,10 @@ def build_and_install_one(ecdict, init_env):
             if build_option("minimal_toolchains"):
                 # for reproducability we dump out the parsed easyconfig since the contents are affected when
                 # --minimal-toolchains (and --use-existing-modules) is used
-                _log.debug("Dumping parsed easyconfig rather than original easyconfig to install dir")
-
-                # add the parsed file to the reproducability directory
                 # TODO --try-toolchain needs to be fixed so this doesn't play havoc with it's usability
-                repo_spec = os.path.join(new_log_dir, 'reprod', ec_filename)
-                app.cfg.dump(repo_spec)
-
-            else:
-                _log.debug("Dumping original easyconfig to install dir")
-                repo_spec = spec
+                reprod_spec = os.path.join(new_log_dir, 'reprod', ec_filename)
+                app.cfg.dump(reprod_spec)
+                _log.debug("Dumped easyconfig tweaked via --minimal-toolchains to %s", reprod_spec)
 
             try:
                 # upload spec to central repository
@@ -2550,7 +2544,7 @@ def build_and_install_one(ecdict, init_env):
                 if 'original_spec' in ecdict:
                     block = det_full_ec_version(app.cfg) + ".block"
                     repo.add_easyconfig(ecdict['original_spec'], app.name, block, buildstats, currentbuildstats)
-                repo.add_easyconfig(repo_spec, app.name, det_full_ec_version(app.cfg), buildstats, currentbuildstats)
+                repo.add_easyconfig(spec, app.name, det_full_ec_version(app.cfg), buildstats, currentbuildstats)
                 repo.commit("Built %s" % app.full_mod_name)
                 del repo
             except EasyBuildError, err:


### PR DESCRIPTION
(fix for #2025)

This restores dumping of the *original* easyconfig used to both the easyconfig archive and the `easybuild` subdir of the install directory.

The tweaked easyconfig, where dependencies may get assigned a particular subtoolchains (and where template values may have been replaced with the actual value) is still dumped to the `easybuild/reprod` subdir of the install directory, as it was before.

The current behaviour, which was introduced in #1614 (EasyBuild v2.7.0) is considered not fully correct, see also https://lists.ugent.be/wws/arc/easybuild/2016-11/msg00063.html .

cc @ocaisa, @JackPerdue, @verdurin