### PR TITLE
avoid appending '-h' to sanity check commands specified as a string

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1943,22 +1943,23 @@ class EasyBlock(object):
             # non-tuple commands
             if isinstance(command, basestring):
                 self.log.debug("Using %s as sanity check command" % command)
-                command = (command, None)
-            elif not isinstance(command, tuple):
-                self.log.debug("Setting sanity check command to default")
-                command = (None, None)
+                commands[i] = command
+            else:
+                if not isinstance(command, tuple):
+                    self.log.debug("Setting sanity check command to default")
+                    command = (None, None)
 
-            # Build substition dictionary
-            check_cmd = {
-                'name': self.name.lower(),
-                'options': '-h',
-            }
-            if command[0] is not None:
-                check_cmd['name'] = command[0]
-            if command[1] is not None:
-                check_cmd['options'] = command[1]
+                # Build substition dictionary
+                check_cmd = {
+                    'name': self.name.lower(),
+                    'options': '-h',
+                }
+                if command[0] is not None:
+                    check_cmd['name'] = command[0]
+                if command[1] is not None:
+                    check_cmd['options'] = command[1]
 
-            commands[i] = "%(name)s %(options)s" % check_cmd
+                commands[i] = "%(name)s %(options)s" % check_cmd
 
         return paths, path_keys_and_check, commands
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1140,9 +1140,14 @@ class ToyBuildTest(EnhancedTestCase):
             # that will fail if the corresponding modules are not loaded
             # cfr. https://github.com/hpcugent/easybuild-framework/pull/1754
             "sanity_check_commands = [",
-            "   ('env | grep EBROOTFFTW', ''),",
-            "   ('env | grep EBROOTGCC', ''),",
+            "   'env | grep EBROOTFFTW',",
+            "   'env | grep EBROOTGCC',",
+            # tuple format (kinda weird but kept in place for backward compatibility)
             "   ('env | grep EBROOTGOOLF', ''),",
+            # True implies running 'toy -h', should work (although pretty senseless in this case)
+            "   True,",
+            # test command to make sure that '-h' is not passed to commands specified as string ('env -h' fails)
+            "   'env',"
             "]",
         ])
 


### PR DESCRIPTION
fix for bug reported in https://github.com/hpcugent/easybuild-easyconfigs/pull/3858