### PR TITLE
consider both pycodestyle and pep8 Python modules in style checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
     # pydot (dep for python-graph-dot) 1.2.0 and more recent doesn't work with Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install pydot==1.1.0; else pip install pydot; fi
     # optional Python packages for EasyBuild
-    - pip install autopep8 GC3Pie pep8 python-graph-dot python-hglib PyYAML
+    - pip install autopep8 GC3Pie pycodestyle python-graph-dot python-hglib PyYAML
     # git config is required to make actual git commits (cfr. tests for GitRepository)
     - git config --global user.name "Travis CI"
     - git config --global user.email "travis@travis-ci.org"

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -124,16 +124,30 @@ def import_available_modules(namespace):
     return modules
 
 
-def only_if_module_is_available(modname, pkgname=None, url=None):
+def only_if_module_is_available(modnames, pkgname=None, url=None):
     """Decorator to guard functions/methods against missing required module with specified name."""
     if pkgname and url is None:
         url = 'https://pypi.python.org/pypi/%s' % pkgname
 
+    if isinstance(modnames, basestring):
+        modnames = (modnames,)
+
     def wrap(orig):
         """Decorated function, raises ImportError if specified module is not available."""
         try:
-            __import__(modname)
-            return orig
+            imported = None
+            for modname in modnames:
+                try:
+                    __import__(modname)
+                    imported = modname
+                    break
+                except ImportError:
+                    pass
+
+            if imported is None:
+                raise ImportError("None of the specified modules %s is available" % ', '.join(modnames))
+            else:
+                return orig
 
         except ImportError as err:
             def error(*args, **kwargs):

--- a/test/framework/general.py
+++ b/test/framework/general.py
@@ -81,12 +81,25 @@ class GeneralTest(EnhancedTestCase):
 
         foo()
 
+        @only_if_module_is_available(('nosuchmoduleoutthere', 'easybuild'))
+        def foo2():
+            pass
+
+        foo2()
+
         @only_if_module_is_available('nosuchmoduleoutthere', pkgname='nosuchpkg')
         def bar():
             pass
 
         err_pat = "required module 'nosuchmoduleoutthere' is not available.*package nosuchpkg.*pypi/nosuchpkg"
         self.assertErrorRegex(EasyBuildError, err_pat, bar)
+
+        @only_if_module_is_available(('nosuchmodule', 'anothernosuchmodule'))
+        def bar2():
+            pass
+
+        err_pat = "ImportError: None of the specified modules nosuchmodule, anothernosuchmodule is available"
+        self.assertErrorRegex(EasyBuildError, err_pat, bar2)
 
         class Foo():
             @only_if_module_is_available('thisdoesnotexist', url='http://example.com')

--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -37,9 +37,12 @@ from vsc.utils import fancylogger
 from easybuild.framework.easyconfig.style import _eb_check_trailing_whitespace, check_easyconfigs_style
 
 try:
-    import pep8
+    import pycodestyle
 except ImportError:
-    pass
+    try:
+        import pep8
+    except ImportError:
+        pass
 
 
 class StyleTest(EnhancedTestCase):
@@ -47,8 +50,8 @@ class StyleTest(EnhancedTestCase):
 
     def test_style_conformance(self):
         """Check the easyconfigs for style"""
-        if 'pep8' not in sys.modules:
-            print "Skipping style checks (no pep8 available)"
+        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
+            print "Skipping style checks (no pycodestyle or pep8 available)"
             return
 
         # all available easyconfig files


### PR DESCRIPTION
`pep8` was renamed to `pycodestyle` a while ago, so we should give preference to `pycodestyle`...