### PR TITLE
interpret statements that extend $MODULEPATH in modpath_extensions_for method

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -711,15 +711,6 @@ class ModulesTool(object):
 
         return loaded_modules
 
-    def read_module_file(self, mod_name):
-        """
-        Read module file with specified name.
-        """
-        modfilepath = self.modulefile_path(mod_name)
-        self.log.debug("modulefile path %s: %s" % (mod_name, modfilepath))
-
-        return read_file(modfilepath)
-
     def modpath_extensions_for(self, mod_names):
         """
         Determine dictionary with $MODULEPATH extensions for specified modules.
@@ -747,7 +738,7 @@ class ModulesTool(object):
 
         modpath_exts = {}
         for mod_name in mod_names:
-            modtxt = self.read_module_file(mod_name)
+            modtxt = self.show(mod_name)
             exts = [ext for tup in modpath_ext_regex.findall(modtxt) for ext in tup if ext]
             self.log.debug("Found $MODULEPATH extensions for %s: %s", mod_name, exts)
             modpath_exts.update({mod_name: exts})

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -711,6 +711,15 @@ class ModulesTool(object):
 
         return loaded_modules
 
+    def read_module_file(self, mod_name):
+        """
+        Read module file with specified name.
+        """
+        modfilepath = self.modulefile_path(mod_name)
+        self.log.debug("modulefile path %s: %s" % (mod_name, modfilepath))
+
+        return read_file(modfilepath)
+
     def modpath_extensions_for(self, mod_names):
         """
         Determine dictionary with $MODULEPATH extensions for specified modules.
@@ -738,11 +747,17 @@ class ModulesTool(object):
 
         modpath_exts = {}
         for mod_name in mod_names:
-            if not self.exist([mod_name], skip_avail=True)[0]:
-                raise EasyBuildError("Can't get MODULEPATH from a non-existing module %s", mod_name)
-            modtxt = self.show(mod_name)
+            modtxt = self.read_module_file(mod_name)
             exts = [ext for tup in modpath_ext_regex.findall(modtxt) for ext in tup if ext]
             self.log.debug("Found $MODULEPATH extensions for %s: %s", mod_name, exts)
+            if exts:
+                modtxt = self.show(mod_name)
+                parsed_exts = [ext for tup in modpath_ext_regex.findall(modtxt) for ext in tup if ext]
+                # modulecmd.tcl show does not include $MODULEPATH extensions; therefore the parsed output
+                # is only valid if there is at least one match
+                if parsed_exts:
+                    exts = parsed_exts
+
             modpath_exts.update({mod_name: exts})
 
             if exts:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -751,12 +751,15 @@ class ModulesTool(object):
             exts = [ext for tup in modpath_ext_regex.findall(modtxt) for ext in tup if ext]
             self.log.debug("Found $MODULEPATH extensions for %s: %s", mod_name, exts)
             if exts:
+                # we must also included parsed MODULEPATH extensions where the module tool expands
+                # environment variables, concatenates strings, etc.
+                # The show output is actually sufficient except for modulecmd.tcl < 1.661
+                # which does not show "module use" statements in the "module show" output.
+                # The easiest is to simply merge "module show" output with the module file contents,
+                # removing common entries.
                 modtxt = self.show(mod_name)
                 parsed_exts = [ext for tup in modpath_ext_regex.findall(modtxt) for ext in tup if ext]
-                # modulecmd.tcl show does not include $MODULEPATH extensions; therefore the parsed output
-                # is only valid if there is at least one match
-                if parsed_exts:
-                    exts = parsed_exts
+                exts += [ext for ext in parsed_exts if ext not in exts]
 
             modpath_exts.update({mod_name: exts})
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -738,6 +738,8 @@ class ModulesTool(object):
 
         modpath_exts = {}
         for mod_name in mod_names:
+            if not self.exist([mod_name], skip_avail=True)[0]:
+                raise EasyBuildError("Can't get MODULEPATH from a non-existing module %s", mod_name)
             modtxt = self.show(mod_name)
             exts = [ext for tup in modpath_ext_regex.findall(modtxt) for ext in tup if ext]
             self.log.debug("Found $MODULEPATH extensions for %s: %s", mod_name, exts)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -405,7 +405,8 @@ class ModulesTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.modpath_extensions_for, ['nosuchmodule/1.2'])
 
         os.environ['HOME'] = os.path.join(self.test_prefix, 'HOME')
-        os.makedirs("%s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'])
+        # need to create this directory, otherwise the conditional below does not expand in "module show" output.
+        mkdir("%s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'], parents=True)
 
         # test result in case conditional loads are used
         test_mod = 'test-modpaths/1.2.3.4'

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -414,9 +414,11 @@ class ModulesTest(EnhancedTestCase):
             'module use "%s/Compiler/GCC/4.7.2"' % mod_dir,
             # using prepend-path & quoted
             ' prepend-path MODULEPATH "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4"' % mod_dir,
-            # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
-            "if { [ file isdirectory %s/modules/Compiler/GCC/4.7.2 ] } {" % os.environ['HOME'],
-            "    module use %s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'],
+            # conditional 'use' on subdirectory in e.g. $HOME, e.g. when --subdir-user-modules is used
+            # we cannot use mod_dir = os.environ['HOME'] here since that may not exist in the test
+            # environment
+            "if { [ file isdirectory %s/Compiler/GCC/4.7.2 ] } {" % mod_dir,
+            "    module use %s/Compiler/GCC/4.7.2" % mod_dir,
             "}",
         ])
         write_file(test_modfile, test_modtxt)
@@ -426,7 +428,7 @@ class ModulesTest(EnhancedTestCase):
                 os.path.join(mod_dir, 'Compiler', 'intel', '2013.5.192-GCC-4.8.3'),
                 os.path.join(mod_dir, 'Compiler', 'GCC', '4.7.2'),
                 os.path.join(mod_dir, 'MPI', 'GCC', '4.7.2', 'OpenMPI', '1.6.4'),
-                os.path.join(os.environ['HOME'], 'modules', 'Compiler', 'GCC', '4.7.2'),
+                os.path.join(mod_dir, 'Compiler', 'GCC', '4.7.2'),
             ]
         }
         self.assertEqual(self.modtool.modpath_extensions_for([test_mod]), expected)
@@ -443,8 +445,10 @@ class ModulesTest(EnhancedTestCase):
                 'prepend_path("MODULEPATH","%s/Compiler/GCC/4.7.2")' % mod_dir,
                 'prepend_path("MODULEPATH", "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4")' % mod_dir,
                 # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
-                'if isDir("%s/modules/Compiler/GCC/4.7.2") then' % os.environ['HOME'],
-                '    prepend_path("MODULEPATH", "%s/modules/Compiler/GCC/4.7.2")' % os.environ['HOME'],
+                # we cannot use mod_dir = os.environ['HOME'] here since that may not exist in the test
+                # environment
+                'if isDir("%s/Compiler/GCC/4.7.2") then' % mod_dir,
+                '    prepend_path("MODULEPATH", "%s/Compiler/GCC/4.7.2")' % mod_dir,
                 'end',
             ])
             write_file(test_modfile, test_modtxt)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -419,8 +419,8 @@ class ModulesTest(EnhancedTestCase):
             # using prepend-path & quoted
             ' prepend-path MODULEPATH "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4"' % mod_dir,
             # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
-            "if { [ file isdirectory %s/modules/Compiler/GCC/4.7.2 ] } {" % os.environ['HOME'],
-            "    module use %s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'],
+            "if { [ file isdirectory $env(HOME)/modules/Compiler/GCC/4.7.2 ] } {",
+            '    prepend-path MODULEPATH "$env(HOME)/modules/Compiler/GCC/4.7.2"',
             "}",
         ])
         write_file(test_modfile, test_modtxt)
