### PR TITLE
Modify robot so that it only appends dependencies of tweaked easyconfigs

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -277,13 +277,13 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
 def alt_easyconfig_paths(tmpdir, tweaked_ecs=False, from_pr=False):
     """Obtain alternative paths for easyconfig files."""
 
-    # paths where tweaked easyconfigs will be placed, easyconfigs listed on the command line take priority, tweaked
-    # dependencies are also created but these will only be appended to the robot path (and only used if strictly
-    # necessary)
+    # paths where tweaked easyconfigs will be placed, easyconfigs listed on the command line take priority and will be
+    # prepended to the robot path, tweaked dependencies are also created but these will only be appended to the robot
+    # path (and therefore only used if strictly necessary)
     tweaked_ecs_paths = None
     if tweaked_ecs:
-        tweaked_ecs_paths = {'tweaked_ecs_path': os.path.join(tmpdir, 'tweaked_easyconfigs'),
-                             'tweaked_ecs_deps_path': os.path.join(tmpdir, 'tweaked_dep_easyconfigs')}
+        tweaked_ecs_paths = (os.path.join(tmpdir, 'tweaked_easyconfigs'),
+                             os.path.join(tmpdir, 'tweaked_dep_easyconfigs'))
 
     # path where files touched in PR will be downloaded to
     pr_path = None

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -279,7 +279,8 @@ def alt_easyconfig_paths(tmpdir, tweaked_ecs=False, from_pr=False):
     # path where tweaked easyconfigs will be placed
     tweaked_ecs_paths = None
     if tweaked_ecs:
-        tweaked_ecs_paths = [os.path.join(tmpdir, 'tweaked_easyconfigs'), os.path.join(tmpdir, 'tweaked_dep_easyconfigs')]
+        tweaked_ecs_paths = {'tweaked_ecs_path': os.path.join(tmpdir, 'tweaked_easyconfigs'),
+                             'tweaked_ecs_deps_path': os.path.join(tmpdir, 'tweaked_dep_easyconfigs')}
 
     # path where files touched in PR will be downloaded to
     pr_path = None

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -276,7 +276,10 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
 
 def alt_easyconfig_paths(tmpdir, tweaked_ecs=False, from_pr=False):
     """Obtain alternative paths for easyconfig files."""
-    # path where tweaked easyconfigs will be placed
+
+    # paths where tweaked easyconfigs will be placed, easyconfigs listed on the command line take priority, tweaked
+    # dependencies are also created but these will only be appended to the robot path (and only used if strictly
+    # necessary)
     tweaked_ecs_paths = None
     if tweaked_ecs:
         tweaked_ecs_paths = {'tweaked_ecs_path': os.path.join(tmpdir, 'tweaked_easyconfigs'),

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -277,16 +277,16 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
 def alt_easyconfig_paths(tmpdir, tweaked_ecs=False, from_pr=False):
     """Obtain alternative paths for easyconfig files."""
     # path where tweaked easyconfigs will be placed
-    tweaked_ecs_path = None
+    tweaked_ecs_paths = None
     if tweaked_ecs:
-        tweaked_ecs_path = os.path.join(tmpdir, 'tweaked_easyconfigs')
+        tweaked_ecs_paths = [os.path.join(tmpdir, 'tweaked_easyconfigs'), os.path.join(tmpdir, 'tweaked_dep_easyconfigs')]
 
     # path where files touched in PR will be downloaded to
     pr_path = None
     if from_pr:
         pr_path = os.path.join(tmpdir, "files_pr%s" % from_pr)
 
-    return tweaked_ecs_path, pr_path
+    return tweaked_ecs_paths, pr_path
 
 
 def det_easyconfig_paths(orig_paths):

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -72,7 +72,8 @@ def ec_filename_for(path):
 
 def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
     """Tweak list of easyconfigs according to provided build specifications."""
-    tweaked_ecs_path, tweaked_ecs_deps_path = targetdirs
+    if targetdirs is not None:
+        tweaked_ecs_path, tweaked_ecs_deps_path = targetdirs
     # make sure easyconfigs all feature the same toolchain (otherwise we *will* run into trouble)
     toolchains = nub(['%(name)s/%(version)s' % ec['ec']['toolchain'] for ec in easyconfigs])
     if len(toolchains) > 1:

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -109,13 +109,13 @@ def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
     for orig_ec in orig_ecs:
         # Place all tweaked dependency easyconfigs in the appended directory
         if orig_ec['spec'] not in listed_ec_paths:
-            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs[1])
+            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_deps_path'])
         # only return tweaked easyconfigs for easyconfigs which were listed originally and only in the prepended path
         # (so that they are found first)
         # easyconfig files for dependencies are also generated but not included, and will be resolved via --robot in the
         # appended path
         if orig_ec['spec'] in listed_ec_paths:
