### PR TITLE
implement get_cpu_features function in systemtools

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -418,7 +418,6 @@ def get_cpu_features():
             _log.debug("Trying to determine CPU features on Darwin via cmd '%s'", cmd)
             out, ec = run_cmd(cmd, force_in_dry_run=True)
             if ec == 0:
-                # returns clock frequency in cycles/sec, but we want MHz
                 cpu_feat.extend(out.strip().lower().split())
 
         cpu_feat.sort()

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -385,6 +385,50 @@ def get_cpu_speed():
     return cpu_freq
 
 
+def get_cpu_features():
+    """
+    Get list of CPU features
+    """
+    cpu_feat = []
+    os_type = get_os_type()
+
+    if os_type == LINUX:
+        if is_readable(PROC_CPUINFO_FP):
+            _log.debug("Trying to determine CPU features on Linux via %s" % PROC_CPUINFO_FP)
+            proc_cpuinfo = read_file(PROC_CPUINFO_FP)
+            # 'flags' on Linux/x86, 'Features' on Linux/ARM
+            flags_regex = re.compile(r"^(?:flags|[fF]eatures)\s*:\s*(?P<flags>.*)", re.M)
+            res = flags_regex.search(proc_cpuinfo)
+            if res:
+                cpu_feat = sorted(res.group('flags').lower().split())
+                _log.debug("Found CPU features using regex '%s': %s" % (flags_regex.pattern, cpu_feat))
+            elif get_cpu_architecture() == POWER:
+                # for Linux@POWER systems, no flags/features are listed, but we can check for Altivec
+                cpu_altivec_regex = re.compile("^cpu\s*:.*altivec supported", re.M)
+                if cpu_altivec_regex.search(proc_cpuinfo):
+                    cpu_feat = ['altivec']
+            else:
+                _log.debug("Failed to determine CPU features from %s", PROC_CPUINFO_FP)
+        else:
+            _log.debug("%s not found to determine CPU features", PROC_CPUINFO_FP)
+
+    elif os_type == DARWIN:
+        for feature_set in ['extfeatures', 'features', 'leaf7_features']:
+            cmd = "sysctl -n machdep.cpu.%s" % feature_set
+            _log.debug("Trying to determine CPU features on Darwin via cmd '%s'" % cmd)
+            out, ec = run_cmd(cmd, force_in_dry_run=True)
+            if ec == 0:
+                # returns clock frequency in cycles/sec, but we want MHz
+                cpu_feat.extend(out.strip().lower().split())
+
+        cpu_feat.sort()
+
+    else:
+        raise SystemToolsException("Could not determine CPU features (OS: %s)." % os_type)
+
+    return cpu_feat
+
+
 def get_kernel_name():
     """NO LONGER SUPPORTED: use get_os_type() instead"""
     _log.nosupport("get_kernel_name() is replaced by get_os_type()", '2.0')

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -394,14 +394,14 @@ def get_cpu_features():
 
     if os_type == LINUX:
         if is_readable(PROC_CPUINFO_FP):
-            _log.debug("Trying to determine CPU features on Linux via %s" % PROC_CPUINFO_FP)
+            _log.debug("Trying to determine CPU features on Linux via %s", PROC_CPUINFO_FP)
             proc_cpuinfo = read_file(PROC_CPUINFO_FP)
             # 'flags' on Linux/x86, 'Features' on Linux/ARM
             flags_regex = re.compile(r"^(?:flags|[fF]eatures)\s*:\s*(?P<flags>.*)", re.M)
             res = flags_regex.search(proc_cpuinfo)
             if res:
                 cpu_feat = sorted(res.group('flags').lower().split())
-                _log.debug("Found CPU features using regex '%s': %s" % (flags_regex.pattern, cpu_feat))
+                _log.debug("Found CPU features using regex '%s': %s", flags_regex.pattern, cpu_feat)
             elif get_cpu_architecture() == POWER:
                 # for Linux@POWER systems, no flags/features are listed, but we can check for Altivec
                 cpu_altivec_regex = re.compile("^cpu\s*:.*altivec supported", re.M)
@@ -415,7 +415,7 @@ def get_cpu_features():
     elif os_type == DARWIN:
         for feature_set in ['extfeatures', 'features', 'leaf7_features']:
             cmd = "sysctl -n machdep.cpu.%s" % feature_set
