### PR TITLE
pass down additional arguments to copy_dir down to shutil.copytree

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1497,6 +1497,8 @@ def copy_dir(path, target_path, force_in_dry_run=False, **kwargs):
     :param path: the original directory path
     :param target_path: path to copy the directory to
     :param force_in_dry_run: force running the command during dry run
+
+    Additional specified named arguments are passed down to shutil.copytree
     """
     if not force_in_dry_run and build_option('extended_dry_run'):
         dry_run_msg("copied directory %s to %s" % (path, target_path))

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1490,7 +1490,7 @@ def copy_file(path, target_path, force_in_dry_run=False):
             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
 
-def copy_dir(path, target_path, force_in_dry_run=False):
+def copy_dir(path, target_path, force_in_dry_run=False, **kwargs):
     """
     Copy a directory from specified location to specified location
 
@@ -1505,7 +1505,7 @@ def copy_dir(path, target_path, force_in_dry_run=False):
             if os.path.exists(target_path):
                 raise EasyBuildError("Target location %s to copy %s to already exists", target_path, path)
 
-            shutil.copytree(path, target_path)
+            shutil.copytree(path, target_path, **kwargs)
             _log.info("%s copied to %s", path, target_path)
         except (IOError, OSError) as err:
             raise EasyBuildError("Failed to copy directory %s to %s: %s", path, target_path, err)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -997,11 +997,14 @@ class FileToolsTest(EnhancedTestCase):
         target_dir = os.path.join(self.test_prefix, 'GCC')
         self.assertFalse(os.path.exists(target_dir))
 
-        ft.copy_dir(to_copy, target_dir)
+        self.assertTrue(os.path.exists(os.path.join(to_copy, 'GCC-4.7.2.eb')))
+
+        ft.copy_dir(to_copy, target_dir, ignore=lambda src, names: [x for x in names if '4.7.2' in x])
         self.assertTrue(os.path.exists(target_dir))
-        expected = ['GCC-4.6.3.eb', 'GCC-4.6.4.eb', 'GCC-4.7.2.eb', 'GCC-4.8.2.eb', 'GCC-4.8.3.eb', 'GCC-4.9.2.eb',
-                    'GCC-4.9.3-2.25.eb']
-        self.assertTrue(sorted(os.listdir(target_dir)), expected)
+        expected = ['GCC-4.6.3.eb', 'GCC-4.6.4.eb', 'GCC-4.8.2.eb', 'GCC-4.8.3.eb', 'GCC-4.9.2.eb', 'GCC-4.9.3-2.25.eb']
+        self.assertEqual(sorted(os.listdir(target_dir)), expected)
+        # GCC-4.7.2.eb should not get copied, since it's specified as file too ignore
+        self.assertFalse(os.path.exists(os.path.join(target_dir, 'GCC-4.7.2.eb')))
 
         # clean error when trying to copy a file with copy_dir
         src, target = os.path.join(to_copy, 'GCC-4.6.3.eb'), os.path.join(self.test_prefix, 'GCC-4.6.3.eb')


### PR DESCRIPTION
`shutil.copytree` has optional arguments like `ignore` and `symlinks`, `copy_dir` should support those too