-            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs[0])
+            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_path'])
             new_ecs = process_easyconfig(new_ec_file, build_specs=build_specs)
             tweaked_easyconfigs.extend(new_ecs)
 

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -106,18 +106,18 @@ def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
 
     # generate tweaked easyconfigs, and continue with those instead
     tweaked_easyconfigs = []
-    for orig_ec in orig_ecs:
-        # Place all tweaked dependency easyconfigs in the directory appended to the robot path
-        if orig_ec['spec'] not in listed_ec_paths:
-            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_deps_path'])
+    for orig_ec in orig_ecs:  
         # Only return tweaked easyconfigs for easyconfigs which were listed originally on the command line (and use the
         # prepended path so that they are found first).
         # easyconfig files for dependencies are also generated but not included, they will be resolved via --robot
-        # either from existing easyconfigs or, if that fails, from easyconfigs in the appended path above
+        # either from existing easyconfigs or, if that fails, from easyconfigs in the appended path
         if orig_ec['spec'] in listed_ec_paths:
             new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_path'])
             new_ecs = process_easyconfig(new_ec_file, build_specs=build_specs)
             tweaked_easyconfigs.extend(new_ecs)
+        else:
+            # Place all tweaked dependency easyconfigs in the directory appended to the robot path
+            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_deps_path'])
 
     return tweaked_easyconfigs
 

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -70,7 +70,7 @@ def ec_filename_for(path):
     return fn
 
 
-def tweak(easyconfigs, build_specs, modtool, targetdir=None):
+def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
     """Tweak list of easyconfigs according to provided build specifications."""
 
     # make sure easyconfigs all feature the same toolchain (otherwise we *will* run into trouble)
@@ -107,10 +107,15 @@ def tweak(easyconfigs, build_specs, modtool, targetdir=None):
     # generate tweaked easyconfigs, and continue with those instead
     tweaked_easyconfigs = []
     for orig_ec in orig_ecs:
-        new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdir)
-        # only return tweaked easyconfigs for easyconfigs which were listed originally
-        # easyconfig files for dependencies are also generated but not included, and will be resolved via --robot
+        # Place all tweaked dependency easyconfigs in the appended directory
+        if orig_ec['spec'] not in listed_ec_paths:
+            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs[1])
+        # only return tweaked easyconfigs for easyconfigs which were listed originally and only in the prepended path
+        # (so that they are found first)
+        # easyconfig files for dependencies are also generated but not included, and will be resolved via --robot in the
+        # appended path
         if orig_ec['spec'] in listed_ec_paths:
+            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs[0])
             new_ecs = process_easyconfig(new_ec_file, build_specs=build_specs)
             tweaked_easyconfigs.extend(new_ecs)
 

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -72,6 +72,7 @@ def ec_filename_for(path):
 
 def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
     """Tweak list of easyconfigs according to provided build specifications."""
+    tweaked_ecs_path, tweaked_ecs_deps_path = None, None
     if targetdirs is not None:
         tweaked_ecs_path, tweaked_ecs_deps_path = targetdirs
     # make sure easyconfigs all feature the same toolchain (otherwise we *will* run into trouble)

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -107,13 +107,13 @@ def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
     # generate tweaked easyconfigs, and continue with those instead
     tweaked_easyconfigs = []
     for orig_ec in orig_ecs:
-        # Place all tweaked dependency easyconfigs in the appended directory
+        # Place all tweaked dependency easyconfigs in the directory appended to the robot path
         if orig_ec['spec'] not in listed_ec_paths:
             new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_deps_path'])
-        # only return tweaked easyconfigs for easyconfigs which were listed originally and only in the prepended path
-        # (so that they are found first)
-        # easyconfig files for dependencies are also generated but not included, and will be resolved via --robot in the
-        # appended path
+        # Only return tweaked easyconfigs for easyconfigs which were listed originally on the command line (and use the
+        # prepended path so that they are found first).
+        # easyconfig files for dependencies are also generated but not included, they will be resolved via --robot
+        # either from existing easyconfigs or, if that fails, from easyconfigs in the appended path above
         if orig_ec['spec'] in listed_ec_paths:
             new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_path'])
             new_ecs = process_easyconfig(new_ec_file, build_specs=build_specs)

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -72,7 +72,7 @@ def ec_filename_for(path):
 
 def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
     """Tweak list of easyconfigs according to provided build specifications."""
