### PR TITLE
fix logic in make_module_dep w.r.t. excluding loads for toolchain & toolchain components

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -921,7 +921,7 @@ class EasyBlock(object):
             tc_mod = self.toolchain.det_short_module_name()
             self.log.debug("Toolchain to load in generated module (before excluding any deps): %s", tc_mod)
 
-        # expand toolchain into toolchain components if desired (and if the toolchain was retained as a dep)
+        # expand toolchain into toolchain components if desired
         tc_dep_mods = None
         if mns.expand_toolchain_load(ec=self.cfg):
             tc_dep_mods = self.toolchain.toolchain_dep_mods
@@ -960,9 +960,14 @@ class EasyBlock(object):
         elif tc_mod is not None:
             deps = [tc_mod] + deps
 
+        # filter dependencies to avoid including loads for toolchain or toolchain components that extend $MODULEPATH
+        # with location to where this module is being installed (full_mod_subdir);
+        # if the modules that extend $MODULEPATH are not loaded this module is not available, so there is not
+        # point in loading them again (in fact, it may cause problems when reloading this module due to a load storm)
         deps = [d for d in deps if d not in excluded_deps]
         self.log.debug("List of retained deps to load in generated module: %s", deps)
 
+        # include load statements for retained dependencies
         loads = []
         for dep in deps:
             unload_modules = []

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -922,7 +922,7 @@ class EasyBlock(object):
             self.log.debug("Toolchain to load in generated module (before excluding any deps): %s", tc_mod)
 
         # expand toolchain into toolchain components if desired (and if the toolchain was retained as a dep)
-        tc_dep_mods = []
+        tc_dep_mods = None
         if mns.expand_toolchain_load(ec=self.cfg):
             tc_dep_mods = self.toolchain.toolchain_dep_mods
             self.log.debug("Toolchain components to load in generated module (before excluding any): %s", tc_dep_mods)
@@ -944,20 +944,20 @@ class EasyBlock(object):
         init_modpaths = mns.det_init_modulepaths(self.cfg)
         top_paths = [self.installdir_mod] + [os.path.join(self.installdir_mod, p) for p in init_modpaths]
 
-        all_deps = [d for d in [tc_mod] + tc_dep_mods + deps[:] if d is not None]
+        all_deps = [d for d in [tc_mod] + (tc_dep_mods or []) + deps if d is not None]
         excluded_deps = self.modules_tool.path_to_top_of_module_tree(top_paths, self.cfg.short_mod_name,
                                                                      full_mod_subdir, all_deps)
 
         # if the toolchain is excluded, so should the toolchain components
-        if tc_mod in excluded_deps:
+        if tc_mod in excluded_deps and tc_dep_mods:
             excluded_deps.extend(tc_dep_mods)
 
         self.log.debug("List of excluded deps: %s", excluded_deps)
 
         # expand toolchain into toolchain components if desired
-        if tc_dep_mods:
+        if tc_dep_mods is not None:
             deps = tc_dep_mods + deps
-        elif tc_mod:
+        elif tc_mod is not None:
             deps = [tc_mod] + deps
 
         deps = [d for d in deps if d not in excluded_deps]

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -922,7 +922,7 @@ class EasyBlock(object):
             self.log.debug("Toolchain to load in generated module (before excluding any deps): %s", tc_mod)
 
         # expand toolchain into toolchain components if desired (and if the toolchain was retained as a dep)
-        tc_dep_mods = None
+        tc_dep_mods = []
         if mns.expand_toolchain_load(ec=self.cfg):
             tc_dep_mods = self.toolchain.toolchain_dep_mods
             self.log.debug("Toolchain components to load in generated module (before excluding any): %s", tc_dep_mods)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -944,9 +944,14 @@ class EasyBlock(object):
         init_modpaths = mns.det_init_modulepaths(self.cfg)
         top_paths = [self.installdir_mod] + [os.path.join(self.installdir_mod, p) for p in init_modpaths]
 
