### PR TITLE
add support for marking installed module file as new default version

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2081,10 +2081,11 @@ class EasyBlock(object):
 
         sets the default module version except if we are in dry run.
         """
-        mod_filepath = self.module_generator.get_module_filepath()
-        mod_folderpath = os.path.dirname(mod_filepath)
+        mod_folderpath = os.path.dirname(self.module_generator.get_module_filepath())
 
-        if not self.dry_run:
+        if self.dry_run:
+            dry_run_msg("Marked %s v%s as default version" % (self.name, self.version))
+        else:
             self.module_generator.set_as_default(mod_folderpath, self.version)
 
     def cleanup_step(self):
@@ -2150,8 +2151,6 @@ class EasyBlock(object):
                 self.dry_run_msg("Generating module file %s, with contents:\n", mod_filepath)
                 for line in txt.split('\n'):
                     self.dry_run_msg(' ' * 4 + line)
-
-            self.dry_run_msg("Generating file to set default module version to %s\n", self.version)
         else:
             write_file(mod_filepath, txt)
             self.log.info("Module file %s written: %s", mod_filepath, txt)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2175,7 +2175,7 @@ class EasyBlock(object):
             if not fake:
                 self.make_devel_module()
 
-        if build_option('set_as_default'):
+        if build_option('set_default_module'):
             self._set_module_as_default()
 
         return modpath

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -160,6 +160,7 @@ BUILD_OPTIONS_CMDLINE = {
         'use_ccache',
         'use_f90cache',
         'use_existing_modules',
+        'set_as_default',
     ],
     True: [
         'cleanup_builddir',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -160,7 +160,7 @@ BUILD_OPTIONS_CMDLINE = {
         'use_ccache',
         'use_f90cache',
         'use_existing_modules',
-        'set_as_default',
+        'set_default_module',
     ],
     True: [
         'cleanup_builddir',

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -177,21 +177,21 @@ def readlink(symlink_path):
 
     :param symlink_path: symlink file path
     """
-
-    # note: we can't use try-except-finally, because Python 2.4 doesn't support it as a single block
     try:
         target_symlink_path = os.readlink(symlink_path)
-    except IOError, err:
+    except OSError as err:
         raise EasyBuildError("Failed to get target of symlink: %s", symlink_path)
-
-    if build_option('extended_dry_run'):
-        dry_run_msg("symlink file %s points to: %s", symlink_path, target_symlink_path)
 
     return target_symlink_path
 
 
 def symlink(source_path, symlink_path):
     """Create a symlink at the specified path to the given path."""
+
+    if build_option('extended_dry_run'):
+        dry_run_msg("Symlinked file %s to %s" % (source_path, symlink_path), silent=build_option('silent'))
+        return
+
     try:
         os.symlink(os.path.abspath(source_path), symlink_path)
         _log.info("Symlinked %s to %s", source_path, symlink_path)
@@ -1072,15 +1072,6 @@ def weld_paths(path1, path2):
             path2_head = None
 
     return os.path.join(path1, path2_tail)
-
-
-def symlink(source_path, symlink_path):
-    """Create a symlink at the specified path to the given path."""
-    try:
-        os.symlink(os.path.abspath(source_path), symlink_path)
-        _log.info("Symlinked %s to %s", source_path, symlink_path)
-    except OSError as err:
-        raise EasyBuildError("Symlinking %s to %s failed: %s", source_path, symlink_path, err)
 
 
 def path_matches(path, paths):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -188,9 +188,9 @@ def readlink(symlink_path):
 def symlink(source_path, symlink_path):
     """Create a symlink at the specified path to the given path."""
 
-    if build_option('extended_dry_run', default=False):
-        dry_run_msg("Symlinked file %s to %s" % (source_path, symlink_path), silent=build_option('silent'))
-        return
+    # if build_option('extended_dry_run', default=False):
+    #     dry_run_msg("Symlinked file %s to %s" % (source_path, symlink_path), silent=build_option('silent'))
+    #     return
 
     try:
         os.symlink(os.path.abspath(source_path), symlink_path)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -188,9 +188,9 @@ def readlink(symlink_path):
 def symlink(source_path, symlink_path):
     """Create a symlink at the specified path to the given path."""
 
