### PR TITLE
Fix fftw_libs for MKL without interface libraries.

### DIFF
--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -101,6 +101,7 @@ class IntelFFTW(Fftw):
             # The cluster interface libs (libfftw3x_cdft*) can be omitted if the toolchain does not provide MPI-FFTW
             # interfaces.
             check_fftw_libs = [l for l in check_fftw_libs if l not in [interface_lib, cluster_interface_lib]]
+            fftw_libs = [l for l in fftw_libs if l not in [interface_lib, cluster_interface_lib]]
         if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
             self.FFT_LIB = fftw_libs
         else:

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -91,8 +91,6 @@ class IntelFFTW(Fftw):
         # so make sure libraries are there before FFT_LIB is set
         imklroot = get_software_root(self.FFT_MODULE_NAME[0])
         fft_lib_dirs = [os.path.join(imklroot, d) for d in self.FFT_LIB_DIR]
-        # filter out libraries from list of FFTW libraries to check for if they are not provided by Intel MKL
-        check_fftw_libs = [lib for lib in fftw_libs if lib not in ['dl', 'gfortran']]
         fftw_lib_exists = lambda x: any([os.path.exists(os.path.join(d, "lib%s.a" % x)) for d in fft_lib_dirs])
         if not fftw_lib_exists(interface_lib) and LooseVersion(imklver) >= LooseVersion("10.2"):
             # interface libs can be optional:
@@ -100,8 +98,11 @@ class IntelFFTW(Fftw):
             # See https://software.intel.com/en-us/articles/intel-mkl-main-libraries-contain-fftw3-interfaces
             # The cluster interface libs (libfftw3x_cdft*) can be omitted if the toolchain does not provide MPI-FFTW
             # interfaces.
-            check_fftw_libs = [l for l in check_fftw_libs if l not in [interface_lib, cluster_interface_lib]]
             fftw_libs = [l for l in fftw_libs if l not in [interface_lib, cluster_interface_lib]]
+
+        # filter out libraries from list of FFTW libraries to check for if they are not provided by Intel MKL
+        check_fftw_libs = [lib for lib in fftw_libs if lib not in ['dl', 'gfortran']]
+
         if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
             self.FFT_LIB = fftw_libs
         else:


### PR DESCRIPTION
PR #2082 allowed the use of MKL without interface libraries
(useful if neither FFTW2 nor MPI are needed in compiler+linalg
toolchains without MPI). However I forgot to adjust fftw_libs
and so the LIBFFT environment variable still included the
non-existing interface libraries.

This patch corrects this issue.