### PR TITLE
add 'rpath' toolchain option to selectively disable use of RPATH wrappers

### DIFF
--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -85,6 +85,7 @@ class Compiler(Toolchain):
         '32bit': (False, "Compile 32bit target"),  # LA, FFTW
         'openmp': (False, "Enable OpenMP"),
         'packed-linker-options': (False, "Pack the linker options as comma separated list"),  # ScaLAPACK mainly
+        'rpath': (True, "Use RPATH wrappers when --rpath is enabled in EasyBuild configuration"),
     }
 
     COMPILER_UNIQUE_OPTION_MAP = None

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -679,7 +679,7 @@ class Toolchain(object):
                 self.prepare_compiler_cache(cache_tool)
 
         if build_option('rpath'):
-            if self.options.get('rpath', False):
+            if self.options.get('rpath', True):
                 self.prepare_rpath_wrappers()
             else:
                 self.log.info("Not putting RPATH wrappers in place, disabled via 'rpath' toolchain option")

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -679,7 +679,10 @@ class Toolchain(object):
                 self.prepare_compiler_cache(cache_tool)
 
         if build_option('rpath'):
-            self.prepare_rpath_wrappers()
+            if self.options.get('rpath', False):
+                self.prepare_rpath_wrappers()
+            else:
+                self.log.info("Not putting RPATH wrappers in place, disabled via 'rpath' toolchain option")
 
     def comp_cache_compilers(self, cache_tool):
         """

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1164,6 +1164,21 @@ class ToolchainTest(EnhancedTestCase):
         # preparing RPATH wrappers requires --experimental, need to bypass that here
         tc.log.experimental = lambda x: x
 
+        # 'rpath' toolchain option gives control to disable use of RPATH wrappers
+        tc.set_options({})
+        self.assertTrue(tc.options['rpath'])  # enabled by default
+
+        # setting 'rpath' toolchain option to false implies no RPATH wrappers being used
+        tc.set_options({'rpath': False})
+        tc.prepare()
+        res = which('gcc', retain_all=True)
+        self.assertTrue(len(res) >= 1)
+        self.assertFalse(tc.is_rpath_wrapper(res[0]))
+        self.assertFalse(any(tc.is_rpath_wrapper(x) for x in res[1:]))
+        self.assertTrue(os.path.samefile(res[0], fake_gcc))
+
+        # enable 'rpath' toolchain option again (equivalent to the default setting)
+        tc.set_options({'rpath': True})
         tc.prepare()
 
         # check that wrapper is indeed in place


### PR DESCRIPTION
@pescobar this probably works, but needs to be tested. Can you give it a try?

I'll also look into a dedicated test for this.