### PR TITLE
Exclude dependencies of dependencies that extend $MODULEPATH

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -965,6 +965,15 @@ class EasyBlock(object):
         # if the modules that extend $MODULEPATH are not loaded this module is not available, so there is not
         # point in loading them again (in fact, it may cause problems when reloading this module due to a load storm)
         deps = [d for d in deps if d not in excluded_deps]
+
+        # load modules that open up the module tree before checking deps of deps (in reverse order)
+        self.modules_tool.load(excluded_deps[::-1])
+ 
+        for dep in excluded_deps:
+            excluded_dep_deps = dependencies_for(dep, self.modules_tool)
+            self.log.debug("List of dependencies for excluded dependency %s: %s" % (dep, excluded_dep_deps))
+            deps = [d for d in deps if d not in excluded_dep_deps]
+
         self.log.debug("List of retained deps to load in generated module: %s", deps)
 
         # include load statements for retained dependencies

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -969,9 +969,9 @@ class EasyBlock(object):
         # load modules that open up the module tree before checking deps of deps (in reverse order)
         self.modules_tool.load(excluded_deps[::-1])
  
-        for dep in excluded_deps:
-            excluded_dep_deps = dependencies_for(dep, self.modules_tool)
-            self.log.debug("List of dependencies for excluded dependency %s: %s" % (dep, excluded_dep_deps))
+        for excluded_dep in excluded_deps:
+            excluded_dep_deps = dependencies_for(excluded_dep, self.modules_tool)
+            self.log.debug("List of dependencies for excluded dependency %s: %s" % (excluded_dep, excluded_dep_deps))
             deps = [d for d in deps if d not in excluded_dep_deps]
 
         self.log.debug("List of retained deps to load in generated module: %s", deps)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -463,6 +463,46 @@ class EasyBlockTest(EnhancedTestCase):
         regex = re.compile('load.*FFTW/3.3.3')
         self.assertTrue(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
 
+    def test_make_module_dep_of_dep_hmns(self):
+        """Test for make_module_dep under HMNS with dependencies of dependencies"""
+        test_ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        all_stops = [x[0] for x in EasyBlock.get_steps()]
+        build_options = {
+            'check_osdeps': False,
+            'robot_path': [test_ecs_path],
+            'valid_stops': all_stops,
+            'validate': False,
+        }
+        os.environ['EASYBUILD_MODULE_NAMING_SCHEME'] = 'HierarchicalMNS'
+        init_config(build_options=build_options)
+        self.setup_hierarchical_modules()
+
+        # GCC and OpenMPI extend $MODULEPATH; hwloc is a dependency of OpenMPI.
+        self.contents = '\n'.join([
+            'easyblock = "ConfigureMake"',
+            'name = "pi"',
+            'version = "3.14"',
+            'homepage = "http://example.com"',
+            'description = "test easyconfig"',
+            "toolchain = {'name': 'goolf', 'version': '1.4.10'}",
+            'dependencies = [',
+            "   ('GCC', '4.7.2', '', True),"
+            "   ('hwloc', '1.6.2', '', ('GCC', '4.7.2')),",
+            "   ('OpenMPI', '1.6.4', '', ('GCC', '4.7.2')),"
+            ']',
+        ])
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+
+        eb.installdir = os.path.join(config.install_path(), 'pi', '3.14')
+        eb.check_readiness_step()
+
+        # GCC, OpenMPI and hwloc modules should *not* be included in loads for dependencies
+        mod_dep_txt = eb.make_module_dep()
+        for mod in ['GCC/4.7.2', 'OpenMPI/1.6.4', 'hwloc/1.6.2']:
+            regex = re.compile('load.*%s' % mod)
+            self.assertFalse(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
+
     def test_extensions_step(self):
         """Test the extensions_step"""
         self.contents = '\n'.join([


### PR DESCRIPTION
This reintroduces commit 81ec7cc which was partially undone by
commit df69253, including the testcase.
This commit reintroduces the old testcase after the new one with
a different name (test_make_module_dep_of_dep_hmns).