@@ -447,8 +447,8 @@ class ModulesTest(EnhancedTestCase):
                 'prepend_path("MODULEPATH","%s/Compiler/GCC/4.7.2")' % mod_dir,
                 'prepend_path("MODULEPATH", "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4")' % mod_dir,
                 # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
-                'if isDir("%s/modules/Compiler/GCC/4.7.2") then' % os.environ['HOME'],
-                '    prepend_path("MODULEPATH", "%s/modules/Compiler/GCC/4.7.2")' % os.environ['HOME'],
+                'if isDir(pathJoin(os.getenv("HOME"), "modules/Compiler/GCC/4.7.2")) then',
+                '    prepend_path("MODULEPATH", pathJoin(os.getenv("HOME"), "modules/Compiler/GCC/4.7.2"))',
                 'end',
             ])
             write_file(test_modfile, test_modtxt)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -401,7 +401,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(res, expected)
 
         # error for non-existing modules
-        error_pattern = "Can't get value from a non-existing module"
+        error_pattern = "Can't get MODULEPATH from a non-existing module"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.modpath_extensions_for, ['nosuchmodule/1.2'])
 
         # test result in case conditional loads are used

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -419,7 +419,7 @@ class ModulesTest(EnhancedTestCase):
             ' prepend-path MODULEPATH "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4"' % mod_dir,
             # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
             "if { [ file isdirectory $env(HOME)/modules/Compiler/GCC/4.7.2 ] } {",
-            '    module use "$env(HOME)/modules/Compiler/GCC/4.7.2"',
+            "    module use $env(HOME)/modules/Compiler/GCC/4.7.2",
             "}",
         ])
         write_file(test_modfile, test_modtxt)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -404,9 +404,8 @@ class ModulesTest(EnhancedTestCase):
         error_pattern = "Can't get value from a non-existing module"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.modpath_extensions_for, ['nosuchmodule/1.2'])
 
+        # make sure $HOME is set to something
         os.environ['HOME'] = os.path.join(self.test_prefix, 'HOME')
-        # need to create this directory, otherwise the conditional below does not expand in "module show" output.
-        mkdir("%s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'], parents=True)
 
         # test result in case conditional loads are used
         test_mod = 'test-modpaths/1.2.3.4'
@@ -420,7 +419,7 @@ class ModulesTest(EnhancedTestCase):
             ' prepend-path MODULEPATH "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4"' % mod_dir,
             # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
             "if { [ file isdirectory $env(HOME)/modules/Compiler/GCC/4.7.2 ] } {",
-            '    prepend-path MODULEPATH "$env(HOME)/modules/Compiler/GCC/4.7.2"',
+            '    module use "$env(HOME)/modules/Compiler/GCC/4.7.2"',
             "}",
         ])
         write_file(test_modfile, test_modtxt)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -404,6 +404,10 @@ class ModulesTest(EnhancedTestCase):
         error_pattern = "Can't get MODULEPATH from a non-existing module"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.modpath_extensions_for, ['nosuchmodule/1.2'])
 
+        realhome = os.environ.get('HOME')
+        os.environ['HOME'] = os.path.join(self.test_prefix, 'HOME')
+        os.makedirs("%s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'])
+
         # test result in case conditional loads are used
         test_mod = 'test-modpaths/1.2.3.4'
         test_modfile = os.path.join(mod_dir, test_mod)
@@ -414,11 +418,9 @@ class ModulesTest(EnhancedTestCase):
             'module use "%s/Compiler/GCC/4.7.2"' % mod_dir,
             # using prepend-path & quoted
             ' prepend-path MODULEPATH "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4"' % mod_dir,
-            # conditional 'use' on subdirectory in e.g. $HOME, e.g. when --subdir-user-modules is used
-            # we cannot use mod_dir = os.environ['HOME'] here since that may not exist in the test
-            # environment
-            "if { [ file isdirectory %s/Compiler/GCC/4.7.2 ] } {" % mod_dir,
-            "    module use %s/Compiler/GCC/4.7.2" % mod_dir,
+            # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
+            "if { [ file isdirectory %s/modules/Compiler/GCC/4.7.2 ] } {" % os.environ['HOME'],
+            "    module use %s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'],
             "}",
         ])
         write_file(test_modfile, test_modtxt)
