### PR TITLE
also skip dependencies of dependencies marked as external module in get_toolchain_hierarchy

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -188,8 +188,11 @@ def get_toolchain_hierarchy(parent_toolchain):
                                      dep['name'], det_full_ec_version(dep))
             easyconfig = process_easyconfig(ecfile, validate=False)[0]['ec']
 
-            # include deps and toolchains of deps of this dep
+            # include deps and toolchains of deps of this dep, but skip dependencies marked as external modules
             for depdep in easyconfig.dependencies():
+                if depdep['external_module']:
+                    continue
+
                 cands.append({'name': depdep['name'], 'version': depdep['version'] + depdep['versionsuffix']})
                 cands.append(depdep['toolchain'])
 

--- a/test/framework/easyconfigs/test_ecs/g/gmvapich2/gmvapich2-15.11.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gmvapich2/gmvapich2-15.11.eb
@@ -1,0 +1,22 @@
+easyblock = "Toolchain"
+
+name = 'gmvapich2'
+version = '15.11'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain,
+ including MVAPICH2 for MPI support."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compname = 'GCC'
+compver = '4.9.3-2.25'
+comp = (compname, compver)
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,
+    ('MVAPICH2', '2.2a', '', comp),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/m/MVAPICH2/MVAPICH2-2.2a-GCC-4.9.3-2.25.eb
+++ b/test/framework/easyconfigs/test_ecs/m/MVAPICH2/MVAPICH2-2.2a-GCC-4.9.3-2.25.eb
@@ -1,0 +1,23 @@
+# this is not correct, but this is just a test easyconfig, so fine
+easyblock = 'ConfigureMake'
+
+name = 'MVAPICH2'
+version = "2.2a"
+
+homepage = 'http://mvapich.cse.ohio-state.edu/overview/mvapich2/'
+description = "This is an MPI 3.0 implementation.  It is based on MPICH2 and MVICH."
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
+
+source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [ ('cudatoolkit/7.0.28', EXTERNAL_MODULE) ]
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['mpicc', 'mpicxx', 'mpif77', 'mpif90']] +
+             ['lib/lib%s' % y for x in ['mpi', 'mpicxx', 'mpifort'] for y in ['%s.so'%x, '%s.a'%x]],
+    'dirs': ['include']
+}
+
+moduleclass = 'mpi'

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -709,12 +709,23 @@ class RobotTest(EnhancedTestCase):
             'add_dummy_to_minimal_toolchains': True,
             'external_modules_metadata': ConfigObj(),
             'robot_path': test_easyconfigs,
+            'valid_module_classes': module_classes(),
         }
         init_config(build_options=build_options)
         craycce_hierarchy = get_toolchain_hierarchy({'name': 'CrayCCE', 'version': '5.1.29'})
         self.assertEqual(craycce_hierarchy, [
             {'name': 'dummy', 'version': ''},
             {'name': 'CrayCCE', 'version': '5.1.29'},
+        ])
+
+        # special case of gmvapich2, where MVAPICH2 has a single dependency that is an external module
+        # test case from https://github.com/eth-cscs/production/blob/master/easybuild/easyconfigs
+        gmvapich2_hierarchy = get_toolchain_hierarchy({'name': 'gmvapich2', 'version': '15.11'})
+        self.assertEqual(gmvapich2_hierarchy, [
+            {'name': 'dummy', 'version': ''},
+            {'name': 'GCCcore', 'version': '4.9.3'},
+            {'name': 'GCC', 'version': '4.9.3-2.25'},
+            {'name': 'gmvapich2', 'version': '15.11'},
         ])
 
     def test_find_resolved_modules(self):

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -84,15 +84,16 @@ class ScriptsTest(EnhancedTestCase):
         out, ec = run_cmd(cmd, simple=False)
 
         # make sure output is kind of what we expect it to be
-        regex = r"Supported Packages \(24 "
+        regex = r"Supported Packages \(26 "
         self.assertTrue(re.search(regex, out), "Pattern '%s' found in output: %s" % (regex, out))
         per_letter = {
             'B': '1',  # bzip2
             'C': '2',  # CrayCCE, CUDA
             'F': '1',  # FFTW
-            'G': '5',  # GCC, GCCcore, gompi, goolf, gzip
+            'G': '6',  # GCC, GCCcore, gmvapich2, gompi, goolf, gzip
             'H': '1',  # hwloc
             'I': '8',  # icc, iccifort, iccifortcuda, ictce, ifort, iimpi, imkl, impi
+            'M': '1',  # MVAPICH2
             'O': '2',  # OpenMPI, OpenBLAS
             'P': '1',  # Python
             'S': '2',  # ScaLAPACK, SQLite


### PR DESCRIPTION
fix for bug reported by @gppezzi 

only occurs when dependencies of a toolchain include external modules as dependencies

edit: this completes the fix added in #1977

```
$ eb HDF5-1.8.15-gmvolf-15.11.eb -d
== temporary log file in case of crash /dev/shm/perettig/easybuild/stage/tmp/eb-Ao_Qb_/easybuild-D4bjgS.log
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/main.py", line 443, in <module>
    main()
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/main.py", line 328, in main
    easyconfigs, generated_ecs = parse_easyconfigs(paths)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/tools.py", line 378, in parse_easyconfigs
    ecs = process_easyconfig(ec_file, **kwargs)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 1257, in process_easyconfig
    ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 321, in __init__
    self.parse()
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 452, in parse
    self._finalize_dependencies()
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 903, in _finalize_dependencies
    tc = robot_find_minimal_toolchain_of_dependency(dep, self.modules_tool, parent_first=True)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 1396, in robot_find_minimal_toolchain_of_dependency
    toolchain_hierarchy = get_toolchain_hierarchy(parent_tc)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 128, in cache_aware_func
    toolchain_hierarchy = func(toolchain)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 193, in get_toolchain_hierarchy
    cands.append({'name': depdep['name'], 'version': depdep['version'] + depdep['versionsuffix']})
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```