### PR TITLE
fix traceback with 'eb --check-github' if GitPython is not installed

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1093,11 +1093,14 @@ def check_github():
         else:
             check_res = "OK"
     elif github_user:
-        gp_ver, req_gp_ver = git.__version__, '1.0'
-        if LooseVersion(gp_ver) < LooseVersion(req_gp_ver):
-            check_res = "FAIL (GitPython version %s is too old, should be version %s or newer)" % (gp_ver, req_gp_ver)
+        if 'git' in sys.modules:
+            ver, req_ver = git.__version__, '1.0'
+            if LooseVersion(ver) < LooseVersion(req_ver):
+                check_res = "FAIL (GitPython version %s is too old, should be version %s or newer)" % (ver, req_ver)
+            else:
+                check_res = "FAIL (unexpected exception: %s)" % push_err
         else:
-            check_res = "FAIL (unexpected exception: %s)" % push_err
+            check_res = "FAIL (GitPython is not available)"
     else:
         check_res = "FAIL (no GitHub user specified)"
 


### PR DESCRIPTION
fix for #1968

Output of `eb --check-github` with this patch included if GitPython is not available:

```
$ PYTHONPATH=$PWD:$HOME/work/vsc-base/lib eb --check-github
== temporary log file in case of crash /tmp/eb-AbfLV8/easybuild-auMOqN.log

Checking status of GitHub integration...

Making sure we're online... OK

* GitHub user... boegel => OK
* GitHub token... (no token found) => FAIL
* git command... OK ("git version 2.10.1 (Apple Git-78); ")
* GitPython module... FAIL (import failed)
* push access to boegel/easybuild-easyconfigs repo @ GitHub... FAIL (GitPython is not available)
* creating gists... FAIL (res: None)
* location to Git working dirs...  OK (/Users/kehoste/work)

One or more checks FAILed, GitHub configuration not fully complete!
See http://easybuild.readthedocs.org/en/latest/Integration_with_GitHub.html#configuration for help.

Status of GitHub integration:
* --from-pr: OK
* --new-pr: not supported
* --review-pr: OK
* --update-pr: not supported
* --upload-test-report: not supported

```