### PR TITLE
#2055: replace --enable-new-dtags with --disable-new-dtags instead of remove…

### DIFF
--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -91,11 +91,14 @@ while idx < len(args):
             # it doesn't make much sense, and it can also break the build because it may result in reordering lib paths
             cmd_args.append('-L%s' % lib_path)
 
-    # filter out --enable-new-dtags if it's used;
-    # this would result in copying rpath to runpath, meaning that $LD_LIBRARY_PATH is taken into account again
+    # replace --enable-new-dtags with --disable-new-dtags if it's used;
+    # --enable-new-dtags would result in copying rpath to runpath, meaning that $LD_LIBRARY_PATH is taken into account again
+    # --enable-new-dtags is not removed but replaced to prevent issues when the linker flag is forwarded from the compiler 
+    # to the linker with an extra prefixed flag (either -Xlinker or -Wl,). In that case, the compiler would erroneously pass
+    # the next random argument to the linker.
     elif arg == '--enable-new-dtags':
         cmd_args.append('--disable-new-dtags');
-    elif arg != '--enable-new-dtags':
+    else:
         cmd_args.append(arg)
 
     idx += 1

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -93,6 +93,8 @@ while idx < len(args):
 
     # filter out --enable-new-dtags if it's used;
     # this would result in copying rpath to runpath, meaning that $LD_LIBRARY_PATH is taken into account again
+    elif arg == '--enable-new-dtags':
+        cmd_args.append('--disable-new-dtags');
     elif arg != '--enable-new-dtags':
         cmd_args.append(arg)
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1055,7 +1055,7 @@ class ToolchainTest(EnhancedTestCase):
         ]
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
-        # linker command, --enable-new-dtags should be filtered out
+        # linker command, --enable-new-dtags should be replaced with --disable-new-dtags
         out, ec = run_cmd("%s ld '' --enable-new-dtags foo.o" % script, simple=False)
         self.assertEqual(ec, 0)
         expected = '\n'.join([
@@ -1066,6 +1066,7 @@ class ToolchainTest(EnhancedTestCase):
         cmd_args = [
             "'-rpath=$ORIGIN/../lib'",
             "'-rpath=$ORIGIN/../lib64'",
+            "'--disable-new-dtags'",
             "'--disable-new-dtags'",
             "'foo.o'",
         ]


### PR DESCRIPTION
… from command-line