### PR TITLE
Avoid creating empty modulefile directories when using `modaltsoftname`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1519,7 +1519,7 @@ class EasyBlock(object):
         # create parent dirs in install and modules path already
         # this is required when building in parallel
         mod_symlink_paths = ActiveMNS().det_module_symlink_paths(self.cfg)
-        parent_subdir = os.path.dirname(self.install_subdir)
+        parent_subdir = os.path.dirname(ActiveMNS().det_full_module_name(self.cfg))
         pardirs = [
             self.installdir,
             os.path.join(self.installdir_mod, parent_subdir),

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1299,9 +1299,15 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertTrue(os.path.exists(os.path.join(software_path, 'toy', '0.0-one', 'bin', 'toy')))
         self.assertTrue(os.path.exists(os.path.join(software_path, 'toy', '0.0-two', 'bin', 'toy')))
 
+        toytwo_name = '0.0-two'
+        yot_name = '0.0-one'
+        if get_module_syntax() == 'Lua':
+            toytwo_name += '.lua'
+            yot_name += '.lua'
+
         # modules for both installations with alternative name should be there
-        self.assertTrue(os.path.exists(os.path.join(modules_path, 'toytwo', '0.0-two.lua')))
-        self.assertTrue(os.path.exists(os.path.join(modules_path, 'yot', '0.0-one.lua')))
+        self.assertTrue(os.path.exists(os.path.join(modules_path, 'toytwo', toytwo_name)))
+        self.assertTrue(os.path.exists(os.path.join(modules_path, 'yot', yot_name)))
 
         # only subdirectories for software should be created
         self.assertEqual(os.listdir(software_path), ['toy'])
@@ -1309,8 +1315,8 @@ class ToyBuildTest(EnhancedTestCase):
 
         # only subdirectories for modules with alternative names should be created
         self.assertEqual(sorted(os.listdir(modules_path)), ['toytwo', 'yot'])
-        self.assertEqual(os.listdir(os.path.join(modules_path, 'toytwo')), ['0.0-two.lua'])
-        self.assertEqual(os.listdir(os.path.join(modules_path, 'yot')), ['0.0-one.lua'])
+        self.assertEqual(os.listdir(os.path.join(modules_path, 'toytwo')), [toytwo_name])
+        self.assertEqual(os.listdir(os.path.join(modules_path, 'yot')), [yot_name])
 
 
 def suite():


### PR DESCRIPTION
Use module name from naming scheme rather than deriving path from install directory. Fixes https://github.com/hpcugent/easybuild-framework/issues/2167 for my use cases.

@boegel I'm not sure about the module symlinking at https://github.com/hpcugent/easybuild-framework/blob/master/easybuild/framework/easyblock.py#L1527, but my gut feeling is that it was broken as well and will be implicitly fixed, too.