@@ -428,7 +430,7 @@ class ModulesTest(EnhancedTestCase):
                 os.path.join(mod_dir, 'Compiler', 'intel', '2013.5.192-GCC-4.8.3'),
                 os.path.join(mod_dir, 'Compiler', 'GCC', '4.7.2'),
                 os.path.join(mod_dir, 'MPI', 'GCC', '4.7.2', 'OpenMPI', '1.6.4'),
-                os.path.join(mod_dir, 'Compiler', 'GCC', '4.7.2'),
+                os.path.join(os.environ['HOME'], 'modules', 'Compiler', 'GCC', '4.7.2'),
             ]
         }
         self.assertEqual(self.modtool.modpath_extensions_for([test_mod]), expected)
@@ -445,10 +447,8 @@ class ModulesTest(EnhancedTestCase):
                 'prepend_path("MODULEPATH","%s/Compiler/GCC/4.7.2")' % mod_dir,
                 'prepend_path("MODULEPATH", "%s/MPI/GCC/4.7.2/OpenMPI/1.6.4")' % mod_dir,
                 # conditional 'use' on subdirectory in $HOME, e.g. when --subdir-user-modules is used
-                # we cannot use mod_dir = os.environ['HOME'] here since that may not exist in the test
-                # environment
-                'if isDir("%s/Compiler/GCC/4.7.2") then' % mod_dir,
-                '    prepend_path("MODULEPATH", "%s/Compiler/GCC/4.7.2")' % mod_dir,
+                'if isDir("%s/modules/Compiler/GCC/4.7.2") then' % os.environ['HOME'],
+                '    prepend_path("MODULEPATH", "%s/modules/Compiler/GCC/4.7.2")' % os.environ['HOME'],
                 'end',
             ])
             write_file(test_modfile, test_modtxt)
@@ -456,6 +456,11 @@ class ModulesTest(EnhancedTestCase):
             expected = {test_mod: expected['test-modpaths/1.2.3.4']}
 
             self.assertEqual(self.modtool.modpath_extensions_for([test_mod]), expected)
+
+        if realhome is not None:
+            os.environ['HOME'] = realhome
+        else:
+            del os.environ['HOME']
 
     def test_path_to_top_of_module_tree_categorized_hmns(self):
         """

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -404,7 +404,6 @@ class ModulesTest(EnhancedTestCase):
         error_pattern = "Can't get value from a non-existing module"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.modpath_extensions_for, ['nosuchmodule/1.2'])
 
-        realhome = os.environ.get('HOME')
         os.environ['HOME'] = os.path.join(self.test_prefix, 'HOME')
         os.makedirs("%s/modules/Compiler/GCC/4.7.2" % os.environ['HOME'])
 
@@ -456,11 +455,6 @@ class ModulesTest(EnhancedTestCase):
             expected = {test_mod: expected['test-modpaths/1.2.3.4']}
 
             self.assertEqual(self.modtool.modpath_extensions_for([test_mod]), expected)
-
-        if realhome is not None:
-            os.environ['HOME'] = realhome
-        else:
-            del os.environ['HOME']
 
     def test_path_to_top_of_module_tree_categorized_hmns(self):
         """

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -401,7 +401,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(res, expected)
 
         # error for non-existing modules
-        error_pattern = "Can't get MODULEPATH from a non-existing module"
+        error_pattern = "Can't get value from a non-existing module"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.modpath_extensions_for, ['nosuchmodule/1.2'])
 
         realhome = os.environ.get('HOME')


### PR DESCRIPTION
This way lmod can do some parsing of the lua file, when the MODULEPATH
extension uses environment variables.