### PR TITLE
fix regex for determining list of patched files in GitHub diff

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -661,8 +661,9 @@ def is_patch_file(path):
 def det_patched_files(path=None, txt=None, omit_ab_prefix=False, github=False, filter_deleted=False):
     """
     Determine list of patched files from a patch.
-    It searches for "+++ path/to/patched/file" lines to determine
-    the patched files.
+    It searches for "+++ path/to/patched/file" lines to determine the patched files.
+    Note: does not correctly handle filepaths with spaces.
+
     :param path: the path to the diff
     :param txt: the contents of the diff (either path or txt should be give)
     :param omit_ab_prefix: ignore the a/ or b/ prefix of the files
@@ -670,7 +671,7 @@ def det_patched_files(path=None, txt=None, omit_ab_prefix=False, github=False, f
     :param filter_deleted: filter out all files that were deleted by the patch
     """
     if github:
-        patched_regex = r"^diff --git (?:[ab]/)?\S+\s*(?P<ab_prefix>[ab]/)?(?P<file>\S+)"
+        patched_regex = r"^diff --git (?:a/)?\S+\s*(?P<ab_prefix>b/)?(?P<file>\S+)"
     else:
         patched_regex = r"^\s*\+{3}\s+(?P<ab_prefix>[ab]/)?(?P<file>\S+)"
     patched_regex = re.compile(patched_regex, re.M)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -670,7 +670,7 @@ def det_patched_files(path=None, txt=None, omit_ab_prefix=False, github=False, f
     :param filter_deleted: filter out all files that were deleted by the patch
     """
     if github:
-        patched_regex = r"^diff --git (?P<ab_prefix>[ab]/)?(?P<file>\S+)"
+        patched_regex = r"^diff --git (?:[ab]/)?\S+\s*(?P<ab_prefix>[ab]/)?(?P<file>\S+)"
     else:
         patched_regex = r"^\s*\+{3}\s+(?P<ab_prefix>[ab]/)?(?P<file>\S+)"
     patched_regex = re.compile(patched_regex, re.M)


### PR DESCRIPTION
This is fixing a test that started failing today for an unclear reason:

```
ERROR: Test fetch_easyconfigs_from_pr function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/192389914/lib/python2.6/site-packages/easybuild_framework-3.1.0.dev0-py2.6.egg/test/framework/github.py", line 135, in test_fetch_easyconfigs_from_pr
    ec_files = gh.fetch_easyconfigs_from_pr(2481, path=tmpdir, github_user=GITHUB_TEST_ACCOUNT)
  File "/tmp/192389914/lib/python2.6/site-packages/easybuild_framework-3.1.0.dev0-py2.6.egg/easybuild/tools/github.py", line 409, in fetch_easyconfigs_from_pr
    raise EasyBuildError("Couldn't find path to patched file %s", os.path.join(path, fn))
EasyBuildError: "Couldn't find path to patched file /tmp/eb-7_cRte/eb-OlhCfN/eb-FkdWgz/eb-wYVtAb/tmp0tNCLf/f/ffmpeg/ffmpeg-2.4-intel-2014.06.eb"
```

The test checks whether the list of patched files for the PR https://github.com/hpcugent/easybuild-easyconfigs/pull/2481 can be obtained correctly.
This PR changes the name of a couple of easyconfig files, which is exactly what is causing problems now.

It *seems* like the format of the GitHub provided by GitHub (e.g. via https://github.com/hpcugent/easybuild-easyconfigs/pull/2481.diff) has been changed...

This change fixes that problem. The `test_fetch_easyconfigs_from_pr` test now works again, and `eb --from-pr 2481 -D` now works again as expected as well...