### PR TITLE
optarch can now be specified on a toolchain basis

### DIFF
--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -36,10 +36,15 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.compiler import Compiler
 
 
+TC_CONSTANT_CLANG = "Clang"
+
+
 class Clang(Compiler):
     """Clang compiler class"""
 
     COMPILER_MODULE_NAME = ['Clang']
+    
+    COMPILER_FAMILY = TC_CONSTANT_CLANG
 
     # Don't set COMPILER_FAMILY in this class because Clang does not have
     # Fortran support, and thus it is not a complete compiler as far as

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -734,8 +734,9 @@ class EasyBuildOptions(GeneralOption):
         optarch_parts = self.options.optarch.split(OPTARCH_SEP)
         
         # we expect to find a ':' in every entry in optarch, in case optarch is specified on a per-compiler basis
-        if (len(optarch_parts) > 1 and not all(p.count(OPTARCH_MAP_CHAR) == 1 for p in optarch_parts)) or \
-                (len(optarch_parts) == 1 and optarch_parts[0].count(OPTARCH_MAP_CHAR) > 1):
+        n_parts = len(optarch_parts)
+        map_char_cnts = [p.count(OPTARCH_MAP_CHAR) for p in optarch_parts]
+        if (n_parts > 1 and any(c != 1 for c in map_char_cnts)) or (n_parts == 1 and map_char_cnts[0] > 1):
             raise EasyBuildError("The optarch option has an incorrect syntax: %s", self.options.optarch)
         else:
             # if there are options for different compilers, we set up a dict

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -734,16 +734,17 @@ class EasyBuildOptions(GeneralOption):
         optarch_parts = self.options.optarch.split(OPTARCH_SEP)
         
         # we expect to find a ':' in every entry in optarch, in case optarch is specified on a per-compiler basis
-        if len(optarch_parts) > 1 and not all(OPTARCH_MAP_CHAR in p for p in optarch_parts):
+        if (len(optarch_parts) > 1 and not all(p.count(OPTARCH_MAP_CHAR) == 1 for p in optarch_parts)) or \
+                (len(optarch_parts) == 1 and optarch_parts[0].count(OPTARCH_MAP_CHAR) > 1):
             raise EasyBuildError("The optarch option has an incorrect syntax: %s", self.options.optarch)
         else:
             # if there are options for different compilers, we set up a dict
             if OPTARCH_MAP_CHAR in optarch_parts[0]:
                 optarch_dict = {}
-                for compiler, compiler_opt in [x.split(OPTARCH_MAP_CHAR) for x in optarch_parts]:
+                for compiler, compiler_opt in [p.split(OPTARCH_MAP_CHAR) for p in optarch_parts]:
                     if compiler in optarch_dict:
                         raise EasyBuildError("The optarch option contains duplicated entries for compiler %s: %s",
-                                compiler, self.options.optarch)
+                                             compiler, self.options.optarch)
                     else:
                         optarch_dict[compiler] = compiler_opt
                 self.options.optarch = optarch_dict 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -351,7 +351,7 @@ class EasyBuildOptions(GeneralOption):
                                  None, 'store', None),
             'mpi-tests': ("Run MPI tests (when relevant)", None, 'store_true', True),
             'optarch': ("Set architecture optimization, overriding native architecture optimizations",
-                        None, 'store', None),
+                        'strlist', 'extend', None),
             'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_TXT, FORMAT_RST]),
             'parallel': ("Specify (maximum) level of parallellism used during build procedure",
                          'int', 'store', None),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -745,7 +745,7 @@ class EasyBuildOptions(GeneralOption):
                 optarch_dict = {}
                 for compiler, compiler_opt in [x.split(OPTARCH_MAP_CHAR) for x in optarch_parts]:
                     if compiler in optarch_dict:
