### PR TITLE
add support for customising easyconfig parameters on a per-extension basis

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -48,7 +48,11 @@ class Extension(object):
     """
     def __init__(self, mself, ext, extra_params=None):
         """
-        mself has the logger
+        Constructor for Extension class
+
+        :param mself: parent Easyblock instance
+        :param ext: dictionary with extension metadata (name, version, src, patches, options, ...)
+        :param extra_params: extra custom easyconfig parameters to take into account for this extension
         """
         self.master = mself
         self.log = self.master.log
@@ -78,10 +82,10 @@ class Extension(object):
         for key in self.options:
             if key in self.cfg:
                 self.cfg[key] = self.options[key]
-                self.log.debug("Customising known easyconfig parameter '%s' for extension %s v%s: %s",
+                self.log.debug("Customising known easyconfig parameter '%s' for extension %s/%s: %s",
                                key, self.ext['name'], self.ext['version'], self.cfg[key])
             else:
-                self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s v%s: %s",
+                self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s/%s: %s",
                                key, self.ext['name'], self.ext['version'], self.options[key])
 
         self.sanity_check_fail_msgs = []

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -79,10 +79,10 @@ class Extension(object):
             if key in self.cfg:
                 self.cfg[key] = self.options[key]
                 self.log.debug("Customising known easyconfig parameter '%s' for extension %s v%s: %s",
-                               key, self.name, self.version, self.cfg[key])
+                               key, self.ext['name'], self.ext['version'], self.cfg[key])
             else:
                 self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s v%s: %s",
-                               key, self.name, self.version, self.options[key])
+                               key, self.ext['name'], self.ext['version'], self.options[key])
 
         self.sanity_check_fail_msgs = []
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -68,6 +68,19 @@ class Extension(object):
         self.patches = self.ext.get('patches', [])
         self.options = copy.deepcopy(self.ext.get('options', {}))
 
+        # custom easyconfig parameters for extension are included in self.options
+        # make sure they are merged into self.cfg so they can be queried;
+        # unknown easyconfig parameters are ignored since self.options may include keys only there for extensions;
+        # this allows to specify custom easyconfig parameters on a per-extension basis
+        for key in self.options:
+            if key in self.cfg:
+                self.cfg[key] = self.options[key]
+                self.log.debug("Customising known easyconfig parameter '%s' for extension %s v%s: %s",
+                               key, self.name, self.version, self.cfg[key])
+            else:
+                self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s v%s: %s",
+                               key, self.name, self.version, self.options[key])
+
         self.sanity_check_fail_msgs = []
 
     @property

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -46,7 +46,7 @@ class Extension(object):
     """
     Support for installing extensions.
     """
-    def __init__(self, mself, ext):
+    def __init__(self, mself, ext, extra_params=None):
         """
         mself has the logger
         """
@@ -67,6 +67,9 @@ class Extension(object):
         self.src = self.ext.get('src', [])
         self.patches = self.ext.get('patches', [])
         self.options = copy.deepcopy(self.ext.get('options', {}))
+
+        if extra_params:
+            self.cfg.extend_params(extra_params, overwrite=False)
 
         # custom easyconfig parameters for extension are included in self.options
         # make sure they are merged into self.cfg so they can be queried;

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -82,12 +82,18 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             self.is_extension = True
             self.unpack_options = None
 
-            # custom easyconfig parameter for extension are included in self.options
+            # custom easyconfig parameters for extension are included in self.options
             # make sure they are merged into self.cfg so they can be queried;
+            # unknown easyconfig parameters are ignored since self.options may include keys only there for extensions;
             # this allows to specify custom easyconfig parameters on a per-extension basis
             for key in self.options:
-                self.cfg[key] = self.options[key]
-                self.log.debug("Customising '%s' for extension %s v%s: %s", key, self.name, self.version, self.cfg[key])
+                if key in self.cfg:
+                    self.cfg[key] = self.options[key]
+                    self.log.debug("Customising known easyconfig parameter '%s' for extension %s v%s: %s",
+                                   key, self.name, self.version, self.cfg[key])
+                else:
+                    self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s v%s: %s",
+                                   key, self.name, self.version, self.options[key])
 
             # make sure that extra custom easyconfig parameters are known
             extra_params = self.__class__.extra_options()

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -72,7 +72,12 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         self.is_extension = False
 
         if isinstance(args[0], EasyBlock):
+            # make sure that extra custom easyconfig parameters are known
+            extra_params = self.__class__.extra_options()
+            kwargs['extra_params'] = extra_params
+
             Extension.__init__(self, *args, **kwargs)
+
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
@@ -81,10 +86,6 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             self.modules_tool = self.master.modules_tool
             self.is_extension = True
             self.unpack_options = None
-
-            # make sure that extra custom easyconfig parameters are known
-            extra_params = self.__class__.extra_options()
-            self.cfg.extend_params(extra_params, overwrite=False)
         else:
             EasyBlock.__init__(self, *args, **kwargs)
             self.options = copy.deepcopy(self.cfg.get('options', {}))  # we need this for Extension.sanity_check_step

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -82,6 +82,13 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             self.is_extension = True
             self.unpack_options = None
 
+            # custom easyconfig parameter for extension are included in self.options
+            # make sure they are merged into self.cfg so they can be queried;
+            # this allows to specify custom easyconfig parameters on a per-extension basis
+            for key in self.options:
+                self.cfg[key] = self.options[key]
+                self.log.debug("Customising '%s' for extension %s v%s: %s", key, self.name, self.version, self.cfg[key])
+
             # make sure that extra custom easyconfig parameters are known
             extra_params = self.__class__.extra_options()
             self.cfg.extend_params(extra_params, overwrite=False)

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -82,19 +82,6 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             self.is_extension = True
             self.unpack_options = None
 
-            # custom easyconfig parameters for extension are included in self.options
-            # make sure they are merged into self.cfg so they can be queried;
-            # unknown easyconfig parameters are ignored since self.options may include keys only there for extensions;
-            # this allows to specify custom easyconfig parameters on a per-extension basis
-            for key in self.options:
-                if key in self.cfg:
-                    self.cfg[key] = self.options[key]
-                    self.log.debug("Customising known easyconfig parameter '%s' for extension %s v%s: %s",
-                                   key, self.name, self.version, self.cfg[key])
-                else:
-                    self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s v%s: %s",
-                                   key, self.name, self.version, self.options[key])
-
             # make sure that extra custom easyconfig parameters are known
             extra_params = self.__class__.extra_options()
             self.cfg.extend_params(extra_params, overwrite=False)

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -20,12 +20,14 @@ checksums = [[
 patches = ['toy-0.0_typo.patch']
 
 exts_list = [
-    ('bar', '0.0'),
+    ('bar', '0.0', {
+        'buildopts': " && gcc bar.c -o bar_bis",
+    }),
     ('barbar', '0.0'),
 ]
 
 sanity_check_paths = {
-    'files': [('bin/yot', 'bin/toy'), 'bin/bar', 'lib/libtoy.a', 'lib/libbar.a'],
+    'files': [('bin/yot', 'bin/toy'), 'bin/bar', 'bin/bar_bis', 'lib/libtoy.a', 'lib/libbar.a'],
     'dirs': [],
 }
 

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -22,6 +22,7 @@ patches = ['toy-0.0_typo.patch']
 exts_list = [
     ('bar', '0.0', {
         'buildopts': " && gcc bar.c -o bar_bis",
+        'unknowneasyconfigparameterthatshouldbeignored': 'foo',
     }),
     ('barbar', '0.0'),
 ]

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -21,7 +21,8 @@ patches = ['toy-0.0_typo.patch']
 
 exts_list = [
     ('bar', '0.0', {
-        'buildopts': " && gcc bar.c -o bar_bis",
+        'buildopts': " && gcc bar.c -o anotherbar",
+        'toy_ext_param': "mv anotherbar bar_bis",
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',
     }),
     ('barbar', '0.0'),

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -28,17 +28,32 @@ EasyBuild support for building and installing toy extensions, implemented as an 
 @author: Kenneth Hoste (Ghent University)
 """
 
