### PR TITLE
use devel logging where relevant in easybuild.tools.toolchain

### DIFF
--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -149,7 +149,7 @@ class Compiler(Toolchain):
     def set_options(self, options):
         """Process compiler toolchain options."""
         self._set_compiler_toolchainoptions()
-        self.log.debug('_compiler_set_options: compiler toolchain options %s' % self.options)
+        self.log.devel('_compiler_set_options: compiler toolchain options %s', self.options)
         super(Compiler, self).set_options(options)
 
     def set_variables(self):
@@ -158,7 +158,7 @@ class Compiler(Toolchain):
         self._set_optimal_architecture()
         self._set_compiler_flags()
 
-        self.log.debug('set_variables: compiler variables %s' % self.variables)
+        self.log.devel('set_variables: compiler variables %s', self.variables)
         super(Compiler, self).set_variables()
 
     def _set_compiler_toolchainoptions(self):
@@ -227,7 +227,6 @@ class Compiler(Toolchain):
         if self.options.get('cciscxx', None):
             self.log.debug("_set_compiler_vars: cciscxx set: switching CXX %s for CC value %s" %
                            (self.variables['CXX'], self.variables['CC']))
-            # FIXME (stdweird): shouldn't this be the other way around??
             self.variables['CXX'] = self.variables['CC']
 
     def _set_compiler_flags(self):

--- a/easybuild/tools/toolchain/fft.py
+++ b/easybuild/tools/toolchain/fft.py
@@ -79,6 +79,6 @@ class Fft(Toolchain):
         ## TODO is link order fully preserved with this order ?
         self._set_fft_variables()
 
-        self.log.debug('set_variables: FFT variables %s' % self.variables)
+        self.log.devel('set_variables: FFT variables %s', self.variables)
 
         super(Fft, self).set_variables()

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -94,7 +94,7 @@ class LinAlg(Toolchain):
             self._set_blacs_variables()
             self._set_scalapack_variables()
 
-        self.log.debug('set_variables: LinAlg variables %s' % self.variables)
+        self.log.devel('set_variables: LinAlg variables %s', self.variables)
 
         super(LinAlg, self).set_variables()
 
@@ -140,8 +140,8 @@ class LinAlg(Toolchain):
         """Set LAPACK related variables
             and LAPACK only, for (working) use BLAS+LAPACK
         """
-        self.log.debug("_set_lapack_variables: LAPACK_IS_BLAS %s LAPACK_REQUIRES %s" %
-                       (self.LAPACK_IS_BLAS, self.LAPACK_REQUIRES))
+        self.log.devel("_set_lapack_variables: LAPACK_IS_BLAS %s LAPACK_REQUIRES %s",
+                       self.LAPACK_IS_BLAS, self.LAPACK_REQUIRES)
         if self.LAPACK_IS_BLAS:
             self.variables.join('LIBLAPACK_ONLY', 'LIBBLAS')
             self.variables.join('LIBLAPACK_MT_ONLY', 'LIBBLAS_MT')

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -87,7 +87,7 @@ class Mpi(Toolchain):
 
         self.options.add_options(self.MPI_UNIQUE_OPTS, self.MPI_UNIQUE_OPTION_MAP)
 
-        self.log.debug('_set_mpi_options: all current options %s' % self.options)
+        self.log.devel('_set_mpi_options: all current options %s', self.options)
 
 
     def set_variables(self):
@@ -95,14 +95,14 @@ class Mpi(Toolchain):
         self._set_mpi_compiler_variables()
         self._set_mpi_variables()
 
-        self.log.debug('set_variables: compiler variables %s' % self.variables)
+        self.log.devel('set_variables: compiler variables %s', self.variables)
         super(Mpi, self).set_variables()
 
     def _set_mpi_compiler_variables(self):
         """Set the MPI compiler variables"""
         is32bit = self.options.get('32bit', None)
         if is32bit:
-            self.log.debug("_set_compiler_variables: 32bit set: changing compiler definitions")
+            self.log.debug("_set_mpi_compiler_variables: 32bit set: changing compiler definitions")
 
         for var_tuple in COMPILER_VARIABLES:
             c_var = var_tuple[0]  # [1] is the description