-                        raise EasyBuildError("The optarch option contains duplicated entries for compiler %s: %s" \
+                        raise EasyBuildError("The optarch option contains duplicated entries for compiler %s: %s" 
                                 % (compiler, self.options.optarch))
                     else:
                         optarch_dict[compiler] = compiler_opt

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -350,8 +350,9 @@ class EasyBuildOptions(GeneralOption):
             'mpi-cmd-template': ("Template for MPI commands (template keys: %(nr_ranks)s, %(cmd)s)",
                                  None, 'store', None),
             'mpi-tests': ("Run MPI tests (when relevant)", None, 'store_true', True),
+            # optarch is in most cases equivalent to strlist, but changing the type breaks compatibility
             'optarch': ("Set architecture optimization, overriding native architecture optimizations",
-                        'strlist', 'extend', None),
+                        None, 'store', None),
             'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_TXT, FORMAT_RST]),
             'parallel': ("Specify (maximum) level of parallellism used during build procedure",
                          'int', 'store', None),

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -298,8 +298,9 @@ class Compiler(Toolchain):
         # --optarch=GENERIC
         elif build_option('optarch') == OPTARCH_GENERIC:
             use_generic = True
-        # no --optarch specified
-        elif self.arch in (self.COMPILER_OPTIMAL_ARCHITECTURE_OPTION or []):
+
+        # no --optarch specified or no option found for the current compiler
+        if use_generic == False and optarch is None and self.arch in (self.COMPILER_OPTIMAL_ARCHITECTURE_OPTION or []):
             optarch = self.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[self.arch]
 
         if use_generic == True:

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -286,9 +286,9 @@ class Compiler(Toolchain):
                 current_compiler = getattr(self, 'COMPILER_FAMILY', None)
                 for optarch_option in build_option('optarch').split(","):
                     comp = optarch_option.split(":")[0]
-                    comp_optarch = optarch_option.split(":")[1] if len(optarch_option.split(":")) > 1 else ''
+                    comp_optarch = optarch_option.split(":")[1] if len(optarch_option.split(":")) > 1 else None 
                     if comp == current_compiler:
-                        if comp_optarch != '' and comp_optarch != OPTARCH_GENERIC:
+                        if comp_optarch is not None and comp_optarch != OPTARCH_GENERIC:
                             optarch = comp_optarch
                         elif comp_optarch == OPTARCH_GENERIC:
                             use_generic = True

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -302,7 +302,7 @@ class Compiler(Toolchain):
                 # no option for this compiler
                 else:
                     optarch = None
-                    self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.", \
+                    self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.", 
                             current_compiler)
             else:
                 raise EasyBuildError("optarch is neither an string or a dict. This should never ever happen")

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -282,7 +282,7 @@ class Compiler(Toolchain):
         use_generic = False
         # --optarch is specified with flags to use
         if build_option('optarch') is not None:
-            for optarch_option in build_option('optarch'):
+            for optarch_option in build_option('optarch').split(','):
                 # No compilers specified, and option is not generic, so simply take what is there
                 if ":" not in optarch_option and optarch_option != OPTARCH_GENERIC:
                     optarch = optarch_option

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -304,7 +304,7 @@ class Compiler(Toolchain):
                     self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.", 
                             current_compiler)
             else:
-                raise EasyBuildError("optarch is neither an string or a dict. This should never ever happen")
+                raise EasyBuildError("optarch is neither an string or a dict %s. This should never happen", optarch)
 
         if use_generic == True:
             if (self.arch, self.cpu_family) in (self.COMPILER_GENERIC_OPTION or []):

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -42,7 +42,7 @@ DEFAULT_OPT_LEVEL = 'defaultopt'
 # by doing eb --optarch=GENERIC
 OPTARCH_GENERIC = 'GENERIC'
 
-# Characters that separate toolchains and options in --optarch
+# Characters that separate compilers and flags in --optarch
 OPTARCH_SEP = ';'
 OPTARCH_MAP_CHAR = ':'
 