-        all_deps = [d for d in [tc_mod] + tc_dep_mods + deps[:] if d]
+        all_deps = [d for d in [tc_mod] + tc_dep_mods + deps[:] if d is not None]
         excluded_deps = self.modules_tool.path_to_top_of_module_tree(top_paths, self.cfg.short_mod_name,
                                                                      full_mod_subdir, all_deps)
+
+        # if the toolchain is excluded, so should the toolchain components
+        if tc_mod in excluded_deps:
+            excluded_deps.extend(tc_dep_mods)
+
         self.log.debug("List of excluded deps: %s", excluded_deps)
 
         # expand toolchain into toolchain components if desired

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -441,11 +441,9 @@ class EasyBlockTest(EnhancedTestCase):
             'version = "3.14"',
             'homepage = "http://example.com"',
             'description = "test easyconfig"',
-            "toolchain = {'name': 'goolf', 'version': '1.4.10'}",
+            "toolchain = {'name': 'gompi', 'version': '1.4.10'}",
             'dependencies = [',
-            "   ('GCC', '4.7.2', '', True),"
-            "   ('hwloc', '1.6.2', '', ('GCC', '4.7.2')),",
-            "   ('OpenMPI', '1.6.4', '', ('GCC', '4.7.2')),"
+            "   ('FFTW', '3.3.3'),",
             ']',
         ])
         self.writeEC()
@@ -453,12 +451,17 @@ class EasyBlockTest(EnhancedTestCase):
 
         eb.installdir = os.path.join(config.install_path(), 'pi', '3.14')
         eb.check_readiness_step()
+        eb.make_builddir()
+        eb.prepare_step()
 
         # GCC, OpenMPI and hwloc modules should *not* be included in loads for dependencies
         mod_dep_txt = eb.make_module_dep()
-        for mod in ['GCC/4.7.2', 'OpenMPI/1.6.4', 'hwloc/1.6.2']:
+        for mod in ['GCC/4.7.2', 'OpenMPI/1.6.4']:
             regex = re.compile('load.*%s' % mod)
             self.assertFalse(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
+
+        regex = re.compile('load.*FFTW/3.3.3')
+        self.assertTrue(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
 
     def test_extensions_step(self):
         """Test the extensions_step"""

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -34,6 +34,7 @@ import shutil
 
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
@@ -62,6 +63,8 @@ class EB_toy(EasyBlock):
         if os.path.exists("%s.source" % name):
             os.rename('%s.source' % name, '%s.c' % name)
 
+        setvar('TOY', '%s-%s' % (self.name, self.version))
+
     def build_step(self, name=None):
         """Build toy."""
         if name is None:
@@ -87,3 +90,9 @@ class EB_toy(EasyBlock):
         f = open(os.path.join(libdir, 'lib%s.a' % name), 'w')
         f.write(name.upper())
         f.close()
+
+    def make_module_extra(self):
+        """Extra stuff for toy module"""
+        txt = super(EB_toy, self).make_module_extra()
+        txt += self.module_generator.set_environment('TOY', os.getenv('TOY', '<TOY_env_var_not_defined>'))
+        return txt

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -382,7 +382,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(tc.options.options_map['optarch'], 'mcpu=cortex-a72.cortex-a53')
         self.assertTrue('-mcpu=cortex-a72.cortex-a53' in os.environ['CFLAGS'])
         self.modtool.purge()
-  
+
     def test_compiler_dependent_optarch(self):
         """Test whether specifying optarch on a per compiler basis works."""
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
@@ -394,7 +394,7 @@ class ToolchainTest(EnhancedTestCase):
         test_cases = product(intel_options, gcc_options, toolchains, enabled)
 
         for (intel_flags, intel_flags_exp), (gcc_flags, gcc_flags_exp), (toolchain, toolchain_ver), enable in test_cases:
-            optarch_var = {} 
+            optarch_var = {}
             optarch_var['Intel'] = intel_flags
             optarch_var['GCC'] = gcc_flags
             build_options = {'optarch': optarch_var}
@@ -406,16 +406,16 @@ class ToolchainTest(EnhancedTestCase):
             if toolchain == 'iccifort':
                 flags = intel_flags_exp
             elif toolchain == 'GCC':
-                flags = gcc_flags_exp 
+                flags = gcc_flags_exp
             else: # PGI as an example of compiler not set
                 # default optarch flag, should be the same as the one in
                 # tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch,tc.cpu_family)]
                 flags = ''
-            
+
             optarch_flags = tc.options.options_map['optarch']
 
             self.assertEquals(flags, optarch_flags)
-            
+
             # Also check that it is correctly passed to xFLAGS, honoring 'enable'
             if flags == '':
                 blacklist = [
@@ -431,7 +431,7 @@ class ToolchainTest(EnhancedTestCase):
 
             for var in flag_vars:
                  set_flags = tc.get_variable(var)
-                
+
                  # Check that the correct flags are there
                  if enable and flags != '':
                      error_msg = "optarch: True means '%s' in '%s'" % (flags, set_flags)
@@ -1016,6 +1016,7 @@ class ToolchainTest(EnhancedTestCase):
             regex = re.compile(pattern)
             self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))
 
+        # $CCACHE_DIR is defined by toolchain.prepare(), and should still be defined after running 'eb'
         self.assertTrue(os.path.samefile(os.environ['CCACHE_DIR'], ccache_dir))
         for comp in ['gcc', 'g++', 'gfortran']:
             self.assertTrue(os.path.samefile(which(comp), os.path.join(self.test_prefix, 'scripts', 'ccache')))

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -860,6 +860,7 @@ class ToyBuildTest(EnhancedTestCase):
             ] + modloadmsg_lua + [
                 r'end',
                 r'io.stderr:write\("oh hai\!"\)',
+                r'setenv\("TOY", "toy-0.0"\)',
                 r'-- Built with EasyBuild version .*$',
             ])
         elif get_module_syntax() == 'Tcl':