@@ -126,16 +126,16 @@ class Mpi(Toolchain):
 
             if self.options.get('usempi', None):
                 var_seq = SEQ_COMPILER_TEMPLATE % {'c_var': c_var}
-                self.log.debug('_set_mpi_compiler_variables: usempi set: defining %s as %s' % (var_seq, self.variables[c_var]))
+                self.log.debug("usempi set: defining %s as %s", var_seq, self.variables[c_var])
                 self.variables[var_seq] = self.variables[c_var]
-                self.log.debug("_set_mpi_compiler_variables: usempi set: switching %s value %s for %s value %s" %
-                               (c_var, self.variables[c_var], var, self.variables[var]))
+                self.log.debug("usempi set: switching %s value %s for %s value %s",
+                               c_var, self.variables[c_var], var, self.variables[var])
                 self.variables[c_var] = self.variables[var]
 
 
         if self.options.get('cciscxx', None):
-            self.log.debug("_set_mpi_compiler_variables: cciscxx set: switching MPICXX %s for MPICC value %s" %
-                           (self.variables['MPICXX'], self.variables['MPICC']))
+            self.log.debug("_set_mpi_compiler_variables: cciscxx set: switching MPICXX %s for MPICC value %s",
+                           self.variables['MPICXX'], self.variables['MPICC'])
             self.variables['MPICXX'] = self.variables['MPICC']
             if self.options.get('usempi', None):
                 # possibly/likely changed

--- a/easybuild/tools/toolchain/options.py
+++ b/easybuild/tools/toolchain/options.py
@@ -61,12 +61,12 @@ class ToolchainOptions(dict):
 
     def _add_options(self, options):
         """Add actual options dict to self"""
-        self.log.debug("_add_options: adding options %s" % options)
+        self.log.debug("Using toolchain options %s", options)
         for name, value in options.items():
             if not isinstance(value, (list, tuple,)) and len(value) == 2:
                 raise EasyBuildError("_add_options: option name %s has to be 2 element list (%s)", name, value)
             if name in self:
-                self.log.debug("_add_options: redefining previous name %s (previous value %s)", name, self.get(name))
+                self.log.devel("_add_options: redefining previous name %s (previous value %s)", name, self.get(name))
             self.__setitem__(name, value[0])
             self.description.__setitem__(name, value[1])
 
@@ -77,9 +77,9 @@ class ToolchainOptions(dict):
         for name in options_map.keys():
             if not name in self:
                 if name.startswith('_opt_'):
-                    self.log.debug("_add_options_map: no option with name %s defined, but allowed", name)
+                    self.log.devel("_add_options_map: no option with name %s defined, but allowed", name)
                 else:
-                    raise EasyBuildError("_add_options_map: no option with name %s defined", name)
+                    raise EasyBuildError("No toolchain option with name %s defined", name)
 
         self.options_map.update(options_map)
 

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -186,7 +186,7 @@ class Toolchain(object):
                 else:
                     raise EasyBuildError("Class constant '%s' to be restored does not exist in %s", cst, self)
 
-            self.log.debug("Copied class constants: %s", self.CLASS_CONSTANT_COPIES[key])
+            self.log.devel("Copied class constants: %s", self.CLASS_CONSTANT_COPIES[key])
 
     def _restore_class_constants(self):
         """Restored class constants that need to be restored when a new instance is created."""
@@ -194,9 +194,9 @@ class Toolchain(object):
         for cst in self.CLASS_CONSTANT_COPIES[key]:
             newval = copy.deepcopy(self.CLASS_CONSTANT_COPIES[key][cst])
             if hasattr(self, cst):
-                self.log.debug("Restoring class constant '%s' to %s (was: %s)", cst, newval, getattr(self, cst))
+                self.log.devel("Restoring class constant '%s' to %s (was: %s)", cst, newval, getattr(self, cst))
             else:
-                self.log.debug("Restoring (currently undefined) class constant '%s' to %s", cst, newval)
+                self.log.devel("Restoring (currently undefined) class constant '%s' to %s", cst, newval)
 
             setattr(self, cst, newval)
 
