### PR TITLE
Remove extra space in easyconfig.py update function.

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -387,7 +387,7 @@ class EasyConfig(object):
         """
         prev_value = self[key]
         if isinstance(prev_value, basestring):
-            self[key] = '%s %s ' % (prev_value, value)
+            self[key] = '%s %s' % (prev_value, value)
         elif isinstance(prev_value, list):
             self[key] = prev_value + value
         else:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1312,10 +1312,10 @@ class EasyConfigTest(EnhancedTestCase):
         ec.update('description', "- just a test")
         self.assertEqual(ec['description'].strip(), "Toy C program. - just a test")
 
-        # spaces in between multiple updates for stirng values
+        # space in between multiple updates for string values
         ec.update('configopts', 'CC="$CC"')
         ec.update('configopts', 'CXX="$CXX"')
-        self.assertTrue(ec['configopts'].strip().endswith('CC="$CC"  CXX="$CXX"'))
+        self.assertTrue(ec['configopts'].strip().endswith('CC="$CC" CXX="$CXX"'))
 
         # for list values: extend
         ec.update('patches', ['foo.patch', 'bar.patch'])


### PR DESCRIPTION
The extra space added to self[key] in the update function should be removed.

It cases repeated calls to update the same string to have double " " in them.

This causes problems in the namd easyblock later on when the string is split and joined with "-", resulting in "xx-yy--zz" instead of "xx-yy-zz".

Also see issue #2189