### PR TITLE
implement change_dir function in filetools module

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -65,7 +65,7 @@ from easybuild.tools.config import build_option, build_path, get_log_filename, g
 from easybuild.tools.config import install_path, log_path, package_path, source_paths
 from easybuild.tools.environment import restore_env, sanitize_env
 from easybuild.tools.filetools import DEFAULT_CHECKSUM
-from easybuild.tools.filetools import adjust_permissions, apply_patch, convert_name, derive_alt_pypi_url
+from easybuild.tools.filetools import adjust_permissions, apply_patch, change_dir, convert_name, derive_alt_pypi_url
 from easybuild.tools.filetools import compute_checksum, download_file, encode_class_name, extract_file
 from easybuild.tools.filetools import is_alt_pypi_url, mkdir, move_logs, read_file, remove_file, rmtree2, write_file
 from easybuild.tools.filetools import verify_checksum, weld_paths
@@ -1121,10 +1121,7 @@ class EasyBlock(object):
 
         lines = []
         if os.path.isdir(self.installdir):
-            try:
-                os.chdir(self.installdir)
-            except OSError, err:
-                raise EasyBuildError("Failed to change to %s: %s", self.installdir, err)
+            change_dir(self.installdir)
 
             lines.append('\n')
 
@@ -1153,10 +1150,7 @@ class EasyBlock(object):
                     lines.append(self.module_generator.prepend_paths(key, paths))
             if self.dry_run:
                 self.dry_run_msg('')
-            try:
-                os.chdir(self.orig_workdir)
-            except OSError, err:
-                raise EasyBuildError("Failed to change back to %s: %s", self.orig_workdir, err)
+            change_dir(self.orig_workdir)
 
         return ''.join(lines)
 
@@ -1342,11 +1336,8 @@ class EasyBlock(object):
 
         self.log.info("Using %s as start dir", self.cfg['start_dir'])
 
-        try:
-            os.chdir(self.cfg['start_dir'])
-            self.log.debug("Changed to real build directory %s (start_dir)" % self.cfg['start_dir'])
-        except OSError, err:
-            raise EasyBuildError("Can't change to real build directory %s: %s", self.cfg['start_dir'], err)
+        change_dir(self.cfg['start_dir'])
+        self.log.debug("Changed to real build directory %s (start_dir)", self.cfg['start_dir'])
 
     def handle_iterate_opts(self):
         """Handle options relevant during iterated part of build/install procedure."""
@@ -1717,7 +1708,7 @@ class EasyBlock(object):
             print_msg("installing extension %s %s (%d/%d)..." % tup, silent=self.silent)
 
             # always go back to original work dir to avoid running stuff from a dir that no longer exists
-            os.chdir(self.orig_workdir)
+            change_dir(self.orig_workdir)
 
             cls, inst = None, None
             class_name = encode_class_name(ext['name'])
@@ -2043,10 +2034,7 @@ class EasyBlock(object):
 
         # chdir to installdir (better environment for running tests)
         if os.path.isdir(self.installdir):
-            try:
-                os.chdir(self.installdir)
-            except OSError, err:
-                raise EasyBuildError("Failed to move to installdir %s: %s", self.installdir, err)
+            change_dir(self.installdir)
 
         # run sanity check commands
         for command in commands:
@@ -2092,11 +2080,12 @@ class EasyBlock(object):
         cleanup_builddir is False, otherwise we remove the installation
         """
         if not self.build_in_installdir and build_option('cleanup_builddir'):
+
+            # make sure we're out of the dir we're removing
+            change_dir(self.orig_workdir)
+            self.log.info("Cleaning up builddir %s (in %s)", self.builddir, os.getcwd())
+
             try:
-                os.chdir(self.orig_workdir)  # make sure we're out of the dir we're removing
-
-                self.log.info("Cleaning up builddir %s (in %s)" % (self.builddir, os.getcwd()))
-
                 rmtree2(self.builddir)
                 base = os.path.dirname(self.builddir)
 
@@ -2228,7 +2217,7 @@ class EasyBlock(object):
         Run provided test cases.
         """
         for test in self.cfg['tests']:
-            os.chdir(self.orig_workdir)
+            change_dir(self.orig_workdir)
             if os.path.isabs(test):
                 path = test
             else:
@@ -2524,7 +2513,7 @@ def build_and_install_one(ecdict, init_env):
     ended = 'ended'
 
     # make sure we're back in original directory before we finish up
-    os.chdir(cwd)
+    change_dir(cwd)
 
     application_log = None
 
@@ -2719,7 +2708,7 @@ def build_easyconfigs(easyconfigs, output_dir, test_results):
             start_time = time.time()
 
             # start with a clean slate
-            os.chdir(base_dir)
+            change_dir(base_dir)
             restore_env(base_env)
             sanitize_env()
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -38,6 +38,7 @@ import os
 
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, build_path
+from easybuild.tools.filetools import change_dir
 from easybuild.tools.run import run_cmd
 
 