+from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.easyblocks.toy import EB_toy
+from easybuild.tools.run import run_cmd
+
 
 class Toy_Extension(ExtensionEasyBlock):
     """Support for building/installing toy."""
+
+    @staticmethod
+    def extra_options():
+        """Custom easyconfig parameters for toy extensions."""
+        extra_vars = {
+            'toy_ext_param': ['', "Toy extension parameter", CUSTOM],
+        }
+        return ExtensionEasyBlock.extra_options(extra_vars=extra_vars)
 
     def run(self):
         """Build toy extension."""
         super(Toy_Extension, self).run(unpack_src=True)
         EB_toy.configure_step(self.master, name=self.name)
         EB_toy.build_step(self.master, name=self.name, buildopts=self.cfg['buildopts'])
+
+        if self.cfg['toy_ext_param']:
+            run_cmd(self.cfg['toy_ext_param'])
+
         EB_toy.install_step(self.master, name=self.name)
 
     def sanity_check_step(self, *args, **kwargs):

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -38,7 +38,7 @@ class Toy_Extension(ExtensionEasyBlock):
         """Build toy extension."""
         super(Toy_Extension, self).run(unpack_src=True)
         EB_toy.configure_step(self.master, name=self.name)
-        EB_toy.build_step(self.master, name=self.name)
+        EB_toy.build_step(self.master, name=self.name, buildopts=self.cfg['buildopts'])
         EB_toy.install_step(self.master, name=self.name)
 
     def sanity_check_step(self, *args, **kwargs):

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -65,14 +65,18 @@ class EB_toy(EasyBlock):
 
         setvar('TOY', '%s-%s' % (self.name, self.version))
 
-    def build_step(self, name=None):
+    def build_step(self, name=None, buildopts=None):
         """Build toy."""
+
+        if buildopts is None:
+            buildopts = self.cfg['buildopts']
+
         if name is None:
             name = self.name
         run_cmd('%(prebuildopts)s gcc %(name)s.c -o %(name)s %(buildopts)s' % {
             'name': name,
             'prebuildopts': self.cfg['prebuildopts'],
-            'buildopts': self.cfg['buildopts'],
+            'buildopts': buildopts,
         })
 
     def install_step(self, name=None):


### PR DESCRIPTION
With this in place, custom values for easyconfig parameters like `buildopts` & co can be specified on a per-extension basis, just like is the case already for `source_urls`.

This fixes a long-standing issue (#991) that has been popping up more frequently recently, for example when certain Python packages must be installed with `pip`, which requires setting the `use_pip` parameter to `True`.