-    # if build_option('extended_dry_run', default=False):
-    #     dry_run_msg("Symlinked file %s to %s" % (source_path, symlink_path), silent=build_option('silent'))
-    #     return
+    if build_option('extended_dry_run', default=False):
+        dry_run_msg("Symlinked file %s to %s" % (source_path, symlink_path), silent=build_option('silent'))
+        return
 
     try:
         os.symlink(os.path.abspath(source_path), symlink_path)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -185,17 +185,20 @@ def readlink(symlink_path):
     return target_symlink_path
 
 
-def symlink(source_path, symlink_path):
+def symlink(source_path, symlink_path, use_abspath_source=True):
     """
     Create a symlink at the specified path to the given path.
 
     :param source_path: source file path
     :param symlink_path: symlink file path
     """
-
     try:
-        os.symlink(os.path.abspath(source_path), symlink_path)
-        _log.info("Symlinked %s to %s", source_path, symlink_path)
+        if use_abspath_source:
+            os.symlink(os.path.abspath(source_path), symlink_path)
+            _log.info("Symlinked %s to %s", os.path.abspath(source_path), symlink_path)
+        else:
+            os.symlink(source_path, symlink_path)
+            _log.info("Symlinked %s to %s", source_path, symlink_path)
     except OSError as err:
         raise EasyBuildError("Symlinking %s to %s failed: %s", source_path, symlink_path, err)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -191,14 +191,14 @@ def symlink(source_path, symlink_path, use_abspath_source=True):
 
     :param source_path: source file path
     :param symlink_path: symlink file path
+    :param use_abspath_source: resolves the absolute path of source_path
     """
+    if use_abspath_source:
+        source_path = os.path.abspath(source_path)
+
     try:
-        if use_abspath_source:
-            os.symlink(os.path.abspath(source_path), symlink_path)
-            _log.info("Symlinked %s to %s", os.path.abspath(source_path), symlink_path)
-        else:
-            os.symlink(source_path, symlink_path)
-            _log.info("Symlinked %s to %s", source_path, symlink_path)
+        os.symlink(source_path, symlink_path)
+        _log.info("Symlinked %s to %s", source_path, symlink_path)
     except OSError as err:
         raise EasyBuildError("Symlinking %s to %s failed: %s", source_path, symlink_path, err)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -180,13 +180,18 @@ def readlink(symlink_path):
     try:
         target_symlink_path = os.readlink(symlink_path)
     except OSError as err:
-        raise EasyBuildError("Failed to get target of symlink: %s", symlink_path)
+        raise EasyBuildError("Get target of symlink %s failed: %s", symlink_path, err)
 
     return target_symlink_path
 
 
 def symlink(source_path, symlink_path):
-    """Create a symlink at the specified path to the given path."""
+    """
+    Create a symlink at the specified path to the given path.
+
+    :param source_path: source file path
+    :param symlink_path: symlink file path
+    """
 
     try:
         os.symlink(os.path.abspath(source_path), symlink_path)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -171,6 +171,34 @@ def write_file(path, txt, append=False, forced=False):
         raise EasyBuildError("Failed to write to %s: %s", path, err)
 
 
+def readlink(symlink_path):
+    """
+    Read symlink target at the specified path to the given path.
+
+    :param symlink_path: symlink file path
+    """
+
+    # note: we can't use try-except-finally, because Python 2.4 doesn't support it as a single block
+    try:
+        target_symlink_path = os.readlink(symlink_path)
+    except IOError, err:
+        raise EasyBuildError("Failed to get target of symlink: %s", symlink_path)
+
+    if build_option('extended_dry_run'):
+        dry_run_msg("symlink file %s points to: %s", symlink_path, target_symlink_path)
+
+    return target_symlink_path
+
+
+def symlink(source_path, symlink_path):
+    """Create a symlink at the specified path to the given path."""
+    try:
+        os.symlink(os.path.abspath(source_path), symlink_path)
+        _log.info("Symlinked %s to %s", source_path, symlink_path)
+    except OSError as err:
+        raise EasyBuildError("Symlinking %s to %s failed: %s", source_path, symlink_path, err)
+
+
 def remove_file(path):
     """Remove file at specified path."""
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -188,7 +188,7 @@ def readlink(symlink_path):
 def symlink(source_path, symlink_path):
     """Create a symlink at the specified path to the given path."""
 
-    if build_option('extended_dry_run'):
+    if build_option('extended_dry_run', default=False):
         dry_run_msg("Symlinked file %s to %s" % (source_path, symlink_path), silent=build_option('silent'))
         return
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -188,10 +188,6 @@ def readlink(symlink_path):
 def symlink(source_path, symlink_path):
     """Create a symlink at the specified path to the given path."""
 
-    if build_option('extended_dry_run', default=False):
-        dry_run_msg("Symlinked file %s to %s" % (source_path, symlink_path), silent=build_option('silent'))
-        return
-
     try:
         os.symlink(os.path.abspath(source_path), symlink_path)
         _log.info("Symlinked %s to %s", source_path, symlink_path)
@@ -208,7 +204,8 @@ def remove_file(path):
         return
 
     try:
-        if os.path.exists(path):
+        # note: file may also be a broken symlink...
+        if os.path.exists(path) or os.path.islink(path):
             os.remove(path)
     except OSError, err:
         raise EasyBuildError("Failed to remove %s: %s", path, err)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -217,7 +217,6 @@ class ModuleGenerator(object):
         raise NotImplementedError
 
 
-# noinspection PyPackageRequirements
 class ModuleGeneratorTcl(ModuleGenerator):
     """
     Class for generating Tcl module files.
