### PR TITLE
fix broken error message in get_toolchain_hierarchy + dedicated test case

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -224,7 +224,7 @@ def get_toolchain_hierarchy(parent_toolchain):
                 subtoolchain_version = ''
             else:
                 raise EasyBuildError("Multiple versions of %s found in dependencies of toolchain %s: %s",
-                                     subtoolchain_name, current_tc_name, unique_dep_tc_versions)
+                                     subtoolchain_name, current_tc_name, ', '.join(sorted(uniq_subtc_versions)))
 
         if subtoolchain_name == DUMMY_TOOLCHAIN_NAME and not build_option('add_dummy_to_minimal_toolchains'):
             # we're done


### PR DESCRIPTION
`unique_dep_tc_versions` was renamed to `uniq_subtc_versions` in #1619, but the error message is still using the old variable name

@gppezzi reported this issue

It only occurs in a very specific/unlikely case (which even @gppezzi didn't seem to be hitting, but fine).

Fixes this traceback:

```
Traceback (most recent call last):
  File "/usr/lib64/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/main.py", line 443, in <module>
    main()
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/main.py", line 328, in main
    easyconfigs, generated_ecs = parse_easyconfigs(paths)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/tools.py", line 378, in parse_easyconfigs
    ecs = process_easyconfig(ec_file, **kwargs)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 1261, in process_easyconfig
    ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 325, in __init__
    self.parse()
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 456, in parse
    self._finalize_dependencies()
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 907, in _finalize_dependencies
    tc = robot_find_minimal_toolchain_of_dependency(dep, self.modules_tool, parent_first=True)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 1400, in robot_find_minimal_toolchain_of_dependency
    toolchain_hierarchy = get_toolchain_hierarchy(parent_tc)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 128, in cache_aware_func
    toolchain_hierarchy = func(toolchain)
  File "/apps/common/UES/easybuild/software/EasyBuild/3.0.1/lib/python2.7/site-packages/easybuild_framework-3.0.1-py2.7.egg/easybuild/framework/easyconfig/easyconfig.py", line 228, in get_toolchain_hierarchy
    subtoolchain_name, current_tc_name, unique_dep_tc_versions)
NameError: global name 'unique_dep_tc_versions' is not defined
```