@@ -222,9 +222,9 @@ class Toolchain(object):
             Needs to be defined for super() relations
         """
         if self.options.option('packed-linker-options'):
-            self.log.debug("set_variables: toolchain variables. packed-linker-options.")
+            self.log.devel("set_variables: toolchain variables. packed-linker-options.")
             self.variables.try_function_on_element('set_packed_linker_options')
-        self.log.debug("set_variables: toolchain variables. Do nothing.")
+        self.log.devel("set_variables: toolchain variables. Do nothing.")
 
     def generate_vars(self):
         """Convert the variables in simple vars"""
@@ -250,7 +250,7 @@ class Toolchain(object):
         if offset is None:
             offset = ''
         txt = sep.join(["%s%s" % (offset, x) for x in res])
-        self.log.debug("show_variables:\n%s" % txt)
+        self.log.debug("show_variables:\n%s", txt)
         return txt
 
     def get_software_root(self, names):
@@ -319,7 +319,7 @@ class Toolchain(object):
         """
         # short-circuit to returning module name for this (non-dummy) toolchain
         if self.name == DUMMY_TOOLCHAIN_NAME:
-            self.log.debug("_toolchain_exists: %s toolchain always exists, returning True" % DUMMY_TOOLCHAIN_NAME)
+            self.log.devel("_toolchain_exists: %s toolchain always exists, returning True", DUMMY_TOOLCHAIN_NAME)
             return True
         else:
             if self.mod_short_name is None:
@@ -355,16 +355,16 @@ class Toolchain(object):
         suffix = dependency.get('versionsuffix', '')
 
         if 'version' in dependency:
-            version = "".join([dependency['version'], toolchain, suffix])
-            self.log.debug("get_dependency_version: version in dependency return %s", version)
+            version = ''.join([dependency['version'], toolchain, suffix])
+            self.log.devel("get_dependency_version: version in dependency return %s", version)
             return version
         else:
-            toolchain_suffix = "".join([toolchain, suffix])
+            toolchain_suffix = ''.join([toolchain, suffix])
             matches = self.modules_tool.available(dependency['name'], toolchain_suffix)
             # Find the most recent (or default) one
             if len(matches) > 0:
                 version = matches[-1][-1]