@@ -724,7 +723,7 @@ class ModuleGeneratorLua(ModuleGenerator):
             remove_file(default_filepath)
             self.log.info("Removed default version marking from %s.", link_target)
         elif os.path.exists(default_filepath):
-            raise EasyBuildError('Found an unexpected file called default in dir %s' % module_folder_path)
+            raise EasyBuildError('Found an unexpected file named default in dir %s' % module_folder_path)
 
         symlink(module_version + self.MODULE_FILE_EXTENSION, default_filepath, use_abspath_source=False)
         self.log.info("Module default version file written to point to %s", default_filepath)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -727,10 +727,7 @@ class ModuleGeneratorLua(ModuleGenerator):
         elif os.path.exists(default_filepath):
             raise EasyBuildError('Found an unexpected file called default in dir %s' % module_folder_path)
 
-        cwd = os.getcwd()
-        #os.chdir(module_folder_path)
-        symlink(module_version + self.MODULE_FILE_EXTENSION, default_filepath)
-        #os.chdir(cwd)
+        symlink(module_version + self.MODULE_FILE_EXTENSION, default_filepath, use_abspath_source=False)
         self.log.info("Module default version file written to point to %s", default_filepath)
 
 

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -460,15 +460,14 @@ class ModuleGeneratorTcl(ModuleGenerator):
         """
         Create .version file inside the package module folder in order to set the default version
         for TMod
-        :param module_folder_path: module folder path, e.g.  /easybuild/modules/all/Bison
-        :param module_version: 3.0.4
+        :param module_folder_path: module folder path, e.g. $HOME/easybuild/modules/all/Bison
+        :param module_version: module version, e.g. 3.0.4
         """
         txt = self.MODULE_SHEBANG + '\n'
         txt += 'set ModulesVersion %s\n' % module_version
-        mod_filepath = os.path.join(module_folder_path, '.version')
 
         # write the file no matter what
-        write_file(mod_filepath, txt)
+        write_file(os.path.join(module_folder_path, '.version'), txt)
 
 
 class ModuleGeneratorLua(ModuleGenerator):
@@ -715,12 +714,10 @@ class ModuleGeneratorLua(ModuleGenerator):
         """
         Create file called "default" inside the package's module folder in order
         to set the default module version
-        :param module_folder_path: module folder path, e.g.  $HOME/easybuild/modules/all/Bison
-        :param module_version: 3.0.4
+        :param module_folder_path: module folder path, e.g. $HOME/easybuild/modules/all/Bison
+        :param module_version: module version, e.g. 3.0.4
         """