-
+    tweaked_ecs_path, tweaked_ecs_deps_path = targetdirs
     # make sure easyconfigs all feature the same toolchain (otherwise we *will* run into trouble)
     toolchains = nub(['%(name)s/%(version)s' % ec['ec']['toolchain'] for ec in easyconfigs])
     if len(toolchains) > 1:
@@ -112,12 +112,12 @@ def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
         # easyconfig files for dependencies are also generated but not included, they will be resolved via --robot
         # either from existing easyconfigs or, if that fails, from easyconfigs in the appended path
         if orig_ec['spec'] in listed_ec_paths:
-            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_path'])
+            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=tweaked_ecs_path)
             new_ecs = process_easyconfig(new_ec_file, build_specs=build_specs)
             tweaked_easyconfigs.extend(new_ecs)
         else:
             # Place all tweaked dependency easyconfigs in the directory appended to the robot path
-            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=targetdirs['tweaked_ecs_deps_path'])
+            new_ec_file = tweak_one(orig_ec['spec'], None, build_specs, targetdir=tweaked_ecs_deps_path)
 
     return tweaked_easyconfigs
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -205,9 +205,9 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # determine robot path
     # --try-X, --dep-graph, --search use robot path for searching, so enable it with path of installed easyconfigs
     tweaked_ecs = try_to_generate and build_specs
-    tweaked_ecs_path, pr_path = alt_easyconfig_paths(eb_tmpdir, tweaked_ecs=tweaked_ecs, from_pr=options.from_pr)
+    tweaked_ecs_paths, pr_path = alt_easyconfig_paths(eb_tmpdir, tweaked_ecs=tweaked_ecs, from_pr=options.from_pr)
     auto_robot = try_to_generate or options.check_conflicts or options.dep_graph or search_query
-    robot_path = det_robot_path(options.robot_paths, tweaked_ecs_path, pr_path, auto_robot=auto_robot)
+    robot_path = det_robot_path(options.robot_paths, tweaked_ecs_paths, pr_path, auto_robot=auto_robot)
     _log.debug("Full robot path: %s" % robot_path)
 
     # configure & initialize build options
@@ -341,7 +341,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # don't try and tweak anything if easyconfigs were generated, since building a full dep graph will fail
     # if easyconfig files for the dependencies are not available
     if try_to_generate and build_specs and not generated_ecs:
-        easyconfigs = tweak(easyconfigs, build_specs, modtool, targetdir=tweaked_ecs_path)
+        easyconfigs = tweak(easyconfigs, build_specs, modtool, targetdirs=tweaked_ecs_paths)
 
     dry_run_mode = options.dry_run or options.dry_run_short
     new_update_pr = options.new_pr or options.update_pr

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -50,15 +50,18 @@ from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 
 _log = fancylogger.getLogger('tools.robot', fname=False)
 
-def det_robot_path(robot_paths_option, tweaked_ecs_path, pr_path, auto_robot=False):
+def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=False):
     """Determine robot path."""
     robot_path = robot_paths_option[:]
     _log.info("Using robot path(s): %s" % robot_path)
 
     # paths to tweaked easyconfigs or easyconfigs downloaded from a PR have priority
-    if tweaked_ecs_path is not None:
-        robot_path.insert(0, tweaked_ecs_path)
-        _log.info("Prepended list of robot search paths with %s: %s" % (tweaked_ecs_path, robot_path))
+    if tweaked_ecs_paths is not None:
+        robot_path.insert(0, tweaked_ecs_paths[0])
+        robot_path.append(tweaked_ecs_paths[1])
+        _log.info("Prepended list of robot search paths with %s and appended with %s: %s" % (tweaked_ecs_paths[0],
+                                                                                             tweaked_ecs_paths[1],
+                                                                                             robot_path))
     if pr_path is not None:
         robot_path.append(pr_path)
         _log.info("Appended list of robot search paths with %s: %s" % (pr_path, robot_path))

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -59,9 +59,8 @@ def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=Fa
     if tweaked_ecs_paths is not None:
         robot_path.insert(0, tweaked_ecs_paths['tweaked_ecs_path'])
         robot_path.append(tweaked_ecs_paths['tweaked_ecs_deps_path'])
