### PR TITLE
add support for using an 'intel' toolchain that only loads an 'intel-psxe' module (WIP)

### DIFF
--- a/easybuild/toolchains/intel.py
+++ b/easybuild/toolchains/intel.py
@@ -42,3 +42,20 @@ class Intel(Iimpi, IntelMKL, IntelFFTW):
     """
     NAME = 'intel'
     SUBTOOLCHAIN = Iimpi.NAME
+
+    def alt_definitions(self):
+        """
+        Return list of alternate definitions for the 'intel' toolchain.
+        """
+        # Intel compilers, MPI and MKL can also be installed as a whole as Intel Parallel Studio XE (PSXE)
+        intel_psxe_modname = 'intel-psxe'
+        intel_psxe = {
+            'COMPILER': [intel_psxe_modname],
+            'MPI': [intel_psxe_modname],
+            'BLAS': [intel_psxe_modname],
+            'LAPACK': [intel_psxe_modname],
+            'SCALAPACK': [intel_psxe_modname],
+            'FFT': [intel_psxe_modname],
+        }
+
+        return [intel_psxe]


### PR DESCRIPTION
This change allows to use an `intel` module that was installed using a single `intel-psxe` module rather than using separate installations for `icc`, `ifort`, `impi` and `imkl`.

I implemented this by introducing a generic concept or 'alternate toolchain definitions', since the need for this may also pop up later for other toolchains.

We *may* be going forward with this approach for `intel/2017a`, that's not fully clear yet.

TODO:

* verify that this works as expected outside of the tests
* look into effect of using an `intel` toolchain that uses `intel-psxe` with `HierarchicalMNS` (an update will be required there too)
* maybe also verify that the `intel-psxe` module defines `$EBROOTICC` & co somewhere, since this is assumed in some places now when the `intel` toolchain is used...