-        module_file = module_version + self.MODULE_FILE_EXTENSION
-        mod_filepath = os.path.join(module_folder_path, module_file)
-
+        mod_filepath = os.path.join(module_folder_path, module_version + self.MODULE_FILE_EXTENSION)
         default_filepath = os.path.join(module_folder_path, 'default')
 
         if os.path.exists(default_filepath):

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -217,6 +217,7 @@ class ModuleGenerator(object):
         raise NotImplementedError
 
 
+# noinspection PyPackageRequirements
 class ModuleGeneratorTcl(ModuleGenerator):
     """
     Class for generating Tcl module files.
@@ -455,7 +456,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
         """
         return '$env(%s)' % envvar
 
-
+    # noinspection PyPackageRequirements,PyPackageRequirements
     def set_as_default(self, module_folder_path, module_version):
         """
         Create .version file inside the package module folder in order to set the default version
@@ -717,15 +718,19 @@ class ModuleGeneratorLua(ModuleGenerator):
         :param module_folder_path: module folder path, e.g. $HOME/easybuild/modules/all/Bison
         :param module_version: module version, e.g. 3.0.4
         """
-        mod_filepath = os.path.join(module_folder_path, module_version + self.MODULE_FILE_EXTENSION)
         default_filepath = os.path.join(module_folder_path, 'default')
 
-        if os.path.exists(default_filepath):
+        if os.path.islink(default_filepath):
             points_to = readlink(default_filepath)
             remove_file(default_filepath)
             self.log.info("Removed default version marking from %s.", points_to)
+        elif os.path.exists(default_filepath):
+            raise EasyBuildError('Found an unexpected file called default in dir %s' % module_folder_path)
 
-        symlink(mod_filepath, default_filepath)
+        cwd = os.getcwd()
+        #os.chdir(module_folder_path)
+        symlink(module_version + self.MODULE_FILE_EXTENSION, default_filepath)
+        #os.chdir(cwd)
         self.log.info("Module default version file written to point to %s", default_filepath)
 
 

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -456,7 +456,6 @@ class ModuleGeneratorTcl(ModuleGenerator):
         """
         return '$env(%s)' % envvar
 
-    # noinspection PyPackageRequirements,PyPackageRequirements
     def set_as_default(self, module_folder_path, module_version):
         """
         Create .version file inside the package module folder in order to set the default version
@@ -713,7 +712,7 @@ class ModuleGeneratorLua(ModuleGenerator):
 
     def set_as_default(self, module_folder_path, module_version):
         """
-        Create file called "default" inside the package's module folder in order
+        Create a symlink called "default" inside the package's module folder in order
         to set the default module version
         :param module_folder_path: module folder path, e.g. $HOME/easybuild/modules/all/Bison
         :param module_version: module version, e.g. 3.0.4
@@ -721,9 +720,9 @@ class ModuleGeneratorLua(ModuleGenerator):
         default_filepath = os.path.join(module_folder_path, 'default')
 
         if os.path.islink(default_filepath):
-            points_to = readlink(default_filepath)
+            link_target = readlink(default_filepath)
             remove_file(default_filepath)
-            self.log.info("Removed default version marking from %s.", points_to)
+            self.log.info("Removed default version marking from %s.", link_target)
         elif os.path.exists(default_filepath):
             raise EasyBuildError('Found an unexpected file called default in dir %s' % module_folder_path)
 

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -458,7 +458,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
 
     def set_as_default(self, module_folder_path, module_version):
         """
-        Create .version file inside the package module folder in order to set the default version
+        Create a .version file inside the package module folder in order to set the default version
         for TMod
         :param module_folder_path: module folder path, e.g. $HOME/easybuild/modules/all/Bison
         :param module_version: module version, e.g. 3.0.4
