### PR TITLE
clarify error message when no software-specific easyblock was found

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1727,7 +1727,8 @@ class EasyBlock(object):
             try:
                 # no error when importing class fails, in case we run into an existing easyblock
                 # with a similar name (e.g., Perl Extension 'GO' vs 'Go' for which 'EB_Go' is available)
-                cls = get_easyblock_class(None, name=ext['name'], default_fallback=False, error_on_failed_import=False)
+                cls = get_easyblock_class(None, name=ext['name'], error_on_failed_import=False,
+                                          error_on_missing_easyblock=False)
                 self.log.debug("Obtained class %s for extension %s" % (cls, ext['name']))
                 if cls is not None:
                     inst = cls(self, ext)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1058,10 +1058,19 @@ def det_installversion(version, toolchain_name, toolchain_version, prefix, suffi
     _log.nosupport('Use det_full_ec_version from easybuild.tools.module_generator instead of %s' % old_fn, '2.0')
 
 
-def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error_on_missing_easyblock=True):
+def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error_on_missing_easyblock=None, **kwargs):
     """
     Get class for a particular easyblock (or use default)
     """
+    if 'default_fallback' in kwargs:
+        msg = "Named argument 'default_fallback' for get_easyblock_class is deprecated, "
+        msg += "use 'error_on_missing_easyblock' instead"
+        _log.deprecated(msg, '4.0')
+        if error_on_missing_easyblock is None:
+            error_on_missing_easyblock = kwargs['default_fallback']
+    elif error_on_missing_easyblock is None:
+        error_on_missing_easyblock = True
+
     cls = None
     try:
         if easyblock:

--- a/easybuild/scripts/fix_broken_easyconfigs.py
+++ b/easybuild/scripts/fix_broken_easyconfigs.py
@@ -82,7 +82,7 @@ def process_easyconfig_file(ec_file):
     """Process an easyconfig file: fix if it's broken, back it up before fixing it inline (if requested)."""
     ectxt = read_file(ec_file)
     name, easyblock = fetch_parameters_from_easyconfig(ectxt, ['name', 'easyblock'])
-    derived_easyblock_class = get_easyblock_class(easyblock, name=name, default_fallback=False)
+    derived_easyblock_class = get_easyblock_class(easyblock, name=name, error_on_missing_easyblock=False)
 
     fixed_ectxt = fix_broken_easyconfig(ectxt, derived_easyblock_class)
 

--- a/easybuild/scripts/generate_software_list.py
+++ b/easybuild/scripts/generate_software_list.py
@@ -128,7 +128,7 @@ for root, subfolders, files in walk(options.path):
                 log.info("found new software package %s" % ec.name)
                 ec.easyblock = None
                 # check if an easyblock exists
-                ebclass = get_easyblock_class(None, name=ec.name, default_fallback=False)
+                ebclass = get_easyblock_class(None, name=ec.name, error_on_missing_easyblock=False)
                 if ebclass is not None:
                     module = ebclass.__module__.split('.')[-1]
                     if module != "configuremake":

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -275,7 +275,7 @@ def avail_easyconfig_params(easyblock, output_format=FORMAT_TXT):
 
     # include list of extra parameters (if any)
     extra_params = {}
-    app = get_easyblock_class(easyblock, default_fallback=False)
+    app = get_easyblock_class(easyblock, error_on_missing_easyblock=False)
     if app is not None:
         extra_params = app.extra_options()
     params.update(extra_params)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -994,7 +994,9 @@ class EasyConfigTest(EnhancedTestCase):
         ]:
             self.assertEqual(get_easyblock_class(easyblock), easyblock_class)
 
-        self.assertEqual(get_easyblock_class(None, name='gzip', default_fallback=False), None)
+        error_pattern = "No software-specific easyblock 'EB_gzip' found"
+        self.assertErrorRegex(EasyBuildError, error_pattern, get_easyblock_class, None, name='gzip')
+        self.assertEqual(get_easyblock_class(None, name='gzip', error_on_missing_easyblock=False), None)
         self.assertEqual(get_easyblock_class(None, name='toy'), EB_toy)
         self.assertErrorRegex(EasyBuildError, "Failed to import EB_TOY", get_easyblock_class, None, name='TOY')
         self.assertEqual(get_easyblock_class(None, name='TOY', error_on_failed_import=False), None)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1001,6 +1001,15 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, "Failed to import EB_TOY", get_easyblock_class, None, name='TOY')
         self.assertEqual(get_easyblock_class(None, name='TOY', error_on_failed_import=False), None)
 
+        # also test deprecated default_fallback named argument
+        self.assertErrorRegex(EasyBuildError, "DEPRECATED", get_easyblock_class, None, name='gzip',
+                                                                                 default_fallback=False)
+
+        orig_value = easybuild.tools.build_log.CURRENT_VERSION
+        easybuild.tools.build_log.CURRENT_VERSION = '3.9'
+        self.assertEqual(get_easyblock_class(None, name='gzip', default_fallback=False), None)
+        easybuild.tools.build_log.CURRENT_VERSION = orig_value
+
     def test_letter_dir(self):
         """Test letter_dir_for function."""
         test_cases = {


### PR DESCRIPTION
This changes a very cryptic error message like:

```
NO LONGER SUPPORTED since v2.0: Fallback to default easyblock ConfigureMake
(from easybuild.easyblocks.generic.configuremake); use "easyblock = \'ConfigureMake\'" in
easyconfig file?;
see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information
```

to:

```
No software-specific easyblock 'EB_MXNet' found for MXNet
```

I made a breaking change to the signature of `get_easyblock_class` for this, basically replacing the `default_fallback` optional argument with `error_on_missing_easyblock`.

Should I include a deprecation warning for that, which detects the use of `default_fallback` and assigns `error_on_missing_easyblock` instead? Just in case this breaks a script that talks with the framework API?