### PR TITLE
avoid reloading already loaded modules that extend $MODULEPATH

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -978,7 +978,7 @@ class EasyBlock(object):
         deps = [d for d in deps if d not in excluded_deps]
 
         # load modules that open up the module tree before checking deps of deps (in reverse order)
-        self.modules_tool.load(excluded_deps[::-1])
+        self.modules_tool.load(excluded_deps[::-1], allow_reload=False)
 
         for excluded_dep in excluded_deps:
             excluded_dep_deps = dependencies_for(excluded_dep, self.modules_tool)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -477,7 +477,7 @@ class ModulesTool(object):
         """NO LONGER SUPPORTED: use exist method instead"""
         self.log.nosupport("exists(<mod_name>) is not supported anymore, use exist([<mod_name>]) instead", '2.0')
 
-    def load(self, modules, mod_paths=None, purge=False, init_env=None):
+    def load(self, modules, mod_paths=None, purge=False, init_env=None, allow_reload=True):
         """
         Load all requested modules.
 
@@ -485,6 +485,7 @@ class ModulesTool(object):
         :param mod_paths: list of module paths to activate before loading
         :param purge: whether or not a 'module purge' should be run before loading
         :param init_env: original environment to restore after running 'module purge'
+        :param allow_reload: allow reloading an already loaded module
         """
         if mod_paths is None:
             mod_paths = []
@@ -506,8 +507,10 @@ class ModulesTool(object):
             full_mod_path = os.path.join(install_path('mod'), build_option('suffix_modules_path'), mod_path)
             self.prepend_module_path(full_mod_path)
 
+        loaded_modules = self.loaded_modules()
         for mod in modules:
-            self.run_module('load', mod)
+            if allow_reload or mod not in loaded_modules:
+                self.run_module('load', mod)
 
     def unload(self, modules=None):
         """
@@ -808,7 +811,7 @@ class ModulesTool(object):
             if exts:
                 # load this module, since it may extend $MODULEPATH to make other modules available
                 # this is required to obtain the list of $MODULEPATH extensions they make (via 'module show')
-                self.load([mod_name])
+                self.load([mod_name], allow_reload=False)
 
         # restore environment (modules may have been loaded above)
         restore_env(env)
@@ -879,7 +882,8 @@ class ModulesTool(object):
             if full_modpath_exts:
                 # load module for this dependency, since it may extend $MODULEPATH to make dependencies available
                 # this is required to obtain the corresponding module file paths (via 'module show')
-                self.load([dep])
+                # don't reload module if it is already loaded, since that'll mess up the order in $MODULEPATH
+                self.load([dep], allow_reload=False)
 
         # restore original environment (modules may have been loaded above)
         restore_env(env)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -192,12 +192,16 @@ class ModulesTest(EnhancedTestCase):
         # if GCC is loaded again, $EBROOTGCC should be set again, and GCC should be listed last
         self.modtool.load(['GCC/4.6.4'])
         self.assertTrue(os.environ.get('EBROOTGCC'))
-        self.assertTrue(self.modtool.loaded_modules()[-1] == 'GCC/4.6.4')
+        if isinstance(self.modtool, Lmod):
+            # order of loaded modules only changes with Lmod
+            self.assertTrue(self.modtool.loaded_modules()[-1] == 'GCC/4.6.4')
 
         # set things up for checking that GCC does *not* get reloaded when requested
         del os.environ['EBROOTGCC']
         self.modtool.load(['OpenMPI/1.6.4-GCC-4.6.4'])
-        self.assertTrue(self.modtool.loaded_modules()[-1] == 'OpenMPI/1.6.4-GCC-4.6.4')
+        if isinstance(self.modtool, Lmod):
+            # order of loaded modules only changes with Lmod
+            self.assertTrue(self.modtool.loaded_modules()[-1] == 'OpenMPI/1.6.4-GCC-4.6.4')
 
         # reloading can be disabled using allow_reload=False
         self.modtool.load(['GCC/4.6.4'], allow_reload=False)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -178,6 +178,18 @@ class ModulesTest(EnhancedTestCase):
         for mod in mods:
             self.assertErrorRegex(EasyBuildError, '.*', self.modtool.load, [mod])
 
+        # by default, modules are always loaded, even if they are already loaded
+        self.modtool.load(['GCC/4.7.2'])
+        del os.environ['EBROOTGCC']
+        self.assertTrue('GCC/4.7.2' in self.modtool.loaded_modules())
+        self.modtool.load(['GCC/4.7.2'])
+        self.assertTrue(os.environ.get('EBROOTGCC'))
+
+        # reloading can be disabled using allow_reload=False
+        del os.environ['EBROOTGCC']
+        self.modtool.load(['GCC/4.7.2'], allow_reload=False)
+        self.assertEqual(os.environ.get('EBROOTGCC'), None)
+
     def test_prepend_module_path(self):
         """Test prepend_module_path method."""
         test_path = tempfile.mkdtemp(prefix=self.test_prefix)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -179,16 +179,30 @@ class ModulesTest(EnhancedTestCase):
             self.assertErrorRegex(EasyBuildError, '.*', self.modtool.load, [mod])
 
         # by default, modules are always loaded, even if they are already loaded
-        self.modtool.load(['GCC/4.7.2'])
+        self.modtool.load(['GCC/4.6.4', 'OpenMPI/1.6.4-GCC-4.6.4'])
+
+        # unset $EBROOTGCC, it should get set again later by loading GCC again
         del os.environ['EBROOTGCC']
-        self.assertTrue('GCC/4.7.2' in self.modtool.loaded_modules())
-        self.modtool.load(['GCC/4.7.2'])
+
+        # GCC should be loaded, but should not be listed last (OpenMPI was loaded last)
+        loaded_modules = self.modtool.loaded_modules()
+        self.assertTrue('GCC/4.6.4' in loaded_modules)
+        self.assertFalse(loaded_modules[-1] == 'GCC/4.6.4')
+
+        # if GCC is loaded again, $EBROOTGCC should be set again, and GCC should be listed last
+        self.modtool.load(['GCC/4.6.4'])
         self.assertTrue(os.environ.get('EBROOTGCC'))
+        self.assertTrue(self.modtool.loaded_modules()[-1] == 'GCC/4.6.4')
+
+        # set things up for checking that GCC does *not* get reloaded when requested
+        del os.environ['EBROOTGCC']
+        self.modtool.load(['OpenMPI/1.6.4-GCC-4.6.4'])
+        self.assertTrue(self.modtool.loaded_modules()[-1] == 'OpenMPI/1.6.4-GCC-4.6.4')
 
         # reloading can be disabled using allow_reload=False
-        del os.environ['EBROOTGCC']
-        self.modtool.load(['GCC/4.7.2'], allow_reload=False)
+        self.modtool.load(['GCC/4.6.4'], allow_reload=False)
         self.assertEqual(os.environ.get('EBROOTGCC'), None)
+        self.assertFalse(loaded_modules[-1] == 'GCC/4.6.4')
 
     def test_prepend_module_path(self):
         """Test prepend_module_path method."""


### PR DESCRIPTION
Fix for an issue reported by @akesandgren where reloading modules for the `icc`,`ifort`,`CUDA` toolchain components of the `intelcuda` caused problems with picking up wrong dependencies from the wrong locations because of order changes in `$MODULEPATH`.

This should also help avoiding load storms since Lmod does an unload/reload of all modules every time something changes to `$MODULEPATH`.

@ocaisa, @damianam, @geimer: please review?