@@ -113,10 +114,7 @@ class Extension(object):
         Sanity check to run after installing extension
         """
 
-        try:
-            os.chdir(self.installdir)
-        except OSError, err:
-            raise EasyBuildError("Failed to change %s: %s", self.installdir, err)
+        change_dir(self.installdir)
 
         # disabling templating is required here to support legacy string templates like name/version
         self.cfg.enable_templating = False

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -186,6 +186,20 @@ def remove_file(path):
         raise EasyBuildError("Failed to remove %s: %s", path, err)
 
 
+def change_dir(path):
+    """
+    Change to directory at specified location.
+
+    :param path: location to change to
+    """
+    cwd = None
+    try:
+        cwd = os.getcwd()
+        os.chdir(path)
+    except OSError as err:
+        raise EasyBuildError("Failed to change from %s to %s: %s", cwd, path, err)
+
+
 def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced=False):
     """
     Extract file at given path to specified directory
@@ -206,11 +220,8 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced
     abs_dest = os.path.abspath(dest)
 
     # change working directory
-    try:
-        _log.debug("Unpacking %s in directory %s.", fn, abs_dest)
-        os.chdir(abs_dest)
-    except OSError, err:
-        raise EasyBuildError("Can't change to directory %s: %s", abs_dest, err)
+    _log.debug("Unpacking %s in directory %s.", fn, abs_dest)
+    change_dir(abs_dest)
 
     if not cmd:
         cmd = extract_cmd(fn, overwrite=overwrite)
@@ -595,10 +606,7 @@ def find_base_dir():
         if not os.path.isdir(new_dir):
             break
 
-        try:
-            os.chdir(new_dir)
-        except OSError, err:
-            raise EasyBuildError("Changing to dir %s from current dir %s failed: %s", new_dir, os.getcwd(), err)
+        change_dir(new_dir)
         lst = get_local_dirs_purged()
 
     # make sure it's a directory, and not a (single) file that was in a tarball for example

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -191,13 +191,21 @@ def change_dir(path):
     Change to directory at specified location.
 
     :param path: location to change to
+    :return: previous location we were in
     """
-    cwd = None
+    # determining the current working directory can fail if we're in a non-existing directory
     try:
         cwd = os.getcwd()
+    except OSError as err:
+        _log.debug("Failed to determine current working directory (but proceeding anyway: %s", err)
+        cwd = None
+
+    try:
         os.chdir(path)
     except OSError as err:
         raise EasyBuildError("Failed to change from %s to %s: %s", cwd, path, err)
+
+    return cwd
 
 
 def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced=False):

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -42,7 +42,7 @@ from vsc.utils.patterns import Singleton
 
 from easybuild.tools.config import PKG_TOOL_FPM, PKG_TYPE_RPM, build_option, get_package_naming_scheme, log_path
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import which
+from easybuild.tools.filetools import change_dir, which
 from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
@@ -83,11 +83,7 @@ def package_with_fpm(easyblock):
     pkgtype = build_option('package_type')
     _log.info("Will be creating %s package(s) in %s", pkgtype, workdir)
 
-    try:
-        origdir = os.getcwd()
-        os.chdir(workdir)
-    except OSError, err:
-        raise EasyBuildError("Failed to chdir into workdir %s: %s", workdir, err)
+    origdir = change_dir(workdir)
 
     package_naming_scheme = ActivePNS()
 
@@ -148,10 +144,7 @@ def package_with_fpm(easyblock):
 
     _log.info("Created %s package(s) in %s", pkgtype, workdir)
 
-    try:
-        os.chdir(origdir)
-    except OSError, err:
-        raise EasyBuildError("Failed to chdir back to %s: %s", origdir, err)
+    change_dir(origdir)
 
     return workdir
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -836,11 +836,25 @@ class FileToolsTest(EnhancedTestCase):
 
     def test_change_dir(self):
         """Test change_dir"""
+
+        prev_dir = ft.change_dir(self.test_prefix)
+        self.assertTrue(os.path.samefile(os.getcwd(), self.test_prefix))
+        self.assertNotEqual(prev_dir, None)
+
+        # prepare another directory to play around with
         test_path = os.path.join(self.test_prefix, 'anotherdir')
         ft.mkdir(test_path)
 
-        ft.change_dir(test_path)
+        # check return value (previous location)
+        prev_dir = ft.change_dir(test_path)
         self.assertTrue(os.path.samefile(os.getcwd(), test_path))
+        self.assertTrue(os.path.samefile(prev_dir, self.test_prefix))
+
+        # check behaviour when current working directory does not exist anymore
+        shutil.rmtree(test_path)
+        prev_dir = ft.change_dir(self.test_prefix)
+        self.assertTrue(os.path.samefile(os.getcwd(), self.test_prefix))
+        self.assertEqual(prev_dir, None)
 
         foo = os.path.join(self.test_prefix, 'foo')
         self.assertErrorRegex(EasyBuildError, "Failed to change from .* to %s" % foo, ft.change_dir, foo)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -834,6 +834,17 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(ft.read_file(to_copy) == ft.read_file(target_path))
         self.assertEqual(txt, '')
 
+    def test_change_dir(self):
+        """Test change_dir"""
+        test_path = os.path.join(self.test_prefix, 'anotherdir')
+        ft.mkdir(test_path)
+
+        ft.change_dir(test_path)
+        self.assertTrue(os.path.samefile(os.getcwd(), test_path))
+
+        foo = os.path.join(self.test_prefix, 'foo')
+        self.assertErrorRegex(EasyBuildError, "Failed to change from .* to %s" % foo, ft.change_dir, foo)
+
     def test_extract_file(self):
         """Test extract_file"""
         testdir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
`change_dir` is currently not used in `easybuild/tools/run.py`, since that would introduce a cyclic dependency between `run.py` and `filetools.py`...