-            _log.debug("Trying to determine CPU features on Darwin via cmd '%s'" % cmd)
+            _log.debug("Trying to determine CPU features on Darwin via cmd '%s'", cmd)
             out, ec = run_cmd(cmd, force_in_dry_run=True)
             if ec == 0:
                 # returns clock frequency in cycles/sec, but we want MHz
@@ -424,7 +424,7 @@ def get_cpu_features():
         cpu_feat.sort()
 
     else:
-        raise SystemToolsException("Could not determine CPU features (OS: %s)." % os_type)
+        raise SystemToolsException("Could not determine CPU features (OS: %s)" % os_type)
 
     return cpu_feat
 

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -43,9 +43,9 @@ from easybuild.tools.systemtools import CPU_FAMILIES, DARWIN, LINUX, UNKNOWN
 from easybuild.tools.systemtools import CPU_VENDORS, AMD, APM, ARM, CAVIUM, IBM, INTEL
 from easybuild.tools.systemtools import MAX_FREQ_FP, PROC_CPUINFO_FP, PROC_MEMINFO_FP
 from easybuild.tools.systemtools import det_parallelism, get_avail_core_count, get_cpu_architecture, get_cpu_family
-from easybuild.tools.systemtools import get_cpu_model, get_cpu_speed, get_cpu_vendor, get_glibc_version
-from easybuild.tools.systemtools import get_os_type, get_os_name, get_os_version, get_platform_name, get_shared_lib_ext
-from easybuild.tools.systemtools import get_system_info, get_total_memory, get_gcc_version
+from easybuild.tools.systemtools import get_cpu_features, get_cpu_model, get_cpu_speed, get_cpu_vendor
+from easybuild.tools.systemtools import get_glibc_version, get_os_type, get_os_name, get_os_version, get_platform_name
+from easybuild.tools.systemtools import get_shared_lib_ext, get_system_info, get_total_memory, get_gcc_version
 
 
 PROC_CPUINFO_TXT = None
@@ -302,6 +302,9 @@ def mocked_run_cmd(cmd, **kwargs):
         "sysctl -n hw.ncpu": '10',
         "sysctl -n hw.memsize": '8589934592',
         "sysctl -n machdep.cpu.brand_string": "Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz",
+        "sysctl -n machdep.cpu.extfeatures": "SYSCALL XD 1GBPAGE EM64T LAHF LZCNT RDTSCP TSCI",
+        "sysctl -n machdep.cpu.features": "FPU VME DE PSE TSC MSR PAE MCE CX8 APIC SEP MTRR PGE MCA CMOV PAT PSE36 CLFSH DS ACPI MMX FXSR SSE SSE2 SS HTT TM PBE SSE3 PCLMULQDQ DTES64 MON DSCPL VMX EST TM2 SSSE3 FMA CX16 TPR PDCM SSE4.1 SSE4.2 x2APIC MOVBE POPCNT AES PCID XSAVE OSXSAVE SEGLIM64 TSCTMR AVX1.0 RDRAND F16C",
+        "sysctl -n machdep.cpu.leaf7_features": "SMEP ERMS RDWRFSGS TSC_THREAD_OFFSET BMI1 AVX2 BMI2 INVPCID FPU_CSDS",
         "sysctl -n machdep.cpu.vendor": 'GenuineIntel',
         "ulimit -u": '40',
     }
@@ -323,6 +326,7 @@ class SystemToolsTest(EnhancedTestCase):
     def setUp(self):
         """Set up systemtools test."""
         super(SystemToolsTest, self).setUp()
+        self.orig_get_cpu_architecture = st.get_cpu_architecture
         self.orig_get_os_type = st.get_os_type
         self.orig_is_readable = st.is_readable
         self.orig_read_file = st.read_file
@@ -333,6 +337,7 @@ class SystemToolsTest(EnhancedTestCase):
         """Cleanup after systemtools test."""
         st.is_readable = self.orig_is_readable
         st.read_file = self.orig_read_file
+        st.get_cpu_architecture = self.orig_get_cpu_architecture
         st.get_os_type = self.orig_get_os_type
         st.run_cmd = self.orig_run_cmd
         st.platform.uname = self.orig_platform_uname