@@ -712,7 +712,7 @@ class ModuleGeneratorLua(ModuleGenerator):
 
     def set_as_default(self, module_folder_path, module_version):
         """
-        Create a symlink called "default" inside the package's module folder in order
+        Create a symlink named 'default' inside the package's module folder in order
         to set the default module version
         :param module_folder_path: module folder path, e.g. $HOME/easybuild/modules/all/Bison
         :param module_version: module version, e.g. 3.0.4

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -979,7 +979,7 @@ class Lmod(ModulesTool):
         if opts is None:
             opts = []
 
-        if build_option('debug_lmod'):
+        if build_option('debug_lmod', default=False):
             opts.append((0, '-D'))
 
         # if --show_hidden is in list of arguments, pass it via 'opts' to make sure it's in the right place,

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -979,7 +979,7 @@ class Lmod(ModulesTool):
         if opts is None:
             opts = []
 
-        if build_option('debug_lmod', default=False):
+        if build_option('debug_lmod'):
             opts.append((0, '-D'))
 
         # if --show_hidden is in list of arguments, pass it via 'opts' to make sure it's in the right place,

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -383,7 +383,7 @@ class EasyBuildOptions(GeneralOption):
                                      None, 'store_true', False),
             'zip-logs': ("Zip logs that are copied to install directory, using specified command",
                          None, 'store_or_None', 'gzip'),
-            'set-as-default': ("Set the generated module as default", None, 'store_true', False),
+            'set-default-module': ("Set the generated module as default", None, 'store_true', False),
 
         })
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -383,8 +383,7 @@ class EasyBuildOptions(GeneralOption):
                                      None, 'store_true', False),
             'zip-logs': ("Zip logs that are copied to install directory, using specified command",
                          None, 'store_or_None', 'gzip'),
-
-                'set-as-default': ("Set the generated module as default", None, 'store_true', False),
+            'set-as-default': ("Set the generated module as default", None, 'store_true', False),
 
         })
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -383,6 +383,9 @@ class EasyBuildOptions(GeneralOption):
                                      None, 'store_true', False),
             'zip-logs': ("Zip logs that are copied to install directory, using specified command",
                          None, 'store_or_None', 'gzip'),
+
+                'set-as-default': ("Set the generated module as default", None, 'store_true', False),
+
         })
 
         self.log.debug("override_options: descr %s opts %s" % (descr, opts))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -367,8 +367,8 @@ class FileToolsTest(EnhancedTestCase):
         # creating the link file
         ft.symlink(fp, link)
 
-        # reading file contents and comparing to link
-        self.assertEqual(ft.read_file(fp), ft.read_file(link))
+        # checking if file is symlink
+        self.assertEqual(os.path.islink(link))
         # reading link target and comparing to file name
         self.assertEqual(fp, ft.readlink(link))
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -355,6 +355,23 @@ class FileToolsTest(EnhancedTestCase):
         os.chmod(test_file, 0)
         self.assertFalse(ft.is_readable(test_file))
 
+    def test_symlink_readlink_file(self):
+        """Test read link target file"""
+
+        # write_file and read_file tests are elsewhere. so not getting their states
+        fp = os.path.join(self.test_prefix, 'test.txt')
+        txt = "test_my_link_file"
+        ft.write_file(fp, txt)
+
+        link = os.path.join(self.test_prefix, 'test.link')
+        # creating the link file
+        ft.symlink(fp, link)
+
+        # reading file contents and comparing to link
+        self.assertEqual(ft.read_file(fp), ft.read_file(link))
+        # reading link target and comparing to file name
+        self.assertEqual(fp, ft.readlink(link))
+
     def test_read_write_file(self):
         """Test reading/writing files."""
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -372,6 +372,32 @@ class FileToolsTest(EnhancedTestCase):
         # reading link target and comparing to file name
         self.assertEqual(fp, ft.readlink(link))
 
+    def test_remove_symlinks(self):
+        """Test remove valid and invalid symlinks"""
+
+        # creating test file
+        fp = os.path.join(self.test_prefix, 'test.txt')
+        txt = "test_my_link_file"
+        ft.write_file(fp, txt)
+
+        # creating the symlink
+        link = os.path.join(self.test_prefix, 'test.link')
+        ft.symlink(fp, link) # test if is symlink is valid is done elsewhere
+
+        # Attempting to remove a valid symlink
+        ft.remove_file(link)
+        self.assertFalse(os.path.islink(link))
+        self.assertFalse(os.path.exists(link))
+
+        # Testing the removal of invalid symlinks
+        # Restoring the symlink and removing the file, this way the symlink is invalid
+        ft.symlink(fp, link)
+        ft.remove_file(fp)
+        # attempting to remove the invalid symlink
+        ft.remove_file(link)
+        self.assertFalse(os.path.islink(link))
+        self.assertFalse(os.path.exists(link))
+
     def test_read_write_file(self):
         """Test reading/writing files."""
 
@@ -404,6 +430,7 @@ class FileToolsTest(EnhancedTestCase):
         ft.write_file(foo, 'bar', forced=True)
         self.assertTrue(os.path.exists(foo))
         self.assertEqual(ft.read_file(foo), 'bar')
+
 
     def test_det_patched_files(self):
         """Test det_patched_files function."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -368,7 +368,7 @@ class FileToolsTest(EnhancedTestCase):
         ft.symlink(fp, link)
 
         # checking if file is symlink
