### PR TITLE
Skip check_trailing_whitespace test if pep8/pycodestyle is not available

### DIFF
--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -65,6 +65,10 @@ class StyleTest(EnhancedTestCase):
 
     def test_check_trailing_whitespace(self):
         """Test for trailing whitespace check."""
+        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
+            print "Skipping trailing whitespace checks (no pycodestyle or pep8 available)"
+            return
+
         lines = [
             "name = 'foo'",  # no trailing whitespace
             "version = '1.2.3'  ",  # trailing whitespace


### PR DESCRIPTION
It failed for me with
```
ERROR: test_check_trailing_whitespace (test.framework.style.StyleTest)
Test for trailing whitespace check.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/framework/style.py", line 91, in test_check_trailing_whitespace
    result = _eb_check_trailing_whitespace(line, lines, line_number, state)
  File "easybuild/framework/easyconfig/style.py", line 86, in _eb_check_trailing_whitespace
    result = trailing_whitespace(line)
NameError: global name 'trailing_whitespace' is not defined
```