### PR TITLE
fix test_vsc_location, vsc.__file__ may not be available when vsc is installed as a namespace package

### DIFF
--- a/test/framework/general.py
+++ b/test/framework/general.py
@@ -33,7 +33,7 @@ import sys
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
-import vsc
+import vsc.utils.generaloption
 
 import easybuild.framework
 from easybuild.tools.build_log import EasyBuildError
@@ -49,8 +49,9 @@ class GeneralTest(EnhancedTestCase):
         # cfr. https://github.com/hpcugent/easybuild-framework/pull/1160
         # easybuild.framework.__file__ provides location to <prefix>/easybuild/framework/__init__.py
         framework_loc = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(easybuild.framework.__file__))))
-        # vsc.__file__ provides location to <prefix>/vsc/__init__.py
-        vsc_loc = os.path.dirname(os.path.dirname(os.path.abspath(vsc.__file__)))
+        # vsc.utils.generaloption.__file__ provides location to <prefix>/vsc/utils/generaloption/__init__.py
+        generaloption_loc = os.path.abspath(vsc.utils.generaloption.__file__)
+        vsc_loc = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(generaloption_loc))))
         # make sure vsc is being imported from outside of framework
         msg = "vsc-base is not provided by EasyBuild framework itself, found location: %s" % vsc_loc
         self.assertFalse(os.path.samefile(framework_loc, vsc_loc), msg)


### PR DESCRIPTION
fix for #2154