### PR TITLE
added HOME and USER from env to available cfg file constants

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -215,12 +215,16 @@ class EasyBuildOptions(GeneralOption):
         # set up constants to seed into config files parser, by section
         self.go_cfg_constants = {
             self.DEFAULTSECT: {
-                'DEFAULT_REPOSITORYPATH': (self.default_repositorypath[0], "Default easyconfigs repository path"),
+                'DEFAULT_REPOSITORYPATH': (self.default_repositorypath[0], 
+                                           "Default easyconfigs repository path"),
                 'DEFAULT_ROBOT_PATHS': (os.pathsep.join(self.default_robot_paths),
                                         "List of default robot paths ('%s'-separated)" % os.pathsep),
+                'USER': (os.environ['USER'], "Current username, derived from the os environment"),
+                'HOME': (os.environ['HOME'], 
+                         "Current user's home directory, derived from the os environment")
             }
         }
-
+        
         # update or define go_configfiles_initenv in named arguments to pass to parent constructor
         go_cfg_initenv = kwargs.setdefault('go_configfiles_initenv', {})
         for section, constants in self.go_cfg_constants.items():

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -40,6 +40,7 @@ import re
 import shutil
 import sys
 import tempfile
+import pwd
 import vsc.utils.generaloption
 from distutils.version import LooseVersion
 from vsc.utils import fancylogger
@@ -219,12 +220,13 @@ class EasyBuildOptions(GeneralOption):
                                            "Default easyconfigs repository path"),
                 'DEFAULT_ROBOT_PATHS': (os.pathsep.join(self.default_robot_paths),
                                         "List of default robot paths ('%s'-separated)" % os.pathsep),
-                'USER': (os.environ['USER'], "Current username, derived from the os environment"),
-                'HOME': (os.environ['HOME'], 
-                         "Current user's home directory, derived from the os environment")
+                'USER': (pwd.getpwuid(os.geteuid()).pw_name,
+                         "Current username, translated uid from password file"),
+                'HOME': (os.path.expanduser('~'), 
+                         "Current user's home directory, expanded '~'")
             }
         }
-        
+
         # update or define go_configfiles_initenv in named arguments to pass to parent constructor
         go_cfg_initenv = kwargs.setdefault('go_configfiles_initenv', {})
         for section, constants in self.go_cfg_constants.items():

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -279,7 +279,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
             'buildpath = %s' % testpath1,
             'sourcepath = %(DEFAULT_REPOSITORYPATH)s',
             'repositorypath = %(DEFAULT_REPOSITORYPATH)s,somesubdir',
-            'robot-paths=/tmp/foo:%(sourcepath)s:%(DEFAULT_ROBOT_PATHS)s:%(HOME)s:/tmp/%(USER)s',
+            'robot-paths=/tmp/foo:%(sourcepath)s:%(HOME)s:/tmp/%(USER)s:%(DEFAULT_ROBOT_PATHS)s',
             'installpath-modules=%s' % installpath_modules,
         ])
         write_file(config_file, cfgtxt)
@@ -304,7 +304,17 @@ class EasyBuildConfigTest(EnhancedTestCase):
             os.getenv('HOME'),
             os.path.join('/tmp',os.getenv('USER')),
         ]
-        self.assertEqual(options.robot_paths[:5], robot_paths)
+
+        # hardcoded first entry
+        self.assertEqual(options.robot_paths[0], '/tmp/foo')
+        # resolved value for %(sourcepath)s template
+        self.assertEqual(options.robot_paths[1], os.path.join(os.getenv('HOME'), '.local', 'easybuild', 'ebfiles_repo'))
+        # resolved value for HOME constant
+        self.assertEqual(options.robot_paths[2], os.getenv('HOME'))
+        # resolved value that uses USER constant
+        self.assertEqual(options.robot_paths[3], os.path.join('/tmp', os.getenv('USER')))
+        # first path in DEFAULT_ROBOT_PATHS
+        self.assertEqual(options.robot_paths[4], os.path.join(tmpdir, 'easybuild', 'easyconfigs'))
 
         testpath3 = os.path.join(self.tmpdir, 'testTHREE')
         os.environ['EASYBUILD_SOURCEPATH'] = testpath2

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -302,9 +302,9 @@ class EasyBuildConfigTest(EnhancedTestCase):
             os.path.join(os.getenv('HOME'), '.local', 'easybuild', 'ebfiles_repo'),
             os.path.join(tmpdir, 'easybuild', 'easyconfigs'),
             os.getenv('HOME'),
