### PR TITLE
Exclude dependencies of dependencies that extend $MODULEPATH

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -71,7 +71,7 @@ from easybuild.tools.filetools import is_alt_pypi_url, mkdir, move_logs, read_fi
 from easybuild.tools.filetools import verify_checksum, weld_paths
 from easybuild.tools.run import run_cmd
 from easybuild.tools.jenkins import write_to_xml
-from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, module_generator
+from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, module_generator, dependencies_for
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import ROOT_ENV_VAR_NAME_PREFIX, VERSION_ENV_VAR_NAME_PREFIX, DEVEL_ENV_VAR_NAME_PREFIX
 from easybuild.tools.modules import invalidate_module_caches_for, get_software_root, get_software_root_env_var_name
@@ -947,6 +947,10 @@ class EasyBlock(object):
         self.log.debug("List of excluded deps: %s", excluded_deps)
 
         deps = [d for d in deps if d not in excluded_deps]
+        for dep in excluded_deps:
+            excluded_dep_deps = dependencies_for(dep, self.modules_tool)
+            self.log.debug("List of dependencies for excluded dependency %s: %s" % (dep, excluded_dep_deps))
+            deps = [d for d in deps if d not in excluded_dep_deps]
         self.log.debug("List of retained deps to load in generated module: %s" % deps)
         recursive_unload = self.cfg['recursive_module_unload']
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -946,11 +946,15 @@ class EasyBlock(object):
                                                                      full_mod_subdir, deps)
         self.log.debug("List of excluded deps: %s", excluded_deps)
 
+        # load modules that open up the module tree before checking deps of deps (in reverse order)
+        self.modules_tool.load(excluded_deps[::-1])
+
         deps = [d for d in deps if d not in excluded_deps]
         for dep in excluded_deps:
             excluded_dep_deps = dependencies_for(dep, self.modules_tool)
             self.log.debug("List of dependencies for excluded dependency %s: %s" % (dep, excluded_dep_deps))
             deps = [d for d in deps if d not in excluded_dep_deps]
+
         self.log.debug("List of retained deps to load in generated module: %s" % deps)
         recursive_unload = self.cfg['recursive_module_unload']
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -421,6 +421,45 @@ class EasyBlockTest(EnhancedTestCase):
         expected = tc_load + '\n\n' + fftw_load + '\n\n' + lapack_load
         self.assertEqual(eb.make_module_dep(unload_info=unload_info).strip(), expected)
 
+    def test_make_module_dep_hmns(self):
+        """Test for make_module_dep under HMNS"""
+        test_ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        all_stops = [x[0] for x in EasyBlock.get_steps()]
+        build_options = {
+            'check_osdeps': False,
+            'robot_path': [test_ecs_path],
+            'valid_stops': all_stops,
+            'validate': False,
+        }
+        os.environ['EASYBUILD_MODULE_NAMING_SCHEME'] = 'HierarchicalMNS'
+        init_config(build_options=build_options)
+        self.setup_hierarchical_modules()
+
+        self.contents = '\n'.join([
+            'easyblock = "ConfigureMake"',
+            'name = "pi"',
+            'version = "3.14"',
+            'homepage = "http://example.com"',
+            'description = "test easyconfig"',
+            "toolchain = {'name': 'goolf', 'version': '1.4.10'}",
+            'dependencies = [',
+            "   ('GCC', '4.7.2', '', True),"
+            "   ('hwloc', '1.6.2', '', ('GCC', '4.7.2')),",
+            "   ('OpenMPI', '1.6.4', '', ('GCC', '4.7.2')),"
+            ']',
+        ])
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+
+        eb.installdir = os.path.join(config.install_path(), 'pi', '3.14')
+        eb.check_readiness_step()
+
+        # GCC, OpenMPI and hwloc modules should *not* be included in loads for dependencies
+        mod_dep_txt = eb.make_module_dep()
+        for mod in ['GCC/4.7.2', 'OpenMPI/1.6.4', 'hwloc/1.6.2']:
+            regex = re.compile('load.*%s' % mod)
+            self.assertFalse(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
+
     def test_extensions_step(self):
         """Test the extensions_step"""
         self.contents = '\n'.join([


### PR DESCRIPTION
This small patch locates dependencies of dependencies that
extend $MODULEPATH and avoids writing load statements for those.