### PR TITLE
make fetch_github_token more robust against RuntimeError from keyring

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1172,8 +1172,8 @@ def fetch_github_token(user):
     else:
         try:
             token = keyring.get_password(KEYRING_GITHUB_TOKEN, user)
-        except RuntimeError as err:
-            _log.warning("Runtime error occurred when fetching GitHub token: %s", err)
+        except Exception as err:
+            _log.warning("Exception occurred when fetching GitHub token: %s", err)
 
         if token is None:
             python_cmd = '; '.join([

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1159,39 +1159,40 @@ def check_github():
     print_msg('', prefix=False)
 
 
-class GithubToken(object):
-    """Representation of a GitHub token."""
-
-    def __init__(self, user):
-        """Initialize: obtain GitHub token for specified user from keyring."""
-        self.token = None
-        if user is None:
-            msg = "No GitHub user name provided, required for fetching GitHub token."
-        elif not HAVE_KEYRING:
-            msg = "Failed to obtain GitHub token from keyring, "
-            msg += "required Python module https://pypi.python.org/pypi/keyring is not available."
-        else:
-            self.token = keyring.get_password(KEYRING_GITHUB_TOKEN, user)
-            if self.token is None:
-                tup = (KEYRING_GITHUB_TOKEN, user)
-                python_cmd = "import getpass, keyring; keyring.set_password(\"%s\", \"%s\", getpass.getpass())" % tup
-                msg = '\n'.join([
-                    "Failed to obtain GitHub token for %s" % user,
-                    "Use the following procedure to install a GitHub token in your keyring:",
-                    "$ python -c '%s'" % python_cmd,
-                ])
-
-        if self.token is None:
-            # failure, for some reason
-            _log.warning(msg)
-        else:
-            # success
-            _log.info("Successfully obtained GitHub token for user %s from keyring." % user)
-
-
 def fetch_github_token(user):
     """Fetch GitHub token for specified user from keyring."""
-    return GithubToken(user).token
+
+    token, msg = None, None
+
+    if user is None:
+        msg = "No GitHub user name provided, required for fetching GitHub token."
+    elif not HAVE_KEYRING:
+        msg = "Failed to obtain GitHub token from keyring, "
+        msg += "required Python module https://pypi.python.org/pypi/keyring is not available."
+    else:
+        try:
+            token = keyring.get_password(KEYRING_GITHUB_TOKEN, user)
+        except RuntimeError as err:
+            _log.warning("Runtime error occurred when fetching GitHub token: %s", err)
+
+        if token is None:
+            python_cmd = '; '.join([
+                "import getpass, keyring",
+                "keyring.set_password(\"%s\", \"%s\", getpass.getpass())" % (KEYRING_GITHUB_TOKEN, user),
+            ])
+            msg = '\n'.join([
+                "Failed to obtain GitHub token for %s" % user,
+                "Use the following procedure to install a GitHub token in your keyring:",
+                "$ python -c '%s'" % python_cmd,
+            ])
+
+    if token is None:
+        # failed to obtain token, log message explaining why
+        _log.warning(msg)
+    else:
+        _log.info("Successfully obtained GitHub token for user %s from keyring." % user)
+
+    return token
 
 
 @only_if_module_is_available('keyring')


### PR DESCRIPTION
Other than getting rid of the useless `GithubToken` class, this also wraps the `keyring.get_password` call into a `try`/`except RuntimeError`, cfr. #2069.