-        self.assertEqual(os.path.islink(link))
+        self.assertTrue(os.path.islink(link))
         # reading link target and comparing to file name
         self.assertEqual(fp, ft.readlink(link))
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -369,8 +369,9 @@ class FileToolsTest(EnhancedTestCase):
 
         # checking if file is symlink
         self.assertTrue(os.path.islink(link))
+
         # reading link target and comparing to file name
-        self.assertEqual(os.path.realpath(fp), ft.readlink(link))
+        self.assertEqual(os.path.realpath(fp), os.path.realpath(ft.readlink(link)))
 
     def test_remove_symlinks(self):
         """Test remove valid and invalid symlinks"""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -370,7 +370,7 @@ class FileToolsTest(EnhancedTestCase):
         # checking if file is symlink
         self.assertTrue(os.path.islink(link))
         # reading link target and comparing to file name
-        self.assertEqual(fp, ft.readlink(link))
+        self.assertEqual(os.path.realpath(fp), ft.readlink(link))
 
     def test_remove_symlinks(self):
         """Test remove valid and invalid symlinks"""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -146,7 +146,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         Test load part in generated module file.
         """
         if self.MODULE_GENERATOR_CLASS == ModuleGeneratorLua and not isinstance(self.modtool, Lmod):
-            pass
+            return
 
         # creating base path
         base_path = os.path.join(self.test_prefix, 'all')

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -141,10 +141,13 @@ class ModuleGeneratorTest(EnhancedTestCase):
         desc = self.modgen.get_description()
         self.assertEqual(desc, expected)
 
-    def test_set_default(self):
+    def test_set_default_module(self):
         """
         Test load part in generated module file.
         """
+
+        # note: the lua modulefiles are only supported by Lmod. Therefore,
+        # skipping when it is not the case
         if self.MODULE_GENERATOR_CLASS == ModuleGeneratorLua and not isinstance(self.modtool, Lmod):
             return
 

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -39,7 +39,7 @@ from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import config
 from easybuild.tools.filetools import mkdir, write_file
-from easybuild.tools.modules import curr_module_paths, reset_module_caches
+from easybuild.tools.modules import curr_module_paths
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl
 from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
 from easybuild.framework.easyblock import EasyBlock

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -38,7 +38,7 @@ from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import config
-from easybuild.tools.filetools import mkdir, write_file
+from easybuild.tools.filetools import mkdir, read_file, write_file
 from easybuild.tools.modules import curr_module_paths
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl
 from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
@@ -158,6 +158,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         txt = self.modgen.MODULE_SHEBANG
         if txt:
             txt += '\n'
+        txt += self.modgen.get_description()
         txt += self.modgen.set_environment('foo', 'bar')
 
         version_one = '1.0'

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -35,6 +35,7 @@ import tempfile
 from distutils.version import StrictVersion
 from unittest import TextTestRunner, TestSuite
 from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
+from vsc.utils.missing import nub
 
 from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import config
@@ -48,7 +49,6 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import Lmod
 from easybuild.tools.utilities import quote_str
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_full_path, init_config
-from vsc.utils.missing import nub
 
 class ModuleGeneratorTest(EnhancedTestCase):
     """Tests for module_generator module."""
@@ -168,11 +168,6 @@ class ModuleGeneratorTest(EnhancedTestCase):
         version_two = '2.0'
         version_two_path = os.path.join(modules_base_path, version_two + self.modgen.MODULE_FILE_EXTENSION)
         write_file(version_two_path, txt)
-
-        # removing all available modules from the environment
-        mod_paths = [p for p in nub(curr_module_paths()) if os.path.exists(p)]
-        for mod_path in nub(mod_paths):
-            self.modtool.unuse(mod_path)
 
         # using base_path to possible module load
         self.modtool.use(base_path)

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -40,6 +40,7 @@ from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import config
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl
 from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
+from easybuild.tools.filetools import mkdir, write_file
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ActiveMNS
 from easybuild.tools.build_log import EasyBuildError
@@ -47,6 +48,8 @@ from easybuild.tools.modules import Lmod
 from easybuild.tools.utilities import quote_str
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_full_path, init_config
 
+from vsc.utils.missing import nub
+from easybuild.tools.modules import curr_module_paths, reset_module_caches
 
 class ModuleGeneratorTest(EnhancedTestCase):
     """Tests for module_generator module."""
@@ -138,6 +141,62 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
         desc = self.modgen.get_description()
         self.assertEqual(desc, expected)
+
+    def test_set_default(self):
+        """
+        Test load part in generated module file.
+        """
+        # if not self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
+        #     return
+
+        # creating base path
+        base_path = os.path.join(self.test_prefix, 'all')
+        mkdir(base_path)
+
+        # creating package module
+        module_name = 'dummy'
+        modules_base_path = os.path.join(base_path, module_name)
+        mkdir(modules_base_path)
+
+        # creating two empty modules
+        txt = self.modgen.MODULE_SHEBANG
+        if txt:
+            txt += '\n'
+
+        foo_version = 'foo_version'
+        foo_version_path = os.path.join(modules_base_path, foo_version)
+        write_file(foo_version_path, txt)
+
+        bar_version = 'bar_version'
+        bar_version_path = os.path.join(modules_base_path, bar_version)
+        write_file(bar_version_path, txt)
+
+        # removing all available modules from the environment
+        mod_paths = [p for p in nub(curr_module_paths()) if os.path.exists(p)]
+        for mod_path in nub(mod_paths):
+            self.modtool.unuse(mod_path)
+
+        # using base_path to possible module load
+        reset_module_caches()
+        self.modtool.use(base_path)
+        reset_module_caches()
+
+        # setting foo version as default
+        self.modgen.set_as_default(modules_base_path, foo_version)
+        self.modtool.load([module_name])
+        composed_module_name = module_name + '/' + foo_version
+
+        self.assertTrue(composed_module_name in self.modtool.loaded_modules())
+        self.modtool.purge()
+
+        # setting bar version as default
+        self.modgen.set_as_default(modules_base_path, bar_version)
+        self.modtool.load([module_name])
+        composed_module_name = module_name + '/' + bar_version
+
+        self.assertTrue(composed_module_name in self.modtool.loaded_modules())
+        self.modtool.purge()
+
 
     def test_load(self):
         """Test load part in generated module file."""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -158,6 +158,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         txt = self.modgen.MODULE_SHEBANG
         if txt:
             txt += '\n'
+        txt += self.modgen.set_environment('foo', 'bar')
 
         version_one = '1.0'
         version_one_path = os.path.join(modules_base_path, version_one + self.modgen.MODULE_FILE_EXTENSION)

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -145,6 +145,9 @@ class ModuleGeneratorTest(EnhancedTestCase):
         """
         Test load part in generated module file.
         """
+        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorLua and not isinstance(self.modtool, Lmod):
+            pass
+
         # creating base path
         base_path = os.path.join(self.test_prefix, 'all')
         mkdir(base_path)


### PR DESCRIPTION
This commit adds support to define a default module version on command
line.

The command line is:
`--set-default-module `

And both Tcl and Lua modules are supported.