### PR TITLE
Add ec parameter to expand_toolchain_load().

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -918,7 +918,7 @@ class EasyBlock(object):
 
         # include load statements for toolchain, either directly or for toolchain dependencies
         if self.toolchain.name != DUMMY_TOOLCHAIN_NAME:
-            if mns.expand_toolchain_load(self.cfg):
+            if mns.expand_toolchain_load(ec=self.cfg):
                 mod_names = self.toolchain.toolchain_dep_mods
                 deps.extend(mod_names)
                 self.log.debug("Adding toolchain components as module dependencies: %s" % mod_names)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -918,7 +918,7 @@ class EasyBlock(object):
 
         # include load statements for toolchain, either directly or for toolchain dependencies
         if self.toolchain.name != DUMMY_TOOLCHAIN_NAME:
-            if mns.expand_toolchain_load():
+            if mns.expand_toolchain_load(self.cfg):
                 mod_names = self.toolchain.toolchain_dep_mods
                 deps.extend(mod_names)
                 self.log.debug("Adding toolchain components as module dependencies: %s" % mod_names)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1707,12 +1707,12 @@ class ActiveMNS(object):
         self.log.debug("Obtained initial module paths: %s" % init_modpaths)
         return init_modpaths
 
-    def expand_toolchain_load(self):
+    def expand_toolchain_load(self, ec):
         """
         Determine whether load statements for a toolchain should be expanded to load statements for its dependencies.
         This is useful when toolchains are not exposed to users.
         """
-        return self.mns.expand_toolchain_load()
+        return self.mns.expand_toolchain_load(ec)
 
     def is_short_modname_for(self, short_modname, name):
         """

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1707,12 +1707,12 @@ class ActiveMNS(object):
         self.log.debug("Obtained initial module paths: %s" % init_modpaths)
         return init_modpaths
 
-    def expand_toolchain_load(self, ec):
+    def expand_toolchain_load(self, ec=None):
         """
         Determine whether load statements for a toolchain should be expanded to load statements for its dependencies.
         This is useful when toolchains are not exposed to users.
         """
-        return self.mns.expand_toolchain_load(ec)
+        return self.mns.expand_toolchain_load(ec=ec)
 
     def is_short_modname_for(self, short_modname, name):
         """

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -218,7 +218,7 @@ class HierarchicalMNS(ModuleNamingScheme):
 
         return paths
 
-    def expand_toolchain_load(self, ec):
+    def expand_toolchain_load(self, ec=None):
         """
         Determine whether load statements for a toolchain should be expanded to load statements for its dependencies.
         This is useful when toolchains are not exposed to users.

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -218,7 +218,7 @@ class HierarchicalMNS(ModuleNamingScheme):
 
         return paths
 
-    def expand_toolchain_load(self):
+    def expand_toolchain_load(self, ec):
         """
         Determine whether load statements for a toolchain should be expanded to load statements for its dependencies.
         This is useful when toolchains are not exposed to users.

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -143,7 +143,7 @@ class ModuleNamingScheme(object):
         """
         return []
 
-    def expand_toolchain_load(self):
+    def expand_toolchain_load(self, ec):
         """
         Determine whether load statements for a toolchain should be expanded to load statements for its dependencies.
         This is useful when toolchains are not exposed to users.

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -143,7 +143,7 @@ class ModuleNamingScheme(object):
         """
         return []
 
-    def expand_toolchain_load(self, ec):
+    def expand_toolchain_load(self, ec=None):
         """
         Determine whether load statements for a toolchain should be expanded to load statements for its dependencies.
         This is useful when toolchains are not exposed to users.


### PR DESCRIPTION
So it can expand depending on the type of easyconfig.
In the module naming scheme used by Compute Canada
we need this because we like compiler-only toolchains
such as GCC and iccifort to be exposed and extend MODULEPATH,
and not be expanded, but higher-level toolchains to be hidden and
expanded.