-        _log.info("Prepended list of robot search paths with %s and appended with %s: %s" % (tweaked_ecs_paths[0],
-                                                                                             tweaked_ecs_paths[1],
-                                                                                             robot_path))
+        _log.info("Prepended list of robot search paths with %s and appended with %s: %s"
+                  % (tweaked_ecs_paths['tweaked_ecs_path'], tweaked_ecs_paths['tweaked_ecs_deps_path'], robot_path))
     if pr_path is not None:
         robot_path.append(pr_path)
         _log.info("Appended list of robot search paths with %s: %s" % (pr_path, robot_path))

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -57,7 +57,9 @@ def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=Fa
 
     # paths to tweaked easyconfigs or easyconfigs downloaded from a PR have priority
     if tweaked_ecs_paths is not None:
+        # easyconfigs listed on the command line (and tweaked) should be found first
         robot_path.insert(0, tweaked_ecs_paths['tweaked_ecs_path'])
+        # dependencies are always tweaked but we should only use them if there is no other option (so they come last)
         robot_path.append(tweaked_ecs_paths['tweaked_ecs_deps_path'])
         _log.info("Prepended list of robot search paths with %s and appended with %s: %s"
                   % (tweaked_ecs_paths['tweaked_ecs_path'], tweaked_ecs_paths['tweaked_ecs_deps_path'], robot_path))

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -53,11 +53,11 @@ _log = fancylogger.getLogger('tools.robot', fname=False)
 def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=False):
     """Determine robot path."""
     robot_path = robot_paths_option[:]
-    tweaked_ecs_path, tweaked_ecs_deps_path = tweaked_ecs_paths
     _log.info("Using robot path(s): %s" % robot_path)
 
     # paths to tweaked easyconfigs or easyconfigs downloaded from a PR have priority
     if tweaked_ecs_paths is not None:
+        tweaked_ecs_path, tweaked_ecs_deps_path = tweaked_ecs_paths
         # easyconfigs listed on the command line (and tweaked) should be found first
         robot_path.insert(0, tweaked_ecs_path)
         # dependencies are always tweaked but we should only use them if there is no other option (so they come last)

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -61,8 +61,8 @@ def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=Fa
         robot_path.insert(0, tweaked_ecs_paths['tweaked_ecs_path'])
         # dependencies are always tweaked but we should only use them if there is no other option (so they come last)
         robot_path.append(tweaked_ecs_paths['tweaked_ecs_deps_path'])
-        _log.info("Prepended list of robot search paths with %s and appended with %s: %s"
-                  % (tweaked_ecs_paths['tweaked_ecs_path'], tweaked_ecs_paths['tweaked_ecs_deps_path'], robot_path))
+        _log.info("Prepended list of robot search paths with %s and appended with %s: %s",
+                  tweaked_ecs_paths['tweaked_ecs_path'], tweaked_ecs_paths['tweaked_ecs_deps_path'], robot_path)
     if pr_path is not None:
         robot_path.append(pr_path)
         _log.info("Appended list of robot search paths with %s: %s" % (pr_path, robot_path))

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -55,6 +55,7 @@ def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=Fa
     robot_path = robot_paths_option[:]
     _log.info("Using robot path(s): %s" % robot_path)
 
+    tweaked_ecs_path, tweaked_ecs_deps_path = None, None
     # paths to tweaked easyconfigs or easyconfigs downloaded from a PR have priority
     if tweaked_ecs_paths is not None:
         tweaked_ecs_path, tweaked_ecs_deps_path = tweaked_ecs_paths

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -53,16 +53,17 @@ _log = fancylogger.getLogger('tools.robot', fname=False)
 def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=False):
     """Determine robot path."""
     robot_path = robot_paths_option[:]
+    tweaked_ecs_path, tweaked_ecs_deps_path = tweaked_ecs_paths
     _log.info("Using robot path(s): %s" % robot_path)
 
     # paths to tweaked easyconfigs or easyconfigs downloaded from a PR have priority
     if tweaked_ecs_paths is not None:
         # easyconfigs listed on the command line (and tweaked) should be found first
-        robot_path.insert(0, tweaked_ecs_paths['tweaked_ecs_path'])
+        robot_path.insert(0, tweaked_ecs_path)
         # dependencies are always tweaked but we should only use them if there is no other option (so they come last)