@@ -431,6 +436,62 @@ class SystemToolsTest(EnhancedTestCase):
         st.get_os_type = lambda: st.DARWIN
         st.run_cmd = mocked_run_cmd
         self.assertEqual(get_cpu_speed(), 2400.0)
+
+    def test_cpu_features_native(self):
+        """Test getting CPU features."""
+        cpu_feat = get_cpu_features()
+        self.assertTrue(isinstance(cpu_feat, list))
+        self.assertTrue(len(cpu_feat) > 0)
+        self.assertTrue(all([isinstance(x, basestring) for x in cpu_feat]))
+
+    def test_cpu_features_linux(self):
+        """Test getting CPU features (mocked for Linux)."""
+        st.get_os_type = lambda: st.LINUX
+        st.read_file = mocked_read_file
+        st.is_readable = lambda fp: mocked_is_readable(PROC_CPUINFO_FP, fp)
+
+        # tweak global constant used by mocked_read_file
+        global PROC_CPUINFO_TXT
+
+        PROC_CPUINFO_TXT = PROC_CPUINFO_TXT_INTEL
+        expected = ['acpi', 'aes', 'aperfmperf', 'apic', 'arat', 'arch_perfmon', 'avx', 'bts', 'clflush', 'cmov',
+                    'constant_tsc', 'cx16', 'cx8', 'dca', 'de', 'ds_cpl', 'dtes64', 'dts', 'dts', 'ept', 'est',
+                    'flexpriority', 'fpu', 'fxsr', 'ht', 'ida', 'lahf_lm', 'lm', 'mca', 'mce', 'mmx', 'monitor',
+                    'msr', 'mtrr', 'nonstop_tsc', 'nx', 'pae', 'pat', 'pbe', 'pcid', 'pclmulqdq', 'pdcm', 'pdpe1gb',
+                    'pebs', 'pge', 'pln', 'pni', 'popcnt', 'pse', 'pse36', 'pts', 'rdtscp', 'rep_good', 'sep', 'smx',
+                    'ss', 'sse', 'sse2', 'sse4_1', 'sse4_2', 'ssse3', 'syscall', 'tm', 'tm2', 'tpr_shadow', 'tsc',
+                    'tsc_deadline_timer', 'vme', 'vmx', 'vnmi', 'vpid', 'x2apic', 'xsave', 'xsaveopt', 'xtopology',
+                    'xtpr']
+        self.assertEqual(get_cpu_features(), expected)
+
+        PROC_CPUINFO_TXT = PROC_CPUINFO_TXT_RASPI2
+        expected = ['edsp', 'evtstrm', 'fastmult', 'half', 'idiva', 'idivt', 'lpae', 'neon',
+                    'thumb', 'tls', 'vfp', 'vfpd32', 'vfpv3', 'vfpv4']
+        self.assertEqual(get_cpu_features(), expected)
+
+        PROC_CPUINFO_TXT = PROC_CPUINFO_TXT_ODROID_XU3
+        expected = ['edsp', 'fastmult', 'half', 'idiva', 'idivt', 'neon', 'swp', 'thumb',
+                    'tls', 'vfp', 'vfpv3', 'vfpv4']
+        self.assertEqual(get_cpu_features(), expected)
+
+        PROC_CPUINFO_TXT = PROC_CPUINFO_TXT_XGENE2
+        expected = ['aes', 'asimd', 'crc32', 'evtstrm', 'fp', 'pmull', 'sha1', 'sha2']
+        self.assertEqual(get_cpu_features(), expected)
+
+        PROC_CPUINFO_TXT = PROC_CPUINFO_TXT_THUNDERX
+        expected = ['aes', 'asimd', 'crc32', 'evtstrm', 'fp', 'pmull', 'sha1', 'sha2']
+        self.assertEqual(get_cpu_features(), expected)
+
+        PROC_CPUINFO_TXT = PROC_CPUINFO_TXT_POWER
+        st.get_cpu_architecture = lambda: POWER
+        self.assertEqual(get_cpu_features(), ['altivec'])
+
+    def test_cpu_features_darwin(self):
+        """Test getting CPU features (mocked for Darwin)."""
+        st.get_os_type = lambda: st.DARWIN
+        st.run_cmd = mocked_run_cmd
+        expected = ['1gbpage', 'acpi', 'aes', 'apic', 'avx1.0', 'avx2', 'bmi1', 'bmi2', 'clfsh', 'cmov', 'cx16', 'cx8', 'de', 'ds', 'dscpl', 'dtes64', 'em64t', 'erms', 'est', 'f16c', 'fma', 'fpu', 'fpu_csds', 'fxsr', 'htt', 'invpcid', 'lahf', 'lzcnt', 'mca', 'mce', 'mmx', 'mon', 'movbe', 'msr', 'mtrr', 'osxsave', 'pae', 'pat', 'pbe', 'pcid', 'pclmulqdq', 'pdcm', 'pge', 'popcnt', 'pse', 'pse36', 'rdrand', 'rdtscp', 'rdwrfsgs', 'seglim64', 'sep', 'smep', 'ss', 'sse', 'sse2', 'sse3', 'sse4.1', 'sse4.2', 'ssse3', 'syscall', 'tm', 'tm2', 'tpr', 'tsc', 'tsc_thread_offset', 'tsci', 'tsctmr', 'vme', 'vmx', 'x2apic', 'xd', 'xsave']
+        self.assertEqual(get_cpu_features(), expected)
 
     def test_cpu_architecture_native(self):
         """Test getting the CPU architecture."""

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -490,7 +490,13 @@ class SystemToolsTest(EnhancedTestCase):
         """Test getting CPU features (mocked for Darwin)."""
         st.get_os_type = lambda: st.DARWIN
         st.run_cmd = mocked_run_cmd
