### PR TITLE
resolve symlinks to location of 'eb' in get_paths_for

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -52,7 +52,7 @@ from easybuild.framework.easyconfig.format.yeb import quote_yaml_special_chars
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import restore_env
-from easybuild.tools.filetools import find_easyconfigs, is_patch_file, which, write_file
+from easybuild.tools.filetools import find_easyconfigs, is_patch_file, resolve_path, which, write_file
 from easybuild.tools.github import fetch_easyconfigs_from_pr, download_repo
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.multidiff import multidiff
@@ -251,7 +251,7 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
     path_list.extend(sys.path)
 
     # figure out installation prefix, e.g. distutils install path for easyconfigs
-    eb_path = which('eb')
+    eb_path = resolve_path(which('eb'))
     if eb_path is None:
         _log.warning("'eb' not found in $PATH, failed to determine installation prefix")
     else:


### PR DESCRIPTION
Fix for bug reported by @pescobar 

The easyconfig files included with EasyBuild were not being found because the `eb` command was found in `/bin/eb` (which is a symlink to `/usr/bin/eb`), while the easyconfig files were located in `/usr/easybuild/easyconfigs`.