-                self.log.debug("get_dependency_version: version not in dependency return %s", version)
+                self.log.devel("get_dependency_version: version not in dependency return %s", version)
                 return
             else:
                 raise EasyBuildError("No toolchain version for dependency name %s (suffix %s) found",
@@ -372,7 +372,7 @@ class Toolchain(object):
 
     def add_dependencies(self, dependencies):
         """ Verify if the given dependencies exist and add them """
-        self.log.debug("add_dependencies: adding toolchain dependencies %s" % dependencies)
+        self.log.debug("add_dependencies: adding toolchain dependencies %s", dependencies)
 
         # use *full* module name to check existence of dependencies, since the modules may not be available in the
         # current $MODULEPATH without loading the prior dependencies in a module hierarchy
@@ -382,6 +382,7 @@ class Toolchain(object):
         dep_mod_names = [dep['full_mod_name'] for dep in dependencies]
 
         # check whether modules exist
+        self.log.debug("add_dependencies: MODULEPATH: %s", os.environ['MODULEPATH'])
         if self.dry_run:
             deps_exist = [True] * len(dep_mod_names)
         else:
@@ -389,10 +390,9 @@ class Toolchain(object):
 
         missing_dep_mods = []
         for dep, dep_mod_name, dep_exists in zip(dependencies, dep_mod_names, deps_exist):
-            self.log.debug("add_dependencies: MODULEPATH: %s" % os.environ['MODULEPATH'])
             if dep_exists:
                 self.dependencies.append(dep)
-                self.log.debug('add_dependencies: added toolchain dependency %s' % str(dep))
+                self.log.devel("add_dependencies: added toolchain dependency %s", str(dep))
             else:
                 missing_dep_mods.append(dep_mod_name)
 
@@ -414,7 +414,7 @@ class Toolchain(object):
             if var.endswith(var_suff):
                 tc_elems.update({var[:-len(var_suff)]: getattr(self, var)})
 
-        _log.debug("Toolchain definition for %s: %s" % (self.as_dict(), tc_elems))
+        self.log.debug("Toolchain definition for %s: %s", self.as_dict(), tc_elems)
         return tc_elems
 
     def is_dep_in_toolchain_module(self, name):
@@ -491,7 +491,7 @@ class Toolchain(object):
                     self.modules_tool.prepend_module_path(os.path.join(install_path('mod'), mod_path_suffix, modpath))
 
             # load modules for all dependencies
-            self.log.debug("Loading module for toolchain: %s" % tc_mod)
+            self.log.debug("Loading module for toolchain: %s", tc_mod)
             self.modules_tool.load([tc_mod])
 
         # append toolchain module to list of modules
@@ -520,7 +520,7 @@ class Toolchain(object):
                         self._simulated_load_dependency_module(dep['name'], dep['version'], {'prefix': deproot})
         else:
             # load modules for all dependencies
-            self.log.debug("Loading modules for dependencies: %s" % dep_mods)
+            self.log.debug("Loading modules for dependencies: %s", dep_mods)
             self.modules_tool.load(dep_mods)
 
         # append dependency modules to list of modules
@@ -578,7 +578,7 @@ class Toolchain(object):
         # determine direct toolchain dependencies
         mod_name = self.det_short_module_name()
         self.toolchain_dep_mods = dependencies_for(mod_name, self.modules_tool, depth=0)
-        self.log.debug('prepare: list of direct toolchain dependencies: %s' % self.toolchain_dep_mods)
+        self.log.debug("List of toolchain dependencies from toolchain module: %s", self.toolchain_dep_mods)
 
         # only retain names of toolchain elements, excluding toolchain name
         toolchain_definition = set([e for es in self.definition().values() for e in es if not e == self.name])
@@ -588,11 +588,10 @@ class Toolchain(object):
             if self.is_required(elem_name) or self.is_dep_in_toolchain_module(elem_name):
                 continue
             # not required and missing: remove from toolchain definition
-            self.log.debug("Removing %s from list of optional toolchain elements." % elem_name)
+            self.log.debug("Removing %s from list of optional toolchain elements.", elem_name)
             toolchain_definition.remove(elem_name)
 
-        self.log.debug("List of toolchain dependencies from toolchain module: %s" % self.toolchain_dep_mods)
-        self.log.debug("List of toolchain elements from toolchain definition: %s" % toolchain_definition)
+        self.log.debug("List of toolchain elements from toolchain definition: %s", toolchain_definition)
 
         if all(map(self.is_dep_in_toolchain_module, toolchain_definition)):
             self.log.info("List of toolchain dependency modules and toolchain definition match!")
@@ -665,10 +664,10 @@ class Toolchain(object):
             # set the variables
             # onlymod can be comma-separated string of variables not to be set
             if onlymod == True:
-                self.log.debug("prepare: do not set additional variables onlymod=%s" % onlymod)
+                self.log.debug("prepare: do not set additional variables onlymod=%s", onlymod)
                 self.generate_vars()
             else:
-                self.log.debug("prepare: set additional variables onlymod=%s" % onlymod)
+                self.log.debug("prepare: set additional variables onlymod=%s", onlymod)
 
                 # add LDFLAGS and CPPFLAGS from dependencies to self.vars
                 self._add_dependency_variables()
@@ -774,7 +773,7 @@ class Toolchain(object):
             rpath_filter = ['/lib.*', '/usr.*']
             self.log.debug("No general RPATH filter specified, falling back to default: %s", rpath_filter)
         rpath_filter = ','.join(rpath_filter + ['%s.*' % d for d in rpath_filter_dirs or []])
-        self.log.debug("Combined RPATH filter: '%s'" % rpath_filter)
+        self.log.debug("Combined RPATH filter: '%s'", rpath_filter)
 
         # create wrappers
         for cmd in nub(c_comps + fortran_comps + ['ld', 'ld.gold', 'ld.bfd']):
@@ -853,7 +852,7 @@ class Toolchain(object):
     def _setenv_variables(self, donotset=None, verbose=True):
         """Actually set the environment variables"""
 
-        self.log.debug("_setenv_variables: setting variables: donotset=%s" % donotset)
+        self.log.devel("_setenv_variables: setting variables: donotset=%s", donotset)
         if self.dry_run:
             dry_run_msg("Defining build environment...\n", silent=not verbose)
 
@@ -866,10 +865,10 @@ class Toolchain(object):
 
         for key, val in sorted(self.vars.items()):
             if key in donotsetlist:
-                self.log.debug("_setenv_variables: not setting environment variable %s (value: %s)." % (key, val))
+                self.log.debug("_setenv_variables: not setting environment variable %s (value: %s).", key, val)
                 continue
 
-            self.log.debug("_setenv_variables: setting environment variable %s to %s" % (key, val))
+            self.log.debug("_setenv_variables: setting environment variable %s to %s", key, val)
             setvar(key, val, verbose=verbose)
 
             # also set unique named variables that can be used in Makefiles

--- a/easybuild/tools/toolchain/variables.py
+++ b/easybuild/tools/toolchain/variables.py
@@ -73,7 +73,7 @@ class LibraryList(StrList):
     def set_packed_linker_options(self, separator=',', separator_begin_end=',', prefix=None, prefix_begin_end=None):
         """Use packed linker options format"""
         if isinstance(self.BEGIN, LinkerFlagList) and isinstance(self.END, LinkerFlagList):
-            self.log.debug("sanitize: PACKED_LINKER_OPTIONS")
+            self.log.devel("sanitize: PACKED_LINKER_OPTIONS")
 
             self.BEGIN.PACKED_LINKER_OPTIONS = True
             self.END.PACKED_LINKER_OPTIONS = True
@@ -166,11 +166,12 @@ class LinkerFlagList(StrList):
             # somehow this should only be run once.
             self.PACKED_LINKER_OPTIONS = None
 
-            self.log.debug("sanitize: PACKED_LINKER_OPTIONS")
+            self.log.devel("sanitize: PACKED_LINKER_OPTIONS")
             if self.IS_BEGIN and self.SEPARATOR:
                 self.BEGIN = str(self.PREFIX).rstrip(self.SEPARATOR)
             self.PREFIX = None
-            self.log.debug("sanitize: PACKED_LINKER_OPTIONS IS_BEGIN %s PREFIX %s BEGIN %s" % (self.IS_BEGIN, self.PREFIX, self.BEGIN))
+            self.log.devel("sanitize: PACKED_LINKER_OPTIONS IS_BEGIN %s PREFIX %s BEGIN %s",
+                           self.IS_BEGIN, self.PREFIX, self.BEGIN)
 
         super(LinkerFlagList, self).sanitize()
 

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -115,7 +115,7 @@ def import_available_modules(namespace):
             if not module.endswith('__init__.py'):
                 mod_name = module.split(os.path.sep)[-1].split('.')[0]
                 modpath = '.'.join([namespace, mod_name])
-                _log.debug("importing module %s" % modpath)
+                _log.debug("importing module %s", modpath)
                 try:
                     mod = __import__(modpath, globals(), locals(), [''])
                 except ImportError as err:

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -162,7 +162,8 @@ class AbsPathList(StrList):
             if suffix : extend the paths with prefixes
             if filename : look for filename in prefix+paths
         """
-        self.log.debug("append_exists: prefix %s paths %s suffix %s filename %s append_all %s" % (prefix, paths, suffix, filename, append_all))
+        self.log.devel("append_exists: prefix %s paths %s suffix %s filename %s append_all %s",
+                       prefix, paths, suffix, filename, append_all)
         if suffix is not None:
             res = []
             for path in paths:
@@ -175,7 +176,7 @@ class AbsPathList(StrList):
                 abs_path = os.path.join(abs_path, filename)
             if os.path.exists(abs_path):
                 self.append(abs_path)
-                self.log.debug("append_exists: added abssolute path %s" % abs_path)
+                self.log.devel("append_exists: added absolute path %s", abs_path)
                 if not append_all:
                     return
 
@@ -183,7 +184,7 @@ class AbsPathList(StrList):
         """
         Add directory base, or its subdirs if subdirs is not None
         """
-        self.log.debug("append_subdirs: base %s subdirs %s" % (base, subdirs))
+        self.log.devel("append_subdirs: base %s subdirs %s", base, subdirs)
 
         if subdirs is None:
             subdirs = [None]
@@ -195,7 +196,7 @@ class AbsPathList(StrList):
 
             if os.path.isdir(directory):
                 self.append(directory)
-                self.log.debug("append_subdirs: added directory %s" % directory)
+                self.log.devel("append_subdirs: added directory %s", directory)
             else:
                 self.log.warning("flags_for_subdirs: directory %s was not found" % directory)
 
@@ -258,13 +259,13 @@ class ListOfLists(list):
         res = False
 
         if type(value) in self.protected_classes:
-            self.log.debug("_is_protected: %s value %s (%s)" % (self.protected_classes, value, type(value)))
+            self.log.devel("_is_protected: %s value %s (%s)", self.protected_classes, value, type(value))
             res = True
         elif isinstance(value, tuple(self.protected_instances)):
-            self.log.debug("_is_protected: %s value %s (%s)" % (self.protected_instances, value, type(value)))
+            self.log.devel("_is_protected: %s value %s (%s)", self.protected_instances, value, type(value))
             res = True
 
-        self.log.debug("_is_protected: %s value %s (%s)" % (res, value, value.__repr__()))
+        self.log.devel("_is_protected: %s value %s (%s)", res, value, value.__repr__())
         return res
 
     def nappend(self, value, **kwargs):
@@ -294,10 +295,12 @@ class ListOfLists(list):
             newvalue.POSITION = position
         if self._str_ok(newvalue) or append_empty:
             self.append(newvalue)
-            self.log.debug("nappend: value %s newvalue %s position %s" % (value.__repr__(), newvalue.__repr__(), position))
+            self.log.devel("nappend: value %s newvalue %s position %s",
+                           value.__repr__(), newvalue.__repr__(), position)
             return newvalue
         else:
-            self.log.debug("nappend: ignoring value %s newvalue %s (not _str_ok)" % (value.__repr__(), newvalue.__repr__()))
+            self.log.devel("nappend: ignoring value %s newvalue %s (not _str_ok)",
+                           value.__repr__(), newvalue.__repr__())
 
     def nextend(self, value=None, **kwargs):
         """Named extend, value is list type (TODO: tighten the allowed values)
@@ -311,7 +314,7 @@ class ListOfLists(list):
         else:
             for el in value:
                 if not self._str_ok(el):
-                    self.log.debug("nextend: ignoring el %s from value %s (not _str_ok)" % (el, value.__repr__()))
+                    self.log.devel("nextend: ignoring el %s from value %s (not _str_ok)", el, value.__repr__())
                     continue
 
                 if type(el) in self.PROTECTED_CLASSES:
@@ -333,7 +336,7 @@ class ListOfLists(list):
                 res.append(newvalue)
 
         self.extend(res)
-        self.log.debug("nextend: value %s res %s" % (value.__repr__(), res.__repr__()))
+        self.log.devel("nextend: value %s res %s", value.__repr__(), res.__repr__())
         return res
 
     def str_convert(self, x):
@@ -366,18 +369,20 @@ class ListOfLists(list):
                         to_remove.extend(all_idx[:-1])
 
             to_remove = sorted(list(set(to_remove)), reverse=True)
-            self.log.debug("sanitize: to_remove in %s %s" % (self.__repr__(), to_remove))
+            self.log.devel("sanitize: to_remove in %s %s", self.__repr__(), to_remove)
             for idx in to_remove:
                 del self[idx]
 
         if self.JOIN_BEGIN_END:
             # group elements with same begin/end into one element
             to_remove = []
-            for idx in range(1, len(self))[::-1]:  # work in reversed order;don't check last one (ie real el 0), it has no next element
+            # work in reversed order; don't check last one (ie real el 0), it has no next element
+            for idx in range(1, len(self))[::-1]:
                 if self[idx].BEGIN is None or self[idx].END is None: continue
-                self.log.debug("idx %s len %s" % (idx, len(self)))
-                if self[idx].BEGIN == self[idx - 1].BEGIN and self[idx].END == self[idx - 1].END:  # do check POSITION, sorting already done
-                    self.log.debug("sanitize: JOIN_BEGIN_END idx %s joining %s and %s" % (idx, self[idx], self[idx - 1]))
+                self.log.devel("idx %s len %s", idx, len(self))
+                # do check POSITION, sorting already done
+                if self[idx].BEGIN == self[idx - 1].BEGIN and self[idx].END == self[idx - 1].END:
+                    self.log.devel("sanitize: JOIN_BEGIN_END idx %s joining %s and %s", idx, self[idx], self[idx - 1])
                     self[idx - 1].extend(self[idx])
                     to_remove.append(idx)  # remove current el
             to_remove = sorted(list(set(to_remove)), reverse=True)
@@ -398,13 +403,13 @@ class ListOfLists(list):
 
         if self._first is None:
             # return empty string
-            self.log.debug("__str__: first is None (self %s)" % self.__repr__())
+            self.log.devel("__str__: first is None (self %s)", self.__repr__())
             return ''
         else:
             sep = self.SEPARATOR
 
             txt = str(sep).join([self.str_convert(x) for x in self if self._str_ok(x)])
-            self.log.debug("__str__: return %s (self: %s)" % (txt, self.__repr__()))
+            self.log.devel("__str__: return %s (self: %s)", txt, self.__repr__())
             return txt
 
     def try_function_on_element(self, function_name, names=None, args=None, kwargs=None):
@@ -480,14 +485,14 @@ class Variables(dict):
             it is first tested if other is an existing element
                 else it is nappend-ed
         """
-        self.log.debug("join name %s others %s" % (name, others))
+        self.log.devel("join name %s others %s", name, others)
 
         # make sure name is defined, even if 'others' list is empty
         self.setdefault(name)
 
         for other in others:
             if other in self:
-                self.log.debug("join other %s in self: other %s" % (other, self.get(other).__repr__()))
+                self.log.devel("join other %s in self: other %s", other, self.get(other).__repr__())
                 for el in self.get(other):
                     self.nappend(name, el)
             else:
@@ -513,7 +518,7 @@ class Variables(dict):
             super(Variables, self).__setitem__(name, default)
 
         if len(default) == 0:
-            self.log.debug("setdefault: name %s initialising." % name)
+            self.log.devel("setdefault: name %s initialising.", name)
             if append_empty:
                 default.append_empty()
         return default
@@ -523,13 +528,13 @@ class Variables(dict):
         if names is None:
             names = self.keys()
         for name in names:
-            self.log.debug("try_function_el: name %s function_name %s" % (name, function_name))
+            self.log.devel("try_function_el: name %s function_name %s", name, function_name)
             self[name].try_function_on_element(function_name, args=args, kwargs=kwargs)
 
     def __getattribute__(self, attr_name):
         # allow for pass-through
         if attr_name in ['nappend', 'nextend', 'append_empty', 'first', 'get_class']:
-            self.log.debug("Passthrough to LISTCLASS function %s" % attr_name)
+            self.log.devel("Passthrough to LISTCLASS function %s", attr_name)
 
             def _passthrough(name, *args, **kwargs):
                 """functions that pass through to LISTCLASS instances"""
@@ -539,7 +544,7 @@ class Variables(dict):
                 return res
             return _passthrough
         elif attr_name in ['nappend_el', 'nextend_el', 'append_exists', 'append_subdirs']:
-            self.log.debug("Passthrough to LISTCLASS element function %s" % attr_name)
+            self.log.devel("Passthrough to LISTCLASS element function %s", attr_name)
 
             def _passthrough(name, *args, **kwargs):
                 """"Functions that pass through to elements of LISTCLASS (accept idx as index)"""


### PR DESCRIPTION
This will significantly clean up the log file produced under `--debug` or `-d`, while still allowing to get all the (internal) details via `--devel`