### PR TITLE
support use of linalg without MPI, add iimkl toolchain definition

### DIFF
--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -68,9 +68,9 @@ class IntelFFTW(Fftw):
 
         interface_lib = "fftw3xc%s%s" % (compsuff, picsuff)
         fftw_libs = [interface_lib]
+        cluster_interface_lib = None
         if self.options.get('usempi', False):
             # add cluster interface for recent imkl versions
-            cluster_interface_lib = None
             if LooseVersion(imklver) >= LooseVersion("11.0.2"):
                 cluster_interface_lib = "fftw3x_cdft%s%s" % (bitsuff, picsuff)
                 fftw_libs.append(cluster_interface_lib)

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -71,11 +71,11 @@ class IntelFFTW(Fftw):
         cluster_interface_lib = None
         if self.options.get('usempi', False):
             # add cluster interface for recent imkl versions
-            if LooseVersion(imklver) >= LooseVersion("11.0.2"):
-                cluster_interface_lib = "fftw3x_cdft%s%s" % (bitsuff, picsuff)
-                fftw_libs.append(cluster_interface_lib)
-            elif LooseVersion(imklver) >= LooseVersion("10.3"):
-                cluster_interface_lib = "fftw3x_cdft%s" % picsuff
+            if LooseVersion(imklver) >= LooseVersion('10.3'):
+                suff = picsuff
+                if LooseVersion(imklver) >= LooseVersion('11.0.2'):
+                    suff = bitsuff + suff
+                cluster_interface_lib = 'fftw3x_cdft%s' % suff
                 fftw_libs.append(cluster_interface_lib)
             fftw_libs.append("mkl_cdft_core")  # add cluster dft
             fftw_libs.extend(self.variables['LIBBLACS'].flatten()) # add BLACS; use flatten because ListOfList

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -100,7 +100,7 @@ class IntelFFTW(Fftw):
             # See https://software.intel.com/en-us/articles/intel-mkl-main-libraries-contain-fftw3-interfaces
             # The cluster interface libs (libfftw3x_cdft*) can be omitted if the toolchain does not provide MPI-FFTW
             # interfaces.
-            check_fftw_libs = [lib for lib in check_fftw_libs if lib != interface_lib and lib != cluster_interface_lib]
+            check_fftw_libs = [l for l in check_fftw_libs if l not in [interface_lib, cluster_interface_lib]]
         if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
             self.FFT_LIB = fftw_libs
         else:

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -66,13 +66,17 @@ class IntelFFTW(Fftw):
             else:
                 raise EasyBuildError("Not using Intel compilers, PGI nor GCC, don't know compiler suffix for FFTW libraries.")
 
-        fftw_libs = ["fftw3xc%s%s" % (compsuff, picsuff)]
+        interface_lib = "fftw3xc%s%s" % (compsuff, picsuff)
+        fftw_libs = [interface_lib]
         if self.options.get('usempi', False):
             # add cluster interface for recent imkl versions
+            cluster_interface_lib = None
             if LooseVersion(imklver) >= LooseVersion("11.0.2"):
-                fftw_libs.append("fftw3x_cdft%s%s" % (bitsuff, picsuff))
+                cluster_interface_lib = "fftw3x_cdft%s%s" % (bitsuff, picsuff)
+                fftw_libs.append(cluster_interface_lib)
             elif LooseVersion(imklver) >= LooseVersion("10.3"):
-                fftw_libs.append("fftw3x_cdft%s" % picsuff)
+                cluster_interface_lib = "fftw3x_cdft%s" % picsuff
+                fftw_libs.append(cluster_interface_lib)
             fftw_libs.append("mkl_cdft_core")  # add cluster dft
             fftw_libs.extend(self.variables['LIBBLACS'].flatten()) # add BLACS; use flatten because ListOfList
 
@@ -90,13 +94,13 @@ class IntelFFTW(Fftw):
         # filter out libraries from list of FFTW libraries to check for if they are not provided by Intel MKL
         check_fftw_libs = [lib for lib in fftw_libs if lib not in ['dl', 'gfortran']]
         fftw_lib_exists = lambda x: any([os.path.exists(os.path.join(d, "lib%s.a" % x)) for d in fft_lib_dirs])
-        if not fftw_lib_exists(check_fftw_libs[0]) and LooseVersion(imklver) >= LooseVersion("10.2"):
+        if not fftw_lib_exists(interface_lib) and LooseVersion(imklver) >= LooseVersion("10.2"):
+            # interface libs can be optional:
             # MKL >= 10.2 include fftw3xc and fftw3xf interfaces in LIBBLAS=libmkl_gf/libmkl_intel
             # See https://software.intel.com/en-us/articles/intel-mkl-main-libraries-contain-fftw3-interfaces
-            check_fftw_libs.pop(0)
-            # and reduce functionality with MPI if wrappers are not built
-            if check_fftw_libs[0].startswith("fftw3x_cdft"):
-                check_fftw_libs.pop(0)
+            # The cluster interface libs (libfftw3x_cdft*) can be omitted if the toolchain does not provide MPI-FFTW
+            # interfaces.
+            check_fftw_libs = [lib for lib in check_fftw_libs if lib != interface_lib and lib != cluster_interface_lib]
         if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
             self.FFT_LIB = fftw_libs
         else:

--- a/easybuild/toolchains/iimkl.py
+++ b/easybuild/toolchains/iimkl.py
@@ -1,0 +1,45 @@
+##
+# Copyright 2012-2016 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for iimkl compiler toolchain (includes Intel compilers (icc, ifort),
+Intel Math Kernel Library (MKL), and Intel FFTW wrappers.
+
+:author: Stijn De Weirdt (Ghent University)
+:author: Kenneth Hoste (Ghent University)
+:author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
+"""
+
+from easybuild.toolchains.iccifort import IccIfort
+from easybuild.toolchains.fft.intelfftw import IntelFFTW
+from easybuild.toolchains.linalg.intelmkl import IntelMKL
+
+
+class Iimkl(IccIfort, IntelMKL, IntelFFTW):
+    """
+    Compiler toolchain with Intel compilers (icc/ifort),
+    Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
+    """
+    NAME = 'iimkl'
+    SUBTOOLCHAIN = IccIfort.NAME

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -90,7 +90,7 @@ class LinAlg(Toolchain):
         ## TODO is link order fully preserved with this order ?
         self._set_blas_variables()
         self._set_lapack_variables()
-        if self.options.get('usempi', False):
+        if getattr(self, 'MPI_MODULE_NAME', None):
             self._set_blacs_variables()
             self._set_scalapack_variables()
 

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -90,8 +90,9 @@ class LinAlg(Toolchain):
         ## TODO is link order fully preserved with this order ?
         self._set_blas_variables()
         self._set_lapack_variables()
-        self._set_blacs_variables()
-        self._set_scalapack_variables()
+        if self.options.get('usempi', False):
+            self._set_blacs_variables()
+            self._set_scalapack_variables()
 
         self.log.debug('set_variables: LinAlg variables %s' % self.variables)
 


### PR DESCRIPTION
The motivation for this request is that at Compute Canada we'd like to install MKL at the core level.
However that means we have to set interfaces = False in the mkl easyconfig.

Since non-MPI FFTW3 interfaces are already included in MKL without compiling interfaces this MKL can be used in toolchains except when MPI-FFTW3 is required (and I don't think many applications use MPI-FFTW3? I should look up some examples).

Another advantage is that one can construct compiler+linalg+fftw toolchains without MPI which is useful for compiler x MPI hierarchies.
