### PR TITLE
Architecture agnostic unit tests (WIP)

### DIFF
--- a/easybuild/toolchains/compiler/ibmxl.py
+++ b/easybuild/toolchains/compiler/ibmxl.py
@@ -41,8 +41,8 @@ class IBMXL(Compiler):
     }
 
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
-        (systemtools.POWER, systemtools.POWER): ['qtune=auto', 'qmaxmem=-1'],
-        (systemtools.POWER, systemtools.POWER_LE): ['qtune=auto', 'qmaxmem=-1'],
+        (systemtools.POWER, systemtools.POWER): 'qtune=auto -qmaxmem=-1',
+        (systemtools.POWER, systemtools.POWER_LE): 'qtune=auto -qmaxmem=-1',
     }
 
     COMPILER_CC = 'xlc'

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -319,8 +319,8 @@ class ToolchainTest(EnhancedTestCase):
                 if optarch_var is not None:
                     flag = '-%s' % optarch_var
                 else:
-                    # default optarch flag
-                    flag = tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch, tc.cpu_family)]
+                    # default optarch flag, contents of tc.options.options_map['optarch'] checked in test_optarch_flags
+                    flag = tc.options.options_map['optarch']
 
                 for var in flag_vars:
                     flags = tc.get_variable(var)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -632,8 +632,10 @@ class ToolchainTest(EnhancedTestCase):
         tc = self.get_toolchain("goalf", version="1.1.0-no-OFED")
         tc.set_options({})
         tc.prepare()
+        # Contents of tc.options.options_map['optarch'] checked in test_optarch_flags
+        optarch_flags = tc.options.options_map['optarch']
         for var in flag_vars:
-            self.assertEqual(os.getenv(var), "-O2 -march=native")
+            self.assertEqual(os.getenv(var), "-O2 -%s" % optarch_flags)
 
         # check other precision flags
         prec_flags = {
@@ -650,9 +652,9 @@ class ToolchainTest(EnhancedTestCase):
                 tc.prepare()
                 for var in flag_vars:
                     if enable:
-                        self.assertEqual(os.getenv(var), "-O2 -march=native %s" % prec_flags[prec])
+                        self.assertEqual(os.getenv(var), "-O2 -%s %s" % (optarch_flags, prec_flags[prec]))
                     else:
-                        self.assertEqual(os.getenv(var), "-O2 -march=native")
+                        self.assertEqual(os.getenv(var), "-O2 -%s" % optarch_flags)
                 self.modtool.purge()
 
     def test_cgoolf_toolchain(self):

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -295,10 +295,8 @@ class ToolchainTest(EnhancedTestCase):
                 tc = self.get_toolchain("goalf", version="1.1.0-no-OFED")
                 tc.set_options({opt: enable})
                 tc.prepare()
-                if opt == 'optarch':
-                    flag = '-%s' % tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch, tc.cpu_family)]
-                else:
-                    flag = '-%s' % tc.options.options_map[opt]
+                # Contents of tc.options.options_map['optarch'] checked in test_optarch_flags
+                flag = '-%s' % tc.options.options_map[opt]
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -734,7 +734,8 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
 
         nvcc_flags = r' '.join([
-            r'-Xcompiler="-O2 -%s -fopenmp"' % tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch, tc.cpu_family)],
+            # Contents of tc.options.options_map['optarch'] checked in test_optarch_flags
+            r'-Xcompiler="-O2 -%s -fopenmp"' % tc.options.options_map['optarch'],
             # the use of -lcudart in -Xlinker is a bit silly but hard to avoid
             r'-Xlinker=".* -lm -lrt -lcudart -lpthread"',
             r' '.join(["-gencode %s" % x for x in opts['cuda_gencode']]),


### PR DESCRIPTION
Various framework unit tests fail on POWER and ARM, mostly due to hard-coded comparisons with compiler flags that are only valid on x86_64.  This PR tries to address this by
 - first checking whether the correct compiler flags end up in `toolchain.options.option_map['optarch']` and
 - using `toolchain.options.option_map['optarch']` in the other tests.

There are also some other issues that I haven't looked into yet, in particular exceptions thrown due to ~~#1950~~.  Here is the full list of failures on AArch64:
 - [ ] `test.framework.toolchain.test_blas_lapack_family` (exception)
 - [ ] `test.framework.toolchain.test_ictce_toolchain` (exception)
 - [ ] `test.framework.toolchain.test_mpi_cmd_for` (exception)
 - [ ] `test.framework.toolchain.test_mpi_family` (exception)
 - [ ] `test.framework.toolchain.test_old_new_iccifort` (exception)
 - [ ] `test.framework.toolchain.test_pgi_imkl` (exception)
 - [ ] `test.framework.toolchain.test_pgi_toolchain` (exception)
 - [ ] `test.framework.toolchain.test_compiler_dependent_optarch` (hard-coded value)
 - [x] `test.framework.toolchain.test_goolfc` (hard-coded value)
 - [x] `test.framework.toolchain.test_misc_flags_unique` (hard-coded value)
 - [ ] `test.framework.toolchain.test_optarch_generic` (hard-coded value)
 - [x] `test.framework.toolchain.test_override_optarch` (hard-coded value)
 - [x] `test.framework.toolchain.test_precision_flags` (hard-coded value)
 - [ ] `test.framework.options.test_dump_env_config` (hard-coded value)