### PR TITLE
Catch exception shutil.Error

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1486,7 +1486,7 @@ def copy_file(path, target_path, force_in_dry_run=False):
             mkdir(os.path.dirname(target_path), parents=True)
             shutil.copy2(path, target_path)
             _log.info("%s copied to %s", path, target_path)
-        except (IOError, OSError) as err:
+        except (IOError, OSError, shutil.Error) as err:
             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -961,6 +961,9 @@ class FileToolsTest(EnhancedTestCase):
         src, target = os.path.dirname(to_copy), os.path.join(self.test_prefix, 'toy')
         self.assertErrorRegex(EasyBuildError, "Failed to copy file.*Is a directory", ft.copy_file, src, target)
 
+        # copying a file to its own location should fail, but nicely (i.e. with an EasyBuildError, not a traceback)
+        self.assertErrorRegex(EasyBuildError, "Failed to copy file", ft.copy_file, to_copy, to_copy)
+
         # also test behaviour of copy_file under --dry-run
         build_options = {
             'extended_dry_run': True,


### PR DESCRIPTION
If the `shutil.copy2` operation fails for any reason (e.g. source and destination are the same), catch the `shutil.Error` exception.
This is a way to solve issues like #2237, where the test report shows `FAIL` even if the build ends successfully and no relevant messages are added to the debug log.