@@ -892,6 +893,7 @@ class ToyBuildTest(EnhancedTestCase):
             ] + modloadmsg_tcl + [
                 r'}',
                 r'puts stderr "oh hai\!"',
+                r'setenv	TOY		"toy-0.0"',
                 r'# Built with EasyBuild version .*$',
             ])
         else:


### PR DESCRIPTION
This provides a proper fix for the problem that #2135 dances around, and basically undoes @bartoldeman's PR #2091 since it implements a better solution that also does the right thing when `GCC` (i.e. the bundle of `GCCcore` and `binutils`) is used as a toolchain.

Thanks to @rtmclay for helping out with figuring out the actual problem by looking at the Lmod debug output provided by @akesandgren where reloading the `OpenMPI` module failed because the `binutils` module couldn't be found anymore.

The problem was that `load` statements were still being inserted for `GCCcore` and `binutils` when something was being built with the `GCC` toolchain (e.g. `OpenMPI`) when a module naming scheme that enables `expand_toolchain_load` was being used (for example `HierarchicalMNS`).

The existing code that excludes dependencies that extend `$MODULEPATH` failed because `GCC` (i.e. the toolchain being used) was expanded into `GCCcore` + `binutils` before the list of dependencies that extend `$MODULEPATH` are determined via `path_to_top_of_module_tree`, and hence `excluded_deps` was an empty list while it should have included `GCC`.

This is only a problem when the `GCC` toolchain was being used, since both `GCC` and its `GCCcore` component extend `$MODULEPATH`.

By now passing both the toolchain (e.g. `GCC`) and the toolchain components (`GCCcore` + `binutils`) to `path_to_top_of_module_tree`, the `GCC` toolchain itself is correctly excluded as well (and hence so are the toolchain components).

The additional loop that excludes dependencies of dependencies that was added in #2091 by @bartoldeman is no longer needed now.

cc @geimer, @ocaisa, @damianam