@@ -282,12 +282,11 @@ class Compiler(Toolchain):
                                 (--optarch and --optarch=GENERIC still override this value)
         """
         use_generic = False
-        optarch= build_option('optarch') 
+        optarch = build_option('optarch') 
         # --optarch is specified with flags to use
         if optarch is not None:
-            # optarch has been validated as a simple string
+            # optarch has been parsed as a simple string
             if isinstance(optarch, basestring):
-                # Option is generic, so mark it as to be set later
                 if optarch == OPTARCH_GENERIC:
                     use_generic = True
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -52,7 +52,7 @@ from easybuild.tools.run import run_cmd
 
 
 # number of modules included for testing purposes
-TEST_MODULES_COUNT = 77
+TEST_MODULES_COUNT = 78
 
 
 class ModulesTest(EnhancedTestCase):

--- a/test/framework/modules/PGI/16.7-GCC-5.4.0-2.26
+++ b/test/framework/modules/PGI/16.7-GCC-5.4.0-2.26
@@ -1,0 +1,3 @@
+#%Module
+# dummy PGI/16.7-GCC-5.4.0-2.26 module
+setenv  EBVERSIONPGI            "16.7-GCC-5.4.0-2.2"

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2981,20 +2981,18 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
 
         # Check that it doesn't raise an exception when the input is correct
-        args = ['--optarch=','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
-        self.eb_main(args, raise_error=True)
-        args = ['--optarch=something','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
-        self.eb_main(args, raise_error=True)
-        args = ['--optarch=GENERIC','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
-        self.eb_main(args, raise_error=True)
-        args = ['--optarch=Intel:something','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
-        self.eb_main(args, raise_error=True)
-        args = ['--optarch=Intel:something;GCC:somethingelse','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
-        self.eb_main(args, raise_error=True)
-        args = ['--optarch=Intel:GENERIC;GCC:somethingelse','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
-        self.eb_main(args, raise_error=True)
-        args = ['--optarch=Intel:;GCC:somethingelse','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
-        self.eb_main(args, raise_error=True)
+        test_easyconfig = 'easyconfigs/test_ecs/t/toy/toy-0.0.eb'
+        test_cases = [
+                ['--optarch=',test_easyconfig],
+                ['--optarch=something',test_easyconfig],
+                ['--optarch=GENERIC',test_easyconfig],
+                ['--optarch=Intel:something',test_easyconfig],
+                ['--optarch=Intel:something;GCC:somethingelse',test_easyconfig],
+                ['--optarch=Intel:GENERIC;GCC:somethingelse',test_easyconfig],
+                ['--optarch=Intel:;GCC:somethingelse;',test_easyconfig]
+                ]
+        for args in test_cases:
+            self.eb_main(args, raise_error=True)
 
         # Check the parsing itself
         test_cases = [

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2967,6 +2967,19 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search('^\s+\* GCC v4.6.3: dummy', txt, re.M))
         self.assertFalse(re.search('gzip', txt, re.M))
 
+    def test_optarch(self):
+        """Test correct parsing of optarch option."""
+        # Check for EasyBuildErrors
+        #
+        args = ['--optarch=Intel:something;GCC']
+        error_msg = "The optarch option has an incorrect syntax"
+        self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
+
+        args = ['--optarch=Intel:something;GCC:somethingelse;Intel:anothersomething']
+        error_msg = "The optarch option contains duplicated entries for compiler"
+        self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
+
+        # TODO: Check for correct parsing and dictionary creation
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2967,7 +2967,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search('^\s+\* GCC v4.6.3: dummy', txt, re.M))
         self.assertFalse(re.search('gzip', txt, re.M))
 
-    def test_optarch(self):
+    def test_parse_optarch(self):
         """Test correct parsing of optarch option."""
         # Check for EasyBuildErrors
         #

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2971,29 +2971,16 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_parse_optarch(self):
         """Test correct parsing of optarch option."""
         
+        options = EasyBuildOptions()
+
         # Check for EasyBuildErrors
-        args = ['--optarch=Intel:something;GCC']
         error_msg = "The optarch option has an incorrect syntax"
-        self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
+        options.options.optarch = 'Intel:something;GCC'
+        self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
 
-        args = ['--optarch=Intel:something;GCC:somethingelse;Intel:anothersomething']
         error_msg = "The optarch option contains duplicated entries for compiler"
-        self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
-
-        # Check that it doesn't raise an exception when the input is correct
-        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
-        test_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
-        test_cases = [
-                ['--optarch=',test_ec],
-                ['--optarch=something',test_ec],
-                ['--optarch=GENERIC',test_ec],
-                ['--optarch=Intel:something',test_ec],
-                ['--optarch=Intel:something;GCC:somethingelse',test_ec],
-                ['--optarch=Intel:GENERIC;GCC:somethingelse',test_ec],
-                ['--optarch=Intel:;GCC:somethingelse',test_ec]
-                ]
-        for args in test_cases:
-            self.eb_main(args, raise_error=True)
+        options.options.optarch = 'Intel:something;GCC:somethingelse;Intel:anothersomething'
+        self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
 
         # Check the parsing itself
         test_cases = [
@@ -3005,8 +2992,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 ('Intel:xHost;GCC:march=x86-64 -mtune=generic', {'Intel': 'xHost', 'GCC': 'march=x86-64 -mtune=generic'}),
                 ('Intel:;GCC:march=x86-64 -mtune=generic', {'Intel': '', 'GCC': 'march=x86-64 -mtune=generic'}),
                 ]
-
-        options = EasyBuildOptions()
 
         for optarch_string, optarch_parsed in test_cases:
             options.options.optarch = optarch_string

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2983,21 +2983,21 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
 
         # Check the parsing itself
+        gcc_generic_flags = "march=x86-64 -mtune=generic"
         test_cases = [
-                ('',''),
-                ('xHost','xHost'),
-                ('GENERIC','GENERIC'),
-                ('Intel:xHost', {'Intel': 'xHost'}),
-                ('Intel:GENERIC', {'Intel': 'GENERIC'}),
-                ('Intel:xHost;GCC:march=x86-64 -mtune=generic', {'Intel': 'xHost', 'GCC': 'march=x86-64 -mtune=generic'}),
-                ('Intel:;GCC:march=x86-64 -mtune=generic', {'Intel': '', 'GCC': 'march=x86-64 -mtune=generic'}),
-                ]
+            ('',''),
+            ('xHost','xHost'),
+            ('GENERIC','GENERIC'),
+            ('Intel:xHost', {'Intel': 'xHost'}),
+            ('Intel:GENERIC', {'Intel': 'GENERIC'}),
+            ('Intel:xHost;GCC:%s' % gcc_generic_flags, {'Intel': 'xHost', 'GCC': gcc_generic_flags}),
+            ('Intel:;GCC:%s' % gcc_generic_flags, {'Intel': '', 'GCC': gcc_generic_flags}),
+        ]
 
         for optarch_string, optarch_parsed in test_cases:
             options.options.optarch = optarch_string
             options.postprocess()
-            self.assertTrue(options.options.optarch == optarch_parsed, "Parsing of optarch: True means %s == %s" % 
-                    (options.options.optarch, optarch_parsed))
+            self.assertEqual(options.options.optarch, optarch_parsed)
     
     def test_check_style(self):
         """Test --check-style."""
@@ -3041,6 +3041,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         for pattern in patterns:
             self.assertTrue(re.search(pattern, stdout, re.M), "Pattern '%s' found in: %s" % (pattern, stdout))
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2978,6 +2978,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
         options.options.optarch = 'Intel:something;GCC'
         self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
 
+        options.options.optarch = 'Intel:something;'
+        self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
+        
+        options.options.optarch = 'Intel:something:somethingelse'
+        self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
+
         error_msg = "The optarch option contains duplicated entries for compiler"
         options.options.optarch = 'Intel:something;GCC:somethingelse;Intel:anothersomething'
         self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2980,7 +2980,22 @@ class CommandLineOptionsTest(EnhancedTestCase):
         error_msg = "The optarch option contains duplicated entries for compiler"
         self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
 
-        # TODO: Check for correct parsing and dictionary creation
+        test_cases = [
+                ('',''),
+                ('xHost','xHost'),
+                ('GENERIC','GENERIC'),
+                ('Intel:xHost', {'Intel': 'xHost'}),
+                ('Intel:GENERIC', {'Intel': 'GENERIC'}),
+                ('Intel:xHost;GCC:march=x86-64 -mtune=generic', {'Intel': 'xHost', 'GCC': 'march=x86-64 -mtune=generic'}),
+                ]
+
+        options = EasyBuildOptions()
+
+        for optarch_string, optarch_parsed in test_cases:
+            options.options.optarch = optarch_string
+            options.postprocess()
+            self.assertTrue(options.options.optarch == optarch_parsed, "Parsing of optarch: True means %s == %s" % 
+                    (options.options.optarch, optarch_parsed))
     
     def test_check_style(self):
         """Test --check-style."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2970,8 +2970,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_parse_optarch(self):
         """Test correct parsing of optarch option."""
