### PR TITLE
only perform is_short_modname_for sanity check in det_short_module_name if modaltsoftname is available

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1668,8 +1668,7 @@ class ActiveMNS(object):
         self.log.debug("Obtained valid short module name %s" % mod_name)
 
         # sanity check: obtained module name should pass the 'is_short_modname_for' check
-        ec = self.check_ec_type(ec)
-        if not self.is_short_modname_for(mod_name, ec.get('modaltsoftname', None) or ec['name']):
+        if 'modaltsoftname' in ec and not self.is_short_modname_for(mod_name, ec['modaltsoftname'] or ec['name']):
             raise EasyBuildError("is_short_modname_for('%s', '%s') for active module naming scheme returns False",
                                  mod_name, ec['name'])
         return mod_name

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1669,7 +1669,7 @@ class ActiveMNS(object):
 
         # sanity check: obtained module name should pass the 'is_short_modname_for' check
         ec = self.check_ec_type(ec)
-        if not self.is_short_modname_for(mod_name, ec['modaltsoftname'] or ec['name']):
+        if not self.is_short_modname_for(mod_name, ec.get('modaltsoftname', None) or ec['name']):
             raise EasyBuildError("is_short_modname_for('%s', '%s') for active module naming scheme returns False",
                                  mod_name, ec['name'])
         return mod_name

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1668,7 +1668,8 @@ class ActiveMNS(object):
         self.log.debug("Obtained valid short module name %s" % mod_name)
 
         # sanity check: obtained module name should pass the 'is_short_modname_for' check
-        if not self.is_short_modname_for(mod_name, ec.get('modaltsoftname', None) or ec['name']):
+        ec = self.check_ec_type(ec)
+        if not self.is_short_modname_for(mod_name, ec['modaltsoftname'] or ec['name']):
             raise EasyBuildError("is_short_modname_for('%s', '%s') for active module naming scheme returns False",
                                  mod_name, ec['name'])
         return mod_name

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1259,6 +1259,32 @@ class ToyBuildTest(EnhancedTestCase):
         write_file(toy_ec, toy_ec_txt)
         self.test_toy_build(ec_file=toy_ec, extra_args=['--rpath', '--experimental'], raise_error=True)
 
+    def test_toy_modaltsoftname(self):
+        """Build two dependent toys as in test_toy_toy but using modaltsoftname"""
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        toy_ec_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec_file)
+
+        ec1 = os.path.join(self.test_prefix, 'toy-0.0-one.eb')
+        ec1_txt = '\n'.join([
+            toy_ec_txt,
+            "versionsuffix = '-one'",
+            "modaltsoftname = 'yot'"
+        ])
+        write_file(ec1, ec1_txt)
+
+        ec2 = os.path.join(self.test_prefix, 'toy-0.0-two.eb')
+        ec2_txt = '\n'.join([
+            toy_ec_txt,
+            "versionsuffix = '-two'",
+            "dependencies = [('toy', '0.0', '-one')]",
+        ])
+        write_file(ec2, ec2_txt)
+
+        self.test_toy_build(ec_file=self.test_prefix, verify=False,
+                            extra_args=['--module-naming-scheme=HierarchicalMNS', 
+                                        '--robot-paths=%s'%self.test_prefix])
+
 
 def suite():
     """ return all the tests in this file """


### PR DESCRIPTION
Fix sanity check for det_short_module_name() where modaltsoftname is set.

Without calling self.check_ec_type to obtain a full parsed easyconfig file
'modaltsoftname' is not set and the sanity check may fail.