-        robot_path.append(tweaked_ecs_paths['tweaked_ecs_deps_path'])
-        _log.info("Prepended list of robot search paths with %s and appended with %s: %s",
-                  tweaked_ecs_paths['tweaked_ecs_path'], tweaked_ecs_paths['tweaked_ecs_deps_path'], robot_path)
+        robot_path.append(tweaked_ecs_deps_path)
+        _log.info("Prepended list of robot search paths with %s and appended with %s: %s", tweaked_ecs_path,
+                  tweaked_ecs_deps_path, robot_path)
     if pr_path is not None:
         robot_path.append(pr_path)
         _log.info("Appended list of robot search paths with %s: %s" % (pr_path, robot_path))

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -57,8 +57,8 @@ def det_robot_path(robot_paths_option, tweaked_ecs_paths, pr_path, auto_robot=Fa
 
     # paths to tweaked easyconfigs or easyconfigs downloaded from a PR have priority
     if tweaked_ecs_paths is not None:
-        robot_path.insert(0, tweaked_ecs_paths[0])
-        robot_path.append(tweaked_ecs_paths[1])
+        robot_path.insert(0, tweaked_ecs_paths['tweaked_ecs_path'])
+        robot_path.append(tweaked_ecs_paths['tweaked_ecs_deps_path'])
         _log.info("Prepended list of robot search paths with %s and appended with %s: %s" % (tweaked_ecs_paths[0],
                                                                                              tweaked_ecs_paths[1],
                                                                                              robot_path))

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -824,6 +824,7 @@ class RobotTest(EnhancedTestCase):
         init_config(build_options={
             'valid_module_classes': module_classes(),
             'robot_path': robot_path,
+            'check_osdeps': False,
         })
 
         # Parse the easyconfig that we want to tweak

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -817,8 +817,7 @@ class RobotTest(EnhancedTestCase):
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
 
         # Create directories to store the tweaked easyconfigs
-        eb_tmpdir = tempfile.gettempdir()
-        tweaked_ecs_paths, pr_path = alt_easyconfig_paths(eb_tmpdir, tweaked_ecs=True)
+        tweaked_ecs_paths, pr_path = alt_easyconfig_paths(self.test_prefix, tweaked_ecs=True)
         robot_path = det_robot_path([test_easyconfigs], tweaked_ecs_paths, pr_path, auto_robot=True)
 
         init_config(build_options={
@@ -829,15 +828,14 @@ class RobotTest(EnhancedTestCase):
 
         # Parse the easyconfig that we want to tweak
         untweaked_openmpi = os.path.join(test_easyconfigs, 'o', 'OpenMPI', 'OpenMPI-1.6.4-GCC-4.6.4.eb')
-        self.assertTrue(os.path.isfile(untweaked_openmpi))
         easyconfigs, _ = parse_easyconfigs([(untweaked_openmpi, False)])
 
         # Tweak the version of the easyconfig
         easyconfigs = tweak(easyconfigs, {'toolchain_version': '4.7.2'}, self.modtool, targetdirs=tweaked_ecs_paths)
 
         # Check that all expected tweaked easyconfigs exists
-        tweaked_openmpi = os.path.join(tweaked_ecs_paths[0],'OpenMPI-1.6.4-GCC-4.7.2.eb')
-        tweaked_hwloc = os.path.join(tweaked_ecs_paths[1],'hwloc-1.6.2-GCC-4.7.2.eb')
+        tweaked_openmpi = os.path.join(tweaked_ecs_paths[0], 'OpenMPI-1.6.4-GCC-4.7.2.eb')
+        tweaked_hwloc = os.path.join(tweaked_ecs_paths[1], 'hwloc-1.6.2-GCC-4.7.2.eb')
         self.assertTrue(os.path.isfile(tweaked_openmpi))
         self.assertTrue(os.path.isfile(tweaked_hwloc))
 
@@ -847,7 +845,7 @@ class RobotTest(EnhancedTestCase):
         # Check it picks up the tweaked OpenMPI
         self.assertTrue(tweaked_openmpi in specs)
         # Check it picks up the untweaked dependency of the tweaked OpenMPI
-        untweaked_hwloc = os.path.join(test_easyconfigs, 'h', 'hwloc','hwloc-1.6.2-GCC-4.7.2.eb')
+        untweaked_hwloc = os.path.join(test_easyconfigs, 'h', 'hwloc', 'hwloc-1.6.2-GCC-4.7.2.eb')
         self.assertTrue(untweaked_hwloc in specs)
 
     def test_robot_find_minimal_toolchain_of_dependency(self):

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -42,7 +42,8 @@ import easybuild.framework.easyconfig.tools as ectools
 import easybuild.tools.build_log
 import easybuild.tools.robot as robot
 from easybuild.framework.easyconfig.easyconfig import _easyconfig_files_cache, process_easyconfig, EasyConfig
-from easybuild.framework.easyconfig.tools import find_resolved_modules, parse_easyconfigs
+from easybuild.framework.easyconfig.tools import alt_easyconfig_paths, find_resolved_modules, parse_easyconfigs
+from easybuild.framework.easyconfig.tweak import tweak
 from easybuild.framework.easyconfig.easyconfig import get_toolchain_hierarchy
 from easybuild.framework.easyconfig.easyconfig import robot_find_minimal_toolchain_of_dependency
 from easybuild.framework.easyconfig.tools import skip_available
@@ -54,7 +55,7 @@ from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.github import fetch_github_token
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import invalidate_module_caches_for
-from easybuild.tools.robot import check_conflicts, resolve_dependencies
+from easybuild.tools.robot import check_conflicts, det_robot_path, resolve_dependencies
 from test.framework.utilities import find_full_path
 
 
@@ -808,6 +809,45 @@ class RobotTest(EnhancedTestCase):
         self.assertEqual([dep['name'] for dep in new_easyconfigs[0]['dependencies']], ['foo', 'bar'])
 
         self.assertTrue(new_avail_modules, ['nodeps/1.2.3', 'onedep/3.14-goolf-1.4.10'])
+
+    def test_tweak_robotpath(self):
+        """Test that the robot correctly resolves the dependencies of tweaked easyconfigs. Tweaked
+        easyconfigs take priority, but tweaked dependencies are only used on an as-needed basis"""
+
+        test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+
+        # Create directories to store the tweaked easyconfigs
+        eb_tmpdir = tempfile.gettempdir()
+        tweaked_ecs_paths, pr_path = alt_easyconfig_paths(eb_tmpdir, tweaked_ecs=True)
+        robot_path = det_robot_path([test_easyconfigs], tweaked_ecs_paths, pr_path, auto_robot=True)
+
+        init_config(build_options={
+            'valid_module_classes': module_classes(),
+            'robot_path': robot_path,
+        })
+
+        # Parse the easyconfig that we want to tweak
+        untweaked_openmpi = os.path.join(test_easyconfigs, 'o', 'OpenMPI', 'OpenMPI-1.6.4-GCC-4.6.4.eb')
+        self.assertTrue(os.path.isfile(untweaked_openmpi))
+        easyconfigs, _ = parse_easyconfigs([(untweaked_openmpi, False)])
+
+        # Tweak the version of the easyconfig
+        easyconfigs = tweak(easyconfigs, {'toolchain_version': '4.7.2'}, self.modtool, targetdirs=tweaked_ecs_paths)
+
+        # Check that all expected tweaked easyconfigs exists
+        tweaked_openmpi = os.path.join(tweaked_ecs_paths[0],'OpenMPI-1.6.4-GCC-4.7.2.eb')
+        tweaked_hwloc = os.path.join(tweaked_ecs_paths[1],'hwloc-1.6.2-GCC-4.7.2.eb')
+        self.assertTrue(os.path.isfile(tweaked_openmpi))
+        self.assertTrue(os.path.isfile(tweaked_hwloc))
+
+        # Check that the robotpath is correctly configured to pick up the right versions of the easyconfigs
+        res = resolve_dependencies(easyconfigs, self.modtool, retain_all_deps=True)
+        specs = [ec['spec'] for ec in res]
+        # Check it picks up the tweaked OpenMPI
+        self.assertTrue(tweaked_openmpi in specs)
+        # Check it picks up the untweaked dependency of the tweaked OpenMPI
+        untweaked_hwloc = os.path.join(test_easyconfigs, 'h', 'hwloc','hwloc-1.6.2-GCC-4.7.2.eb')
+        self.assertTrue(untweaked_hwloc in specs)
 
     def test_robot_find_minimal_toolchain_of_dependency(self):
         """Test robot_find_minimal_toolchain_of_dependency."""


### PR DESCRIPTION
Modify the robot behaviour so that for dependencies it always check the existing easyconfigs first before resorting to using the ones that are generated by `--try-toolchain`

Fixes #1372