-        expected = ['1gbpage', 'acpi', 'aes', 'apic', 'avx1.0', 'avx2', 'bmi1', 'bmi2', 'clfsh', 'cmov', 'cx16', 'cx8', 'de', 'ds', 'dscpl', 'dtes64', 'em64t', 'erms', 'est', 'f16c', 'fma', 'fpu', 'fpu_csds', 'fxsr', 'htt', 'invpcid', 'lahf', 'lzcnt', 'mca', 'mce', 'mmx', 'mon', 'movbe', 'msr', 'mtrr', 'osxsave', 'pae', 'pat', 'pbe', 'pcid', 'pclmulqdq', 'pdcm', 'pge', 'popcnt', 'pse', 'pse36', 'rdrand', 'rdtscp', 'rdwrfsgs', 'seglim64', 'sep', 'smep', 'ss', 'sse', 'sse2', 'sse3', 'sse4.1', 'sse4.2', 'ssse3', 'syscall', 'tm', 'tm2', 'tpr', 'tsc', 'tsc_thread_offset', 'tsci', 'tsctmr', 'vme', 'vmx', 'x2apic', 'xd', 'xsave']
+        expected = ['1gbpage', 'acpi', 'aes', 'apic', 'avx1.0', 'avx2', 'bmi1', 'bmi2', 'clfsh', 'cmov', 'cx16',
+                    'cx8', 'de', 'ds', 'dscpl', 'dtes64', 'em64t', 'erms', 'est', 'f16c', 'fma', 'fpu', 'fpu_csds',
+                    'fxsr', 'htt', 'invpcid', 'lahf', 'lzcnt', 'mca', 'mce', 'mmx', 'mon', 'movbe', 'msr', 'mtrr',
+                    'osxsave', 'pae', 'pat', 'pbe', 'pcid', 'pclmulqdq', 'pdcm', 'pge', 'popcnt', 'pse', 'pse36',
+                    'rdrand', 'rdtscp', 'rdwrfsgs', 'seglim64', 'sep', 'smep', 'ss', 'sse', 'sse2', 'sse3', 'sse4.1',
+                    'sse4.2', 'ssse3', 'syscall', 'tm', 'tm2', 'tpr', 'tsc', 'tsc_thread_offset', 'tsci', 'tsctmr',
+                    'vme', 'vmx', 'x2apic', 'xd', 'xsave']
         self.assertEqual(get_cpu_features(), expected)
 
     def test_cpu_architecture_native(self):


### PR DESCRIPTION
This could be used to implement an FFTW easyblock that auto-detects which configure flags can be specified to optimise performance (e.g. `--enable-avx`, `--enable-avx2`, etc.), rather than hardcoding configure flags in the FFTW easyconfigs (which is an issue already, since `--enable-sse2` doesn't work on Linux/POWER for example).