+        
         # Check for EasyBuildErrors
-        #
         args = ['--optarch=Intel:something;GCC']
         error_msg = "The optarch option has an incorrect syntax"
         self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
@@ -2980,6 +2980,23 @@ class CommandLineOptionsTest(EnhancedTestCase):
         error_msg = "The optarch option contains duplicated entries for compiler"
         self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
 
+        # Check that it doesn't raise an exception when the input is correct
+        args = ['--optarch=','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
+        self.eb_main(args, raise_error=True)
+        args = ['--optarch=something','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
+        self.eb_main(args, raise_error=True)
+        args = ['--optarch=GENERIC','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
+        self.eb_main(args, raise_error=True)
+        args = ['--optarch=Intel:something','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
+        self.eb_main(args, raise_error=True)
+        args = ['--optarch=Intel:something;GCC:somethingelse','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
+        self.eb_main(args, raise_error=True)
+        args = ['--optarch=Intel:GENERIC;GCC:somethingelse','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
+        self.eb_main(args, raise_error=True)
+        args = ['--optarch=Intel:;GCC:somethingelse','easyconfigs/test_ecs/t/toy/toy-0.0.eb']
+        self.eb_main(args, raise_error=True)
+
+        # Check the parsing itself
         test_cases = [
                 ('',''),
                 ('xHost','xHost'),
@@ -2987,6 +3004,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 ('Intel:xHost', {'Intel': 'xHost'}),
                 ('Intel:GENERIC', {'Intel': 'GENERIC'}),
                 ('Intel:xHost;GCC:march=x86-64 -mtune=generic', {'Intel': 'xHost', 'GCC': 'march=x86-64 -mtune=generic'}),
+                ('Intel:;GCC:march=x86-64 -mtune=generic', {'Intel': '', 'GCC': 'march=x86-64 -mtune=generic'}),
                 ]
 
         options = EasyBuildOptions()

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2981,15 +2981,16 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_msg, self.eb_main, args, raise_error=True)
 
         # Check that it doesn't raise an exception when the input is correct
-        test_easyconfig = 'easyconfigs/test_ecs/t/toy/toy-0.0.eb'
+        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        test_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
         test_cases = [
-                ['--optarch=',test_easyconfig],
-                ['--optarch=something',test_easyconfig],
-                ['--optarch=GENERIC',test_easyconfig],
-                ['--optarch=Intel:something',test_easyconfig],
-                ['--optarch=Intel:something;GCC:somethingelse',test_easyconfig],
-                ['--optarch=Intel:GENERIC;GCC:somethingelse',test_easyconfig],
-                ['--optarch=Intel:;GCC:somethingelse;',test_easyconfig]
+                ['--optarch=',test_ec],
+                ['--optarch=something',test_ec],
+                ['--optarch=GENERIC',test_ec],
+                ['--optarch=Intel:something',test_ec],
+                ['--optarch=Intel:something;GCC:somethingelse',test_ec],
+                ['--optarch=Intel:GENERIC;GCC:somethingelse',test_ec],
+                ['--optarch=Intel:;GCC:somethingelse',test_ec]
                 ]
         for args in test_cases:
             self.eb_main(args, raise_error=True)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -417,19 +417,31 @@ class ToolchainTest(EnhancedTestCase):
             self.assertTrue(flag == flags, "optarch: True means '%s' == '%s'" % (flag, flags))
             
             # Also check that it is correctly passed to xFLAGS, honoring 'enable'
-            if flag != '':
-                for var in flag_vars:
-                    flags = tc.get_variable(var)
-                    if enable:
-                        self.assertTrue(flag in flags, "optarch: True means '%s' in '%s'" 
-                                % (flag, flags))
-                    else:
-                        self.assertFalse(flag in flags, "optarch: False means no '%s' in '%s'" 
-                                % (flag, flags))
-            # if flag is '' there is not much to check. A more robust approach
-            # would be to check against a blacklist, but that is probably not necessary
+            if flag == '':
+                blacklist = [
+                       intel_options[0][1],
+                       intel_options[1][1],
+                       gcc_options[0][1],
+                       gcc_options[1][1],
+                       'xHost', # default optimal for Intel
+                       'march=native', # default optimal for GCC
+                       ]
             else:
-                pass
+                blacklist = [flag]
+
+            for var in flag_vars:
+                 flags = tc.get_variable(var)
+                
+                 # Check that the correct flags are there
+                 if enable and flag != '':
+                     self.assertTrue(flag in flags, "optarch: True means '%s' in '%s'" 
+                             % (flag, flags))
+
+                 # Check that there aren't unexpected flags
+                 else:
+                     for blacklisted_flag in blacklist:
+                         self.assertFalse(blacklisted_flag in flags, "optarch: False means no '%s' in '%s'" 
+                                 % (blacklisted_flag, flags))
 
             self.modtool.purge()
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -421,10 +421,10 @@ class ToolchainTest(EnhancedTestCase):
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:
-                        self.assertTrue(flag in flags, "optarch: True means '%s' in '%s'" \
+                        self.assertTrue(flag in flags, "optarch: True means '%s' in '%s'" 
                                 % (flag, flags))
                     else:
-                        self.assertFalse(flag in flags, "optarch: False means no '%s' in '%s'" \
+                        self.assertFalse(flag in flags, "optarch: False means no '%s' in '%s'" 
                                 % (flag, flags))
             # if flag is '' there is not much to check. A more robust approach
             # would be to check against a blacklist, but that is probably not necessary

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -384,26 +384,37 @@ class ToolchainTest(EnhancedTestCase):
   
     def test_compiler_dependent_optarch(self):
         """Test whether specifying optarch on a per compiler basis works."""
+        flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
         for intelflags,intel_expanded_flags in [('intelflag','intelflag'),('GENERIC','xSSE2'),('','')]:
             for gccflags,gcc_expanded_flags in  [('gccflag','gccflag'),('GENERIC','march=x86-64 -mtune=generic'),('','')]:
                 optarch_var = 'Intel:%s,GCC:%s' % (intelflags,gccflags)
                 build_options = {'optarch': optarch_var}
                 init_config(build_options=build_options)
                 for toolchain, toolchain_version in [('iccifort','2011.13.367'),('GCC','4.7.2'),('PGI','16.7-GCC-5.4.0-2.26')]:
-               	    tc = self.get_toolchain(toolchain, version=toolchain_version)
-                    tc.prepare()
-                    flag = None
-                    if toolchain == 'iccifort':
-                        flag = intel_expanded_flags
-                    elif toolchain == 'GCC':
-                        flag = gcc_expanded_flags 
-                    else: # PGI as an example of compiler not set
-                        # default optarch flag
-                        flag = tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch,tc.cpu_family)]
-                    
-                    flags = tc.options.options_map['optarch']
+                    for enable in [True, False]:
+               	        tc = self.get_toolchain(toolchain, version=toolchain_version)
+                        tc.set_options({'optarch': enable})
+                        tc.prepare()
+                        flag = None
+                        if toolchain == 'iccifort':
+                            flag = intel_expanded_flags
+                        elif toolchain == 'GCC':
+                            flag = gcc_expanded_flags 
+                        else: # PGI as an example of compiler not set
+                            # default optarch flag
+                            flag = tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch,tc.cpu_family)]
+                        
+                        flags = tc.options.options_map['optarch']
 
-                    self.assertTrue(flag == flags, "optarch: True means '%s' == '%s'" % (flag, flags))
+                        self.assertTrue(flag == flags, "optarch: True means '%s' == '%s'" % (flag, flags))
+                        
+                        # Also check that it is correctly passed to xFLAGS, honoring 'enable'
+                        if flag != '':
+                            for var in flag_vars:
+                                if enable:
+                                    self.assertTrue(flag in tc.get_variable(var), "optarch: True means '%s' in '%s'" % (flag, tc.get_variable(var)))
+                                else:
+                                    self.assertFalse(flag in tc.get_variable(var), "optarch: False means no '%s' in '%s'" % (flag, tc.get_variable(var)))
 
                     self.modtool.purge()
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -387,12 +387,14 @@ class ToolchainTest(EnhancedTestCase):
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
         for intelflags,intel_expanded_flags in [('intelflag','intelflag'),('GENERIC','xSSE2'),('','')]:
             for gccflags,gcc_expanded_flags in  [('gccflag','gccflag'),('GENERIC','march=x86-64 -mtune=generic'),('','')]:
-                optarch_var = 'Intel:%s,GCC:%s' % (intelflags,gccflags)
+                optarch_var = dict()
+                optarch_var['Intel'] = '%s' % intelflags
+                optarch_var['GCC'] = '%s' % gccflags
                 build_options = {'optarch': optarch_var}
                 init_config(build_options=build_options)
                 for toolchain, toolchain_version in [('iccifort','2011.13.367'),('GCC','4.7.2'),('PGI','16.7-GCC-5.4.0-2.26')]:
                     for enable in [True, False]:
-               	        tc = self.get_toolchain(toolchain, version=toolchain_version)
+                        tc = self.get_toolchain(toolchain, version=toolchain_version)
                         tc.set_options({'optarch': enable})
                         tc.prepare()
                         flag = None
@@ -401,8 +403,9 @@ class ToolchainTest(EnhancedTestCase):
                         elif toolchain == 'GCC':
                             flag = gcc_expanded_flags 
                         else: # PGI as an example of compiler not set
-                            # default optarch flag
-                            flag = tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch,tc.cpu_family)]
+                            # default optarch flag, should be the same as the one in
+                            # tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch,tc.cpu_family)]
+                            flag = ''
                         
                         flags = tc.options.options_map['optarch']
 
@@ -415,6 +418,10 @@ class ToolchainTest(EnhancedTestCase):
                                     self.assertTrue(flag in tc.get_variable(var), "optarch: True means '%s' in '%s'" % (flag, tc.get_variable(var)))
                                 else:
                                     self.assertFalse(flag in tc.get_variable(var), "optarch: False means no '%s' in '%s'" % (flag, tc.get_variable(var)))
+                        # if flag is '' there is not much to check. A more robust approach
+                        # would be to check against a blacklist, but that is probably not necessary
+                        else:
+                            pass
 
                     self.modtool.purge()
 


### PR DESCRIPTION
This PR enables EB to accept a more powerful `--optarch` syntax. Valid options are:

`--optarch=someflag` -> Same as now
`--optarch=GENERIC` -> Same as now
`--optarch=Intel:xCORE-AVX512,GCC:GENERIC` -> Tells Intel based toolchains to use `-xCORE-AVX512` as a flag, and GCC based toolchains to use a generic set of flags (as specified in the toolchain definition)
`--optarch=Intel:,GCC:someflag` -> Tells Intel based toolchains to have the default behaviour (currently `-xHost`), and GCC based toolchains to use `-someflag`
`--optarch=Intel,GCC:someflag` -> Same as the previous case
`--optarch=Intel:xCORE-AVX512,GCC:GENERIC,Intel:xHost` -> Tells Intel based toolchains to use `-xCORE-AVX512`. The second case is ignored.

This allows to install packages on multiple toolchains using the correct `--optarch` option in a single command, or to have a single definition of `EASYBUILD_OPTARCH` that is correct regardless of the toolchain used.

A test is pending.