### PR TITLE
add support for --package-tool-options

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -119,6 +119,7 @@ BUILD_OPTIONS_CMDLINE = {
         'mpi_cmd_template',
         'only_blocks',
         'optarch',
+        'package_tool_options',
         'parallel',
         'rpath_filter',
         'regtest_output_dir',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -580,6 +580,7 @@ class EasyBuildOptions(GeneralOption):
         opts = OrderedDict({
             'package': ("Enabling packaging", None, 'store_true', False),
             'package-tool': ("Packaging tool to use", None, 'store', DEFAULT_PKG_TOOL),
+            'package-tool-options': ("Extra options for packaging tool", None, 'store', ''),
             'package-type': ("Type of package to generate", None, 'store', DEFAULT_PKG_TYPE),
             'package-release': ("Package release iteration number", None, 'store', DEFAULT_PKG_RELEASE),
         })

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -47,8 +47,8 @@ from easybuild.tools.package.package_naming_scheme.pns import PackageNamingSchem
 from easybuild.tools.run import run_cmd
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.tools.utilities import import_available_modules
-
 _log = fancylogger.getLogger('tools.package')  # pylint: disable=C0103
+
 
 
 def avail_package_naming_schemes():
@@ -104,6 +104,10 @@ def package_with_fpm(easyblock):
         '--description', easyblock.cfg["description"],
         '--url', easyblock.cfg["homepage"],
     ]
+
+    extra_pkg_options = build_option('package_tool_options')
+    if extra_pkg_options:
+        cmdlist.extend(extra_pkg_options.split(' '))
 
     if build_option('debug'):
         cmdlist.append('--debug')


### PR DESCRIPTION
This follows a request to support passing down `--rpm-sign` to `fpm`.

cc @shahzebsiddiqui