### PR TITLE
make log.deprecated more verbose by also printing deprecation warnings to stderr

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -128,8 +128,17 @@ class EasyBuildLog(fancylogger.FancyLogger):
                     else: version to check against max_ver to determine warning vs exception
         :param max_ver: version threshold for warning vs exception (compared to 'ver')
         """
+        # provide log_callback function that both logs a warning and prints to stderr
+        def log_callback_warning_and_print(msg):
+            """Log warning message, and also print it to stderr."""
+            self.warning(msg)
+            sys.stderr.write(msg + '\n')
+
+        kwargs['log_callback'] = log_callback_warning_and_print
+
         # always raise an EasyBuildError, nothing else
         kwargs['exception'] = EasyBuildError
+
         if max_ver is None:
             msg += "; see %s for more information" % DEPRECATED_DOC_URL
             fancylogger.FancyLogger.deprecated(self, msg, str(CURRENT_VERSION), ver, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ implement support for installing particular (groups of) software packages.""",
     install_requires=[
         'setuptools >= 0.6',
         "vsc-install >= 0.9.19",
-        "vsc-base >= 2.5.4",
+        "vsc-base >= 2.5.8",
     ],
     extras_require = {
         'yeb': ["PyYAML >= 3.11"],

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -112,8 +112,15 @@ class BuildLogTest(EnhancedTestCase):
         log.error("err: %s", 'msg: %s')
         stderr = self.get_stderr()
         self.mock_stderr(False)
-        # no output to stderr (should all go to log file)
-        self.assertEqual(stderr, '')
+
+        more_info = "see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information"
+        expected_stderr = '\n'.join([
+            "Deprecated functionality, will no longer work in v10000001: anotherwarning; " + more_info,
+            "Deprecated functionality, will no longer work in v2.0: onemorewarning",
+            "Deprecated functionality, will no longer work in v2.0: lastwarning",
+        ]) + '\n'
+        self.assertEqual(stderr, expected_stderr)
+
         try:
             log.exception("oops")
         except EasyBuildError:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1290,10 +1290,17 @@ class CommandLineOptionsTest(EnhancedTestCase):
         topt = EasyBuildOptions(
             go_args=['--deprecated=0.%s' % orig_value],
         )
+        stderr = None
         try:
+            self.mock_stderr(True)
             log.deprecated('x', str(orig_value))
+            stderr = self.get_stderr()
+            self.mock_stderr(False)
         except easybuild.tools.build_log.EasyBuildError, err:
             self.assertTrue(False, 'Deprecated logging should work')
+
+        stderr_regex = re.compile("^Deprecated functionality, will no longer work in")
+        self.assertTrue(stderr_regex.search(stderr), "Pattern '%s' found in: %s" % (stderr_regex.pattern, stderr))
 
         # force it to current version, which should result in deprecation
         topt = EasyBuildOptions(


### PR DESCRIPTION
`log.deprecated` now only results in logging warnings in the log file, where they (too) easily get ignored.

This changes that by also printing deprecation messages to `stderr`, where they should pop up more easily.

Unless you are using deprecated functionality, you should not be seeing any warnings like this.

(note: requires https://github.com/hpcugent/vsc-base/pull/250)