-            os.path.join('tmp',os.getenv('USER'))
+            os.path.join('tmp',os.getenv('USER')),
         ]
-        self.assertEqual(options.robot_paths[:3], robot_paths)
+        self.assertEqual(options.robot_paths[:5], robot_paths)
 
         testpath3 = os.path.join(self.tmpdir, 'testTHREE')
         os.environ['EASYBUILD_SOURCEPATH'] = testpath2

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -297,13 +297,6 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertEqual(source_paths(), [testpath2])  # via command line
         self.assertEqual(build_path(), testpath1)  # via config file
         self.assertEqual(get_repositorypath(), [os.path.join(topdir, 'ebfiles_repo'), 'somesubdir'])  # via config file
-        robot_paths = [
-            '/tmp/foo',
-            os.path.join(os.getenv('HOME'), '.local', 'easybuild', 'ebfiles_repo'),
-            os.path.join(tmpdir, 'easybuild', 'easyconfigs'),
-            os.getenv('HOME'),
-            os.path.join('/tmp',os.getenv('USER')),
-        ]
 
         # hardcoded first entry
         self.assertEqual(options.robot_paths[0], '/tmp/foo')

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -272,13 +272,14 @@ class EasyBuildConfigTest(EnhancedTestCase):
         sys.path.insert(0, tmpdir)  # prepend to give it preference over possible other installed easyconfigs pkgs
 
         # test with config file passed via environment variable
+        # also test for existence of HOME and USER by adding paths to robot-paths
         installpath_modules = tempfile.mkdtemp(prefix='installpath-modules')
         cfgtxt = '\n'.join([
             '[config]',
             'buildpath = %s' % testpath1,
             'sourcepath = %(DEFAULT_REPOSITORYPATH)s',
             'repositorypath = %(DEFAULT_REPOSITORYPATH)s,somesubdir',
-            'robot-paths=/tmp/foo:%(sourcepath)s:%(DEFAULT_ROBOT_PATHS)s',
+            'robot-paths=/tmp/foo:%(sourcepath)s:%(DEFAULT_ROBOT_PATHS)s:%(HOME)s:/tmp/%(USER)s',
             'installpath-modules=%s' % installpath_modules,
         ])
         write_file(config_file, cfgtxt)
@@ -300,6 +301,8 @@ class EasyBuildConfigTest(EnhancedTestCase):
             '/tmp/foo',
             os.path.join(os.getenv('HOME'), '.local', 'easybuild', 'ebfiles_repo'),
             os.path.join(tmpdir, 'easybuild', 'easyconfigs'),
+            os.getenv('HOME'),
+            os.path.join('tmp',os.getenv('USER'))
         ]
         self.assertEqual(options.robot_paths[:3], robot_paths)
 

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -302,7 +302,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
             os.path.join(os.getenv('HOME'), '.local', 'easybuild', 'ebfiles_repo'),
             os.path.join(tmpdir, 'easybuild', 'easyconfigs'),
             os.getenv('HOME'),
-            os.path.join('tmp',os.getenv('USER')),
+            os.path.join('/tmp',os.getenv('USER')),
         ]
         self.assertEqual(options.robot_paths[:5], robot_paths)
 


### PR DESCRIPTION
Brought up in this [issue](https://github.com/hpcugent/easybuild-framework/issues/2057). After playing around a bit I didn't see a great reason to introduce other environment variables than HOME and USER.