### PR TITLE
ensure that $EBEXTSLIST* is also included in generated module under --module-only

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1067,7 +1067,8 @@ class EasyBlock(object):
         footer = [self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION)]
 
         # add extra stuff for extensions (if any)
-        footer.append(self.make_module_extra_extensions())
+        if self.cfg['exts_list']:
+            footer.append(self.make_module_extra_extensions())
 
         # include modules footer if one is specified
         if self.modules_footer is not None:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1046,7 +1046,7 @@ class EasyBlock(object):
 
         return txt
 
-    def make_module_extra_extensions(self, extensions):
+    def make_module_extra_extensions(self):
         """
         Sets optional variables for extensions.
         """
@@ -1054,7 +1054,7 @@ class EasyBlock(object):
         lines = [self.module_extra_extensions]
 
         # set environment variable that specifies list of extensions
-        exts_list = ','.join(['%s-%s' % (ext[0], ext[1]) for ext in extensions])
+        exts_list = ','.join(['%s-%s' % (ext[0], ext[1]) for ext in self.cfg['exts_list']])
         env_var_name = convert_name(self.name, upper=True)
         lines.append(self.module_generator.set_environment('EBEXTSLIST%s' % env_var_name, exts_list))
 
@@ -1067,9 +1067,7 @@ class EasyBlock(object):
         footer = [self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION)]
 
         # add extra stuff for extensions (if any)
-        extensions = self.cfg['exts_list']
-        if extensions:
-            footer.append(self.make_module_extra_extensions(extensions))
+        footer.append(self.make_module_extra_extensions())
 
         # include modules footer if one is specified
         if self.modules_footer is not None:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1046,7 +1046,7 @@ class EasyBlock(object):
 
         return txt
 
-    def make_module_extra_extensions(self):
+    def make_module_extra_extensions(self, extensions):
         """
         Sets optional variables for extensions.
         """
@@ -1054,10 +1054,9 @@ class EasyBlock(object):
         lines = [self.module_extra_extensions]
 
         # set environment variable that specifies list of extensions
-        if self.exts_all:
-            exts_list = ','.join(['%s-%s' % (ext['name'], ext.get('version', '')) for ext in self.exts_all])
-            env_var_name = convert_name(self.name, upper=True)
-            lines.append(self.module_generator.set_environment('EBEXTSLIST%s' % env_var_name, exts_list))
+        exts_list = ','.join(['%s-%s' % (ext[0], ext[1]) for ext in extensions])
+        env_var_name = convert_name(self.name, upper=True)
+        lines.append(self.module_generator.set_environment('EBEXTSLIST%s' % env_var_name, exts_list))
 
         return ''.join(lines)
 
@@ -1068,8 +1067,9 @@ class EasyBlock(object):
         footer = [self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION)]
 
         # add extra stuff for extensions (if any)
-        if self.cfg['exts_list']:
-            footer.append(self.make_module_extra_extensions())
+        extensions = self.cfg['exts_list']
+        if extensions:
+            footer.append(self.make_module_extra_extensions(extensions))
 
         # include modules footer if one is specified
         if self.modules_footer is not None:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -323,6 +323,11 @@ class EasyConfigTest(EnhancedTestCase):
         eb = EasyBlock(ec)
         exts_sources = eb.fetch_extension_sources()
 
+        modfile = os.path.join(eb.make_module_step(), 'pi', '3.14' + eb.module_generator.MODULE_FILE_EXTENSION)
+        modtxt = read_file(modfile)
+        regex = re.compile('EBEXTSLISTPI.*ext1-ext_ver1,ext2-ext_ver2')
+        self.assertTrue(regex.search(modtxt), "Pattern '%s' found in: %s" % (regex.pattern, modtxt))
+
     def test_suggestions(self):
         """ If a typo is present, suggestions should be provided (if possible) """
         self.contents = '\n'.join([


### PR DESCRIPTION
Rather than using the filtered list of extensions built up during installation, use the full list from the easyconfig.  Using the filtered list breaks when adding extensions and with `--module-only`.