### PR TITLE
fix cleanup of easyconfigs for --new-pr and --update-pr under --extended-dry-run

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1526,7 +1526,7 @@ def clean_up_easyconfigs(paths):
         ectxt = read_file(path)
         for regex in regexs:
             ectxt = regex.sub('', ectxt)
-        write_file(path, ectxt)
+        write_file(path, ectxt, forced=True)
 
 
 def copy_easyconfigs(paths, target_dir):


### PR DESCRIPTION
The `test_new_update_pr ` test is broken because of the changes in #2197, see for example https://travis-ci.org/hpcugent/easybuild-framework/jobs/233554181.

The breakage occurred because `write_file` doesn't actually write to file under `--extended-dry-run` (used in the test), unless forced.

This slipped through with #2197 because some tests that require a GitHub token are not run for PRs (no way around that, it's a security feature of Travis not to expose the GitHub token to PRs).