### PR TITLE
add support for renaming sources on download

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -348,7 +348,7 @@ class EasyBlock(object):
 
             elif isinstance(source, (list, tuple)) and len(source) == 2:
                 self.log.deprecated("Using a 2-element list/tuple to specify sources is deprecated, "
-                                    "use a dictionary with 'name', 'extract_cmd' keys instead", '4.0')
+                                    "use a dictionary with 'filename', 'extract_cmd' keys instead", '4.0')
                 filename, extract_cmd = source
             else:
                 raise EasyBuildError("Unexpected source spec, not a string or dict: %s", source)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -730,9 +730,54 @@ class EasyBlockTest(EnhancedTestCase):
         logtxt = read_file(eb.logfile)
         self.assertTrue(eb_log_msg_re.search(logtxt), "Pattern '%s' found in: %s" % (eb_log_msg_re.pattern, logtxt))
 
+    def test_fetch_sources(self):
+        """Test fetch_sources method."""
+        testdir = os.path.abspath(os.path.dirname(__file__))
+        ec = process_easyconfig(os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb'))[0]
+        eb = get_easyblock_instance(ec)
+
+        toy_source = os.path.join(testdir, 'sandbox', 'sources', 'toy', 'toy-0.0.tar.gz')
+
+        eb.fetch_sources()
+        self.assertEqual(len(eb.src), 1)
+        self.assertTrue(os.path.samefile(eb.src[0]['path'], toy_source))
+        self.assertEqual(eb.src[0]['name'], 'toy-0.0.tar.gz')
+        self.assertEqual(eb.src[0]['cmd'], None)
+        self.assertEqual(len(eb.src[0]['checksum']), 6)
+        self.assertEqual(eb.src[0]['checksum'][0], 'be662daa971a640e40be5c804d9d7d10')
+
+        # reconfigure EasyBuild so we can check 'downloaded' sources
+        os.environ['EASYBUILD_SOURCEPATH'] = self.test_prefix
+        init_config()
+
+        eb.cfg['source_urls'] = ['file://%s' % os.path.dirname(toy_source)]
+
+        # reset and try with provided list of sources
+        eb.src = []
+        sources = [
+            'toy-0.0.tar.gz',
+            'toy-extra.txt -> toy-0.0-extra.txt',
+            ('toy-0.0_gzip.patch.gz', "gunzip %s"),
+        ]
+        eb.fetch_sources(sources, checksums=[])
+
+        toy_source_dir = os.path.join(self.test_prefix, 't', 'toy')
+        expected_sources = ['toy-0.0.tar.gz', 'toy-0.0-extra.txt', 'toy-0.0_gzip.patch.gz']
+
+        # make source sources were downloaded, using correct filenames
+        self.assertEqual(len(eb.src), 3)
+        for idx in range(3):
+            self.assertEqual(eb.src[idx]['name'], expected_sources[idx])
+            self.assertTrue(os.path.exists(eb.src[idx]['path']))
+            source_loc = os.path.join(toy_source_dir, expected_sources[idx])
+            self.assertTrue(os.path.exists(source_loc))
+            self.assertTrue(os.path.samefile(eb.src[idx]['path'], source_loc))
+        self.assertEqual(eb.src[0]['cmd'], None)
+        self.assertEqual(eb.src[1]['cmd'], None)
+        self.assertEqual(eb.src[2]['cmd'], "gunzip %s")
+
     def test_fetch_patches(self):
         """Test fetch_patches method."""
-        # adjust PYTHONPATH such that test easyblocks are found
         testdir = os.path.abspath(os.path.dirname(__file__))
         ec = process_easyconfig(os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb'))[0]
         eb = get_easyblock_instance(ec)


### PR DESCRIPTION
This adds support for:

```python
sources = ["toy.tar.gz -> toy-0.0.tar.gz"]
```

With this construct, the source will be downloading using `toy.tar.gz`, but saved to disk using `toy-0.0.tar.gz`. If the file is already available as `toy-0.0.tar.gz` it will be picked up and `toy.tar.gz` will not be downloaded again.

I'm open to suggestions for alternate notations other than `->`, this is just one of the possibilities I went with that make it quite explicit. Another alternative would be something like `toy.tar.gz:toy-0.0.tar.gz`.

fix for #455

cc @wpoely86